### PR TITLE
Fix: subwoofer lotus spawn error (color shadowing)

### DIFF
--- a/src/foliage/flowers.js
+++ b/src/foliage/flowers.js
@@ -11,6 +11,7 @@ import {
     createTransparentNodeMaterial, // Added import
     sharedGeometries // Added import
 } from './common.js';
+import { color as tslColor } from 'three/tsl';
 
 export function createFlower(options = {}) {
     const { color = null, shape = 'simple' } = options;
@@ -162,7 +163,7 @@ export function createGlowingFlower(options = {}) {
 }
 
 export function createStarflower(options = {}) {
-    const { color = 0xFF6EC7 } = options;
+    const { color: hexColor = 0xFF6EC7 } = options;
     const group = new THREE.Group();
 
     const stemH = 0.7 + Math.random() * 0.4;
@@ -176,7 +177,7 @@ export function createStarflower(options = {}) {
     center.position.y = stemH;
     group.add(center);
 
-    const petalMat = createClayMaterial(color);
+    const petalMat = createClayMaterial(hexColor);
     registerReactiveMaterial(petalMat);
 
     const petalCount = 6 + Math.floor(Math.random() * 3);
@@ -191,7 +192,7 @@ export function createStarflower(options = {}) {
     }
 
     const beamMat = foliageMaterials.lightBeam.clone();
-    beamMat.colorNode = color(color);
+    beamMat.colorNode = tslColor(hexColor);
     const beam = new THREE.Mesh(sharedGeometries.unitCone, beamMat);
     beam.position.y = stemH;
     beam.scale.set(0.02, 4.0, 0.02); // Tall thin beam
@@ -315,11 +316,11 @@ export function createPrismRoseBush(options = {}) {
         const roseGroup = new THREE.Group();
         roseGroup.position.y = branchLen;
 
-        const color = roseColors[Math.floor(Math.random() * roseColors.length)];
+        const hexColor = roseColors[Math.floor(Math.random() * roseColors.length)];
         
         // Use safe helper
         const petalMat = createStandardNodeMaterial({
-            color: color,
+            color: hexColor,
             roughness: 0.7,
             emissive: 0x000000,
             emissiveIntensity: 0.0
@@ -337,7 +338,7 @@ export function createPrismRoseBush(options = {}) {
         roseGroup.add(inner);
 
         const washMat = foliageMaterials.lightBeam.clone();
-        washMat.colorNode = color(color);
+        washMat.colorNode = tslColor(hexColor);
         const wash = new THREE.Mesh(sharedGeometries.unitSphere, washMat);
         wash.scale.setScalar(1.2);
         wash.userData.isWash = true;
@@ -355,17 +356,17 @@ export function createPrismRoseBush(options = {}) {
 }
 
 export function createSubwooferLotus(options = {}) {
-    const { color = 0x2E8B57 } = options;
+    const { color: hexColor = 0x2E8B57 } = options;
     const group = new THREE.Group();
 
-    const pad = new THREE.Mesh(sharedGeometries.unitCylinder, createClayMaterial(color));
+    const pad = new THREE.Mesh(sharedGeometries.unitCylinder, createClayMaterial(hexColor));
     pad.scale.set(1.5, 0.5, 1.5);
     pad.position.y = 0;
     pad.castShadow = true;
     pad.receiveShadow = true;
 
     const ringMat = foliageMaterials.lotusRing.clone();
-    ringMat.emissiveNode = color(0x000000); 
+    ringMat.emissiveNode = tslColor(0x000000); 
     pad.userData.ringMaterial = ringMat;
     registerReactiveMaterial(ringMat);
 

--- a/verification/verify_spawn_subwoofer_lotus.js
+++ b/verification/verify_spawn_subwoofer_lotus.js
@@ -1,0 +1,31 @@
+// verification/verify_spawn_subwoofer_lotus.js
+// Simple verification test to ensure createSubwooferLotus spawns without throwing
+
+import * as THREE from 'three';
+import { createSubwooferLotus } from '../src/foliage/flowers.js';
+import { fileURLToPath } from 'url';
+
+export function verifySpawnSubwooferLotus() {
+    try {
+        const obj = createSubwooferLotus({ color: 0x2E8B57 });
+        if (!obj || typeof obj !== 'object') throw new Error('createSubwooferLotus returned invalid object');
+        if (!obj.userData || obj.userData.type !== 'lotus') throw new Error('spawned object missing expected userData.type');
+        // Basic shape checks
+        const hasPad = obj.children && obj.children.length > 0;
+        if (!hasPad) throw new Error('spawned lotus missing pad child');
+        return { ok: true, message: 'createSubwooferLotus created a valid object' };
+    } catch (err) {
+        return { ok: false, message: String(err) };
+    }
+}
+
+// If run directly, print result (ESM-friendly)
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+    const res = verifySpawnSubwooferLotus();
+    if (!res.ok) {
+        console.error('[verify_spawn_subwoofer_lotus] FAILED:', res.message);
+        process.exitCode = 2;
+    } else {
+        console.log('[verify_spawn_subwoofer_lotus] OK:', res.message);
+    }
+}


### PR DESCRIPTION
Problem: local variables named 'color' in several flower factories shadow the TSL 'color' helper, causing runtime TypeError when spawning 'subwoofer_lotus'.\n\nFix: rename local color variables to 'hexColor', import the TSL helper as 'tslColor' and use it where appropriate.\n\nAlso added a small verification test: verification/verify_spawn_subwoofer_lotus.js.\n\nThis PR fixes the runtime spawn errors and adds a test to prevent regressions.