### PR TITLE
Migrate DiscoverySystem to TypeScript

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -69,6 +69,8 @@
   - **Player Abilities**: Implemented Dash ('E') and Double Jump mechanics in `src/systems/physics.js` with visual feedback (chromatic pulse) and discovery tracking.
   - **Migrate InteractionSystem (Phase 1)**: **Status: Implemented ✅**
     - *Implementation Details:* Migrated `src/systems/interaction.js` to `src/systems/interaction.ts`. Added strict typing for `InteractiveObject`, `ReticleCallback`, and system logic. Replaced legacy Sets with typed `Set<InteractiveObject>` and optimized double-buffered update loop. Updated `main.js` to import the new TypeScript module.
+  - **Migrate DiscoverySystem (Phase 1)**: **Status: Implemented ✅**
+    - *Implementation Details:* Migrated `src/systems/discovery.js` to `src/systems/discovery.ts`. Added strict typing for discovered items and storage keys. Updated `src/systems/physics.ts` to import the typed module correctly, removing legacy `@ts-ignore` directives. Confirmed build stability by fixing unrelated broken imports in foliage modules (`sky.js` -> `sky.ts`).
 
 ---
 

--- a/src/foliage/cave.js
+++ b/src/foliage/cave.js
@@ -9,7 +9,7 @@ import {
 import {
     uAudioLow, createRimLight, triplanarNoise, perturbNormal
 } from './common.js';
-import { uTwilight } from './sky.js';
+import { uTwilight } from './sky.ts';
 import { createWaterfall } from './waterfalls.js';
 
 export function createCaveEntrance(options = {}) {

--- a/src/foliage/flowers.js
+++ b/src/foliage/flowers.js
@@ -13,7 +13,7 @@ import {
     calculateFlowerBloom // Added export
 } from './common.js';
 import { color as tslColor, mix, float, positionLocal } from 'three/tsl';
-import { uTwilight } from './sky.js';
+import { uTwilight } from './sky.ts';
 
 export function createFlower(options = {}) {
     const { color = null, shape = 'simple' } = options;

--- a/src/foliage/grass.js
+++ b/src/foliage/grass.js
@@ -4,7 +4,7 @@ import * as THREE from 'three';
 import { MeshStandardNodeMaterial } from 'three/webgpu';
 import { time, positionLocal, positionWorld, sin, cos, vec3, color, normalView, dot, float, max, mix, sign, smoothstep, normalize } from 'three/tsl';
 import { uWindSpeed, uWindDirection, createClayMaterial, uAudioLow, uAudioHigh, uPlayerPosition } from './common.js';
-import { uSkyDarkness } from './sky.js';
+import { uSkyDarkness } from './sky.ts';
 
 let grassMeshes = [];
 const dummy = new THREE.Object3D();

--- a/src/foliage/mushroom-batcher.ts
+++ b/src/foliage/mushroom-batcher.ts
@@ -9,7 +9,7 @@ import {
     sharedGeometries, foliageMaterials, uTime,
     uAudioLow, uAudioHigh, createRimLight
 } from './common.js';
-import { uTwilight } from './sky.js';
+import { uTwilight } from './sky.ts';
 import { foliageGroup } from '../world/state.js'; // Assuming state.js exports foliageGroup
 
 const MAX_MUSHROOMS = 4000;

--- a/src/foliage/trees.ts
+++ b/src/foliage/trees.ts
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { foliageMaterials, registerReactiveMaterial, attachReactivity, pickAnimation, createClayMaterial, createGradientMaterial, sharedGeometries, uAudioLow, uWindSpeed, calculatePlayerPush } from './common.js';
 import { color as tslColor, mix, float, sin, cos, vec3, positionLocal, positionWorld, time } from 'three/tsl';
-import { uTwilight } from './sky.js';
+import { uTwilight } from './sky.ts';
 import { createBerryCluster } from './berries.js';
 import { FoliageObject } from './types.js';
 

--- a/src/systems/discovery.ts
+++ b/src/systems/discovery.ts
@@ -1,4 +1,6 @@
-// src/systems/discovery.js
+// src/systems/discovery.ts
+
+// @ts-ignore
 import { showToast } from '../utils/toast.js';
 
 /**
@@ -6,8 +8,11 @@ import { showToast } from '../utils/toast.js';
  * Tracks discovered items in localStorage (optional) and triggers UI notifications.
  */
 class DiscoverySystem {
+    private discoveredItems: Set<string>;
+    private storageKey: string;
+
     constructor() {
-        this.discoveredItems = new Set();
+        this.discoveredItems = new Set<string>();
         this.storageKey = 'candy_world_discovery';
         this.loadDiscovery();
     }
@@ -15,13 +20,13 @@ class DiscoverySystem {
     /**
      * Load discovered items from local storage.
      */
-    loadDiscovery() {
+    private loadDiscovery(): void {
         try {
             const data = localStorage.getItem(this.storageKey);
             if (data) {
                 const items = JSON.parse(data);
                 if (Array.isArray(items)) {
-                    items.forEach(item => this.discoveredItems.add(item));
+                    items.forEach((item: string) => this.discoveredItems.add(item));
                 }
             }
         } catch (e) {
@@ -32,7 +37,7 @@ class DiscoverySystem {
     /**
      * Save discovered items to local storage.
      */
-    saveDiscovery() {
+    private saveDiscovery(): void {
         try {
             localStorage.setItem(this.storageKey, JSON.stringify(Array.from(this.discoveredItems)));
         } catch (e) {
@@ -47,7 +52,7 @@ class DiscoverySystem {
      * @param {string} icon - Emoji or icon to display.
      * @returns {boolean} - True if this is a new discovery.
      */
-    discover(id, displayName, icon = '🌿') {
+    public discover(id: string, displayName: string, icon: string = '🌿'): boolean {
         if (!id) return false;
 
         if (!this.discoveredItems.has(id)) {
@@ -66,14 +71,14 @@ class DiscoverySystem {
      * @param {string} id
      * @returns {boolean}
      */
-    isDiscovered(id) {
+    public isDiscovered(id: string): boolean {
         return this.discoveredItems.has(id);
     }
 
     /**
      * Reset discovery progress (for debug).
      */
-    reset() {
+    public reset(): void {
         this.discoveredItems.clear();
         this.saveDiscovery();
         console.log('[Discovery] Progress reset.');

--- a/src/systems/physics.ts
+++ b/src/systems/physics.ts
@@ -12,7 +12,6 @@ import {
     foliageMushrooms, foliageTrampolines, foliageClouds,
     activeVineSwing, setActiveVineSwing, lastVineDetachTime, setLastVineDetachTime, vineSwings, animatedFoliage
 } from '../world/state.ts';
-// @ts-ignore - Importing JS module
 import { discoverySystem } from './discovery.js';
 import { DISCOVERY_MAP } from './discovery_map.ts';
 import {
@@ -192,7 +191,6 @@ function checkFloraDiscovery(playerPos: THREE.Vector3) {
 
         if (discoveryInfo) {
             // Already discovered? Skip distance check
-            // @ts-ignore
             if (discoverySystem.isDiscovered(type)) continue;
 
             const dx = playerPos.x - obj.position.x;
@@ -201,7 +199,6 @@ function checkFloraDiscovery(playerPos: THREE.Vector3) {
             const distSq = dx*dx + dy*dy + dz*dz;
 
             if (distSq < DISCOVERY_RADIUS_SQ) {
-                // @ts-ignore
                 discoverySystem.discover(type, discoveryInfo.name, discoveryInfo.icon);
             }
         }


### PR DESCRIPTION
Migrated `src/systems/discovery.js` to `src/systems/discovery.ts` with strict typing. Updated references in `src/systems/physics.ts` to remove `@ts-ignore`. Fixed build errors by updating imports in `grass.js`, `flowers.js`, `cave.js`, `trees.ts`, and `mushroom-batcher.ts` to point to `sky.ts` instead of the deleted `sky.js`. Verified build with `npx vite build`.

---
*PR created automatically by Jules for task [6212603026799828870](https://jules.google.com/task/6212603026799828870) started by @ford442*