### PR TITLE
Migrate foliage modules to TypeScript

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -10,12 +10,14 @@
 
 ## Next Steps
 
-1. **Phase 1 (JS -> TS)**: Continue migrating core systems and foliage modules to TypeScript to enforce type safety across the project.
+1. **Phase 1 (JS -> TS)**: Continue migrating remaining foliage modules (`trees.legacy.js`, `mushrooms.js`, `berries.js`) and gameplay systems to TypeScript.
 
 ---
 
 ## Recent Progress
 - **Accomplished:**
+  - **Phase 1 (JS -> TS): Foliage Core Migration**: **Status: Implemented ✅**
+    - *Implementation Details:* Migrated `src/foliage/common.js` (the central TSL material factory), `src/foliage/grass.js`, and `src/foliage/flowers.js` to TypeScript (`.ts`). Added strict typing for TSL nodes, material options, and geometry helpers. Updated 35+ dependent files to import from the new `.ts` modules. Verified build integrity via `vite build`.
   - **Phase 1 (JS -> TS): Foliage Migration**: **Status: Implemented ✅**
     - *Implementation Details:* Migrated `src/foliage/sky.js`, `src/foliage/water.js`, and `src/foliage/mirrors.js` to TypeScript (`.ts`). Added strict typing for uniforms, function arguments, and return types. Updated `src/foliage/index.js` exports.
   - **Phase 4 (Three.js -> WebGPU): Fireflies Compute Shader**: **Status: Implemented ✅**

--- a/src/foliage/animation.ts
+++ b/src/foliage/animation.ts
@@ -2,7 +2,7 @@
 
 import * as THREE from 'three';
 import { freqToHue } from '../utils/wasm-loader.js';
-import { reactiveMaterials, _foliageReactiveColor, median } from './common.js';
+import { reactiveMaterials, _foliageReactiveColor, median } from './common.ts';
 import { CONFIG } from '../core/config.js';
 import { FoliageObject, AudioData, FoliageMaterial, ChannelData } from './types.js';
 import { foliageBatcher } from './foliage-batcher.js';

--- a/src/foliage/arpeggio-batcher.ts
+++ b/src/foliage/arpeggio-batcher.ts
@@ -4,11 +4,11 @@ import {
     createCandyMaterial,
     registerReactiveMaterial,
     sharedGeometries
-} from './common.js';
+} from './common.ts';
 import {
     color, float, uniform, vec3, positionLocal, sin, cos, mix, uv, attribute, varying
 } from 'three/tsl';
-import { uTime, uGlitchIntensity } from './common.js';
+import { uTime, uGlitchIntensity } from './common.ts';
 import { applyGlitch } from './glitch.js';
 
 const MAX_FERNS = 2000; // Cap at 2000 ferns (10,000 fronds)

--- a/src/foliage/berries.js
+++ b/src/foliage/berries.js
@@ -4,7 +4,7 @@ import {
     color, float, uniform, vec3, positionLocal, positionWorld,
     sin, cos, pow, mix, dot, time, attribute
 } from 'three/tsl';
-import { CandyPresets, uAudioLow, uTime } from './common.js';
+import { CandyPresets, uAudioLow, uTime } from './common.ts';
 import { spawnImpact } from './impacts.js';
 import { uChromaticIntensity } from './chromatic.js';
 

--- a/src/foliage/cave.js
+++ b/src/foliage/cave.js
@@ -8,7 +8,7 @@ import {
 } from 'three/tsl';
 import {
     uAudioLow, createRimLight, triplanarNoise, perturbNormal
-} from './common.js';
+} from './common.ts';
 import { uTwilight } from './sky.ts';
 import { createWaterfall } from './waterfalls.js';
 

--- a/src/foliage/celestial-bodies.js
+++ b/src/foliage/celestial-bodies.js
@@ -1,7 +1,7 @@
 // src/foliage/celestial-bodies.js
 
 import * as THREE from 'three';
-import { attachReactivity } from './common.js';
+import { attachReactivity } from './common.ts';
 
 // Helper to place objects on a distant sky sphere
 function getRandomSkyPosition(radius) {

--- a/src/foliage/clouds.js
+++ b/src/foliage/clouds.js
@@ -3,7 +3,7 @@
 import * as THREE from 'three';
 import { color, uniform, mix, vec3, positionLocal, normalLocal, mx_noise_float, float, normalize, positionWorld, normalWorld, cameraPosition, dot, abs, sin, pow } from 'three/tsl';
 import { MeshStandardNodeMaterial } from 'three/webgpu';
-import { uTime, createRimLight, uAudioLow } from './common.js';
+import { uTime, createRimLight, uAudioLow } from './common.ts';
 
 // --- Global Uniforms (Driven by WeatherSystem) ---
 // These are true TSL uniforms now

--- a/src/foliage/dandelion-batcher.ts
+++ b/src/foliage/dandelion-batcher.ts
@@ -7,7 +7,7 @@ import {
     registerReactiveMaterial,
     uAudioHigh,
     uTime
-} from './common.js';
+} from './common.ts';
 // @ts-ignore
 import {
     float, vec3, positionLocal, sin, cos, mix, instanceIndex, normalLocal, timerLocal

--- a/src/foliage/environment.js
+++ b/src/foliage/environment.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { MeshStandardNodeMaterial } from 'three/webgpu';
 import { time, vec3, positionLocal, length, sin, cos } from 'three/tsl';
-import { registerReactiveMaterial, attachReactivity } from './common.js';
+import { registerReactiveMaterial, attachReactivity } from './common.ts';
 
 export function createMelodyLake(width = 200, depth = 200) {
     const geo = new THREE.PlaneGeometry(width, depth, 64, 64);

--- a/src/foliage/fireflies.legacy.js
+++ b/src/foliage/fireflies.legacy.js
@@ -3,7 +3,7 @@
 import * as THREE from 'three';
 import { PointsNodeMaterial } from 'three/webgpu';
 import { attribute, sin, cos, mix, color, positionLocal, vec3, float } from 'three/tsl';
-import { uTime, uAudioLow, uAudioHigh } from './common.js';
+import { uTime, uAudioLow, uAudioHigh } from './common.ts';
 
 export function createFireflies(count = 80, areaSize = 100) {
     const geo = new THREE.BufferGeometry();

--- a/src/foliage/fireflies.ts
+++ b/src/foliage/fireflies.ts
@@ -5,7 +5,7 @@ import {
     mix, sin, cos, normalize, color,
     mx_noise_float, vertexIndex, max, length, min
 } from 'three/tsl';
-import { uTime, uAudioLow, uAudioHigh, uPlayerPosition } from './common.js';
+import { uTime, uAudioLow, uAudioHigh, uPlayerPosition } from './common.ts';
 
 export function createFireflies(count = 150, areaSize = 100) {
     // 1. Setup Buffers

--- a/src/foliage/grass.ts
+++ b/src/foliage/grass.ts
@@ -1,16 +1,16 @@
-// src/foliage/grass.js
+// src/foliage/grass.ts
 
 import * as THREE from 'three';
 import { MeshStandardNodeMaterial } from 'three/webgpu';
-import { time, positionLocal, positionWorld, sin, cos, vec3, color, normalView, dot, float, max, mix, sign, smoothstep, normalize } from 'three/tsl';
-import { uWindSpeed, uWindDirection, createClayMaterial, uAudioLow, uAudioHigh, uPlayerPosition } from './common.js';
+import { time, positionLocal, positionWorld, sin, vec3, color, normalView, dot, float, max, sign, smoothstep, normalize } from 'three/tsl';
+import { uWindSpeed, uWindDirection, createClayMaterial, uAudioLow, uAudioHigh, uPlayerPosition } from './common.ts';
 import { uSkyDarkness } from './sky.ts';
 
-let grassMeshes = [];
+let grassMeshes: THREE.InstancedMesh[] = [];
 const dummy = new THREE.Object3D();
 const MAX_PER_MESH = 1000;
 
-export function initGrassSystem(scene, count = 5000) {
+export function initGrassSystem(scene: THREE.Scene, count = 5000): THREE.InstancedMesh[] {
     grassMeshes = [];
     const height = 0.8;
     const geo = new THREE.BoxGeometry(0.05, height, 0.05);
@@ -128,7 +128,7 @@ export function initGrassSystem(scene, count = 5000) {
     return grassMeshes;
 }
 
-export function addGrassInstance(x, y, z) {
+export function addGrassInstance(x: number, y: number, z: number) {
     const mesh = grassMeshes.find(m => m.count < m.instanceMatrix.count);
     if (!mesh) return;
 
@@ -145,7 +145,7 @@ export function addGrassInstance(x, y, z) {
     mesh.instanceMatrix.needsUpdate = true;
 }
 
-export function createGrass(options = {}) {
+export function createGrass(options: { color?: number | string | THREE.Color, shape?: 'tall' | 'bushy' } = {}) {
     const { color = 0x7CFC00, shape = 'tall' } = options;
     const material = createClayMaterial(color);
     let geo;
@@ -165,7 +165,12 @@ export function createGrass(options = {}) {
         const height = 0.2 + Math.random() * 0.3;
         geo = new THREE.CylinderGeometry(0.1, 0.05, height, 8);
         geo.translate(0, height / 2, 0);
+    } else {
+        // Fallback for types
+        const height = 0.5;
+        geo = new THREE.BoxGeometry(0.05, height, 0.05);
     }
+
     geo.computeVertexNormals();
 
     const blade = new THREE.Mesh(geo, material);

--- a/src/foliage/impacts.js
+++ b/src/foliage/impacts.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { PointsNodeMaterial } from 'three/webgpu';
 import { attribute, float, mix, color, vec3, smoothstep, sin, positionLocal, pointUV, length, exp } from 'three/tsl';
-import { uTime, uAudioHigh } from './common.js';
+import { uTime, uAudioHigh } from './common.ts';
 
 const MAX_PARTICLES = 1500;
 let _impactMesh = null;

--- a/src/foliage/index.js
+++ b/src/foliage/index.js
@@ -1,10 +1,10 @@
 // src/foliage/index.js
 // Export all foliage sub-modules
-export * from './common.js';
+export * from './common.ts';
 export * from './berries.js';
-export * from './grass.js';
+export * from './grass.ts';
 export * from './mushrooms.js';
-export * from './flowers.js';
+export * from './flowers.ts';
 export * from './trees.ts';
 export * from './clouds.js';
 export * from './waterfalls.js';
@@ -15,8 +15,8 @@ export * from './water.ts'; // Added Waveform Water
 export * from './glitch.js'; // Added Glitch Shader
 export * from './chromatic.js'; // Added Chromatic Aberration
 
-// Export lantern flower explicitly if not covered by flowers.js (it is, but let's be safe)
-export { createLanternFlower } from './flowers.js';
+// Export lantern flower explicitly if not covered by flowers.ts (it is, but let's be safe)
+export { createLanternFlower } from './flowers.ts';
 
 // Export moved modules
 export * from './sky.ts';

--- a/src/foliage/instrument.js
+++ b/src/foliage/instrument.js
@@ -6,12 +6,12 @@ import {
     sharedGeometries,
     registerReactiveMaterial,
     attachReactivity
-} from './common.js';
+} from './common.ts';
 import {
     color, float, mix, uv, sin, cos, positionLocal,
     vec3, normalWorld, mx_noise_float
 } from 'three/tsl';
-import { triplanarNoise } from './common.js';
+import { triplanarNoise } from './common.ts';
 
 export function createInstrumentShrine(options = {}) {
     const {

--- a/src/foliage/lantern-batcher.ts
+++ b/src/foliage/lantern-batcher.ts
@@ -9,7 +9,7 @@ import {
     sharedGeometries, foliageMaterials, uTime,
     uAudioLow, uAudioHigh, createRimLight, calculateWindSway, applyPlayerInteraction,
     createStandardNodeMaterial, createUnifiedMaterial
-} from './common.js';
+} from './common.ts';
 import { foliageGroup } from '../world/state.ts';
 
 const MAX_LANTERNS = 1000;
@@ -166,7 +166,7 @@ export class LanternBatcher {
         // We need to calculate sway at height.
         // Re-use calculateWindSway but using the Offset Position
         // Note: calculateWindSway uses positionWorld usually?
-        // In common.js: `const swayPhase = positionWorld.x...`
+        // In common.ts: `const swayPhase = positionWorld.x...`
         // But `posNode.y` (local) is used for bending factor.
         // Here `posNode` is local. `posNode.y` is relative to Top Center.
         // The effective height for bending is `height + pos.y`.

--- a/src/foliage/lotus.js
+++ b/src/foliage/lotus.js
@@ -14,7 +14,7 @@ import {
     uAudioLow,
     uGlitchIntensity,
     uTime
-} from './common.js';
+} from './common.ts';
 
 /**
  * Creates a "Subwoofer Lotus" - A bass-reactive flora with a "Speaker" center.

--- a/src/foliage/mirrors.ts
+++ b/src/foliage/mirrors.ts
@@ -7,8 +7,8 @@ import {
     reflect, sin, abs, dot,
     texture, uniform
 } from 'three/tsl';
-// @ts-ignore: common.js is not yet migrated
-import { attachReactivity, createRimLight, uAudioHigh, uTime } from './common.js';
+// @ts-ignore: common.ts is not yet migrated
+import { attachReactivity, createRimLight, uAudioHigh, uTime } from './common.ts';
 
 // Global texture for the "Dream Reflection"
 // Since we don't have a real cubemap, we generate a static noise/gradient texture

--- a/src/foliage/moon.js
+++ b/src/foliage/moon.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { color, vec3, time, sin, cos, uniform, mix, positionLocal } from 'three/tsl';
 import { MeshStandardNodeMaterial } from 'three/webgpu';
-import { attachReactivity } from './common.js';
+import { attachReactivity } from './common.ts';
 
 // Moon Configuration
 export const moonConfig = {

--- a/src/foliage/mushroom-batcher.ts
+++ b/src/foliage/mushroom-batcher.ts
@@ -8,7 +8,7 @@ import {
 import {
     sharedGeometries, foliageMaterials, uTime,
     uAudioLow, uAudioHigh, createRimLight, createJuicyRimLight
-} from './common.js';
+} from './common.ts';
 import { uTwilight } from './sky.ts';
 import { foliageGroup } from '../world/state.js'; // Assuming state.js exports foliageGroup
 
@@ -508,7 +508,7 @@ export class MushroomBatcher {
         if (indices) {
             // Get current time from uniform wrapper if possible, or pass it in.
             // But we need the CPU time to write to attribute.
-            // common.js exports `uTime` (node) but we need JS time.
+            // common.ts exports `uTime` (node) but we need JS time.
             // Using performance.now() / 1000 or a global time tracker?
             // `foliageBatcher` gets passed time.
             // We can approximate or use a Date.now().

--- a/src/foliage/mushrooms.js
+++ b/src/foliage/mushrooms.js
@@ -2,8 +2,8 @@
 
 import * as THREE from 'three';
 import { mushroomBatcher } from './mushroom-batcher.ts';
-import { sharedGeometries } from './common.js';
-import { uTime } from './common.js'; // Check if we need this, probably not for registration
+import { sharedGeometries } from './common.ts';
+import { uTime } from './common.ts'; // Check if we need this, probably not for registration
 
 // 12 Chromatic Notes with their corresponding colors
 // Colors are defined here to match CONFIG.noteColorMap.mushroom palette

--- a/src/foliage/musical_flora.js
+++ b/src/foliage/musical_flora.js
@@ -7,7 +7,7 @@ import {
     foliageMaterials,
     uTime,
     uGlitchIntensity
-} from './common.js';
+} from './common.ts';
 import {
     color, float, uniform, vec3, positionLocal, sin, cos, mix, uv
 } from 'three/tsl';

--- a/src/foliage/panning-pads.js
+++ b/src/foliage/panning-pads.js
@@ -8,7 +8,7 @@ import {
     attachReactivity,
     sharedGeometries,
     createStandardNodeMaterial
-} from './common.js';
+} from './common.ts';
 import { color, float, mix, uv, distance, vec2, smoothstep, uniform } from 'three/tsl';
 
 export function createPanningPad(options = {}) {

--- a/src/foliage/pines.js
+++ b/src/foliage/pines.js
@@ -9,7 +9,7 @@ import {
     mix,
     Fn
 } from 'three/tsl';
-import { attachReactivity } from './common.js';
+import { attachReactivity } from './common.ts';
 
 /**
  * Creates a "Portamento Pine" - A towering antenna cluster made of copper alloy.

--- a/src/foliage/portamento-batcher.ts
+++ b/src/foliage/portamento-batcher.ts
@@ -4,11 +4,11 @@ import {
     createClayMaterial,
     createCandyMaterial,
     registerReactiveMaterial
-} from './common.js';
+} from './common.ts';
 import {
     color, float, uniform, vec3, positionLocal, sin, cos, mix, uv, attribute, varying, normalize
 } from 'three/tsl';
-import { uTime } from './common.js';
+import { uTime } from './common.ts';
 
 const MAX_PINES = 1000;
 

--- a/src/foliage/ribbons.js
+++ b/src/foliage/ribbons.js
@@ -7,7 +7,7 @@ import {
     cameraPosition, sin, abs, smoothstep, uv,
     mx_noise_float
 } from 'three/tsl';
-import { createUnifiedMaterial } from './common.js';
+import { createUnifiedMaterial } from './common.ts';
 
 /**
  * Melody Ribbon System

--- a/src/foliage/silence-spirits.js
+++ b/src/foliage/silence-spirits.js
@@ -7,7 +7,7 @@ import {
     registerReactiveMaterial,
     attachReactivity,
     uTime
-} from './common.js';
+} from './common.ts';
 import { color, float, mix, sin, cos, positionLocal, vec3, normalWorld } from 'three/tsl';
 
 export function createSilenceSpirit(options = {}) {

--- a/src/foliage/sparkle-trail.js
+++ b/src/foliage/sparkle-trail.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { PointsNodeMaterial } from 'three/webgpu';
 import { attribute, float, mix, color, vec3, smoothstep, sin, positionLocal, cos } from 'three/tsl';
-import { uTime, uAudioHigh, uAudioLow } from './common.js';
+import { uTime, uAudioHigh, uAudioLow } from './common.ts';
 
 const TRAIL_SIZE = 1500; // Increased buffer size for richer trails
 

--- a/src/foliage/stars.js
+++ b/src/foliage/stars.js
@@ -3,7 +3,7 @@
 import * as THREE from 'three';
 import { color, float, vec3, vec4, time, positionLocal, attribute, uniform, mix, length, sin, cos } from 'three/tsl';
 import { PointsNodeMaterial } from 'three/webgpu';
-import { uAudioLow, uAudioHigh } from './common.js';
+import { uAudioLow, uAudioHigh } from './common.ts';
 
 // Global uniforms
 // Removed uStarPulse to fix unison pulsing bug and use direct audio reactivity

--- a/src/foliage/trees.legacy.js
+++ b/src/foliage/trees.legacy.js
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import { foliageMaterials, registerReactiveMaterial, attachReactivity, pickAnimation, createClayMaterial, createGradientMaterial, sharedGeometries } from './common.js';
+import { foliageMaterials, registerReactiveMaterial, attachReactivity, pickAnimation, createClayMaterial, createGradientMaterial, sharedGeometries } from './common.ts';
 import { createBerryCluster } from './berries.js';
 
 // @refactor {target: "ts", reason: "complex-config", note: "Factory functions prone to undefined option bugs"}

--- a/src/foliage/trees.ts
+++ b/src/foliage/trees.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import { foliageMaterials, registerReactiveMaterial, attachReactivity, pickAnimation, createClayMaterial, createGradientMaterial, sharedGeometries, uAudioLow, uWindSpeed, calculatePlayerPush } from './common.js';
+import { foliageMaterials, registerReactiveMaterial, attachReactivity, pickAnimation, createClayMaterial, createGradientMaterial, sharedGeometries, uAudioLow, uWindSpeed, calculatePlayerPush } from './common.ts';
 import { color as tslColor, mix, float, sin, cos, vec3, positionLocal, positionWorld, time } from 'three/tsl';
 import { uTwilight } from './sky.ts';
 import { createBerryCluster } from './berries.js';

--- a/src/foliage/water.ts
+++ b/src/foliage/water.ts
@@ -7,8 +7,8 @@ import {
     uv, normalize, smoothstep, mix, abs, max, positionWorld,
     mx_noise_float, normalLocal
 } from 'three/tsl';
-// @ts-ignore: common.js is not yet migrated
-import { CandyPresets, uAudioLow, uAudioHigh, createRimLight } from './common.js';
+// @ts-ignore: common.ts is not yet migrated
+import { CandyPresets, uAudioLow, uAudioHigh, createRimLight } from './common.ts';
 
 export const uWaveHeight = uniform(1.0); // Base wave height scaler
 

--- a/src/foliage/waterfalls.js
+++ b/src/foliage/waterfalls.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { color, time, uv, texture, float, positionLocal, vec2, mix, sin, vec3, uniform } from 'three/tsl';
 import { MeshStandardNodeMaterial } from 'three/webgpu';
-import { foliageMaterials, registerReactiveMaterial, attachReactivity, CandyPresets, createUnifiedMaterial } from './common.js';
+import { foliageMaterials, registerReactiveMaterial, attachReactivity, CandyPresets, createUnifiedMaterial } from './common.ts';
 
 /**
  * Creates a bioluminescent waterfall connecting two points.

--- a/src/gameplay/rainbow-blaster.js
+++ b/src/gameplay/rainbow-blaster.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import { foliageClouds } from '../world/state.ts'; // The list of active clouds
-import { createCandyMaterial } from '../foliage/common.js';
+import { createCandyMaterial } from '../foliage/common.ts';
 import { getCelestialState } from '../core/cycle.js'; // Import cycle check
 
 const PROJECTILES = [];

--- a/src/world/generation.ts
+++ b/src/world/generation.ts
@@ -14,7 +14,7 @@ import {
     createPanningPad, createSilenceSpirit, createInstrumentShrine, createMelodyMirror
 } from '../foliage/index.js';
 import { createCaveEntrance } from '../foliage/cave.js';
-import { validateFoliageMaterials } from '../foliage/common.js';
+import { validateFoliageMaterials } from '../foliage/common.ts';
 import { CONFIG } from '../core/config.ts';
 import { registerPhysicsCave } from '../systems/physics.ts';
 import {

--- a/verification/verify_foliage_logic.js
+++ b/verification/verify_foliage_logic.js
@@ -1,8 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 
-const commonPath = path.resolve('src/foliage/common.js');
-const flowersPath = path.resolve('src/foliage/flowers.js');
+const commonPath = path.resolve('src/foliage/common.ts');
+const flowersPath = path.resolve('src/foliage/flowers.ts');
 
 console.log('Verifying Foliage Logic...');
 


### PR DESCRIPTION
Migrated critical foliage logic (`common`, `grass`, `flowers`) from JavaScript to TypeScript to enforce type safety. This includes typing for TSL node factories, material definitions, and geometry helpers. Updated all dependent files to import from the new TypeScript modules and verified the build succeeds.

---
*PR created automatically by Jules for task [12650961637656843445](https://jules.google.com/task/12650961637656843445) started by @ford442*