### PR TITLE
🎨 Palette: Auto-focus Start Button

### DIFF
--- a/main.js
+++ b/main.js
@@ -622,6 +622,7 @@ initWasm().then(async (wasmLoaded) => {
     if (startButton) {
         startButton.disabled = false;
         startButton.innerText = 'Enter World 🍭';
+        startButton.focus();
         
         startButton.addEventListener('click', () => {
             console.log('[Startup] Entering world...');


### PR DESCRIPTION
💡 What: Added `startButton.focus()` to `main.js` immediately after the loading sequence finishes and the button is enabled.
🎯 Why: Ensures keyboard and screen reader users are automatically placed on the primary action ("Enter World") when the loading overlay vanishes, preventing them from having to navigate blindly to find the button.
♿ Accessibility: Fixes a focus management issue during state transition (Loading -> Ready).

---
*PR created automatically by Jules for task [12182753244118523178](https://jules.google.com/task/12182753244118523178) started by @ford442*