### PR TITLE
Fix WebGPURenderer crash and improve WASM loading diagnostics

### DIFF
--- a/src/core/init.js
+++ b/src/core/init.js
@@ -20,6 +20,8 @@ export function initScene() {
     }
 
     const renderer = new WebGPURenderer({ canvas, antialias: true });
+    // Fix: WebGPURenderer 0.171.0+ can crash in setupHardwareClipping if this is undefined
+    renderer.clippingPlanes = [];
     renderer.setSize(window.innerWidth, window.innerHeight);
     renderer.setPixelRatio(Math.min(window.devicePixelRatio, 1.5)); // Cap pixel ratio for better performance
     renderer.toneMapping = THREE.ACESFilmicToneMapping;

--- a/src/utils/wasm-loader.js
+++ b/src/utils/wasm-loader.js
@@ -210,6 +210,10 @@ async function loadEmscriptenModule(forceSingleThreaded = false) {
              }
         } catch(e) {
             console.warn("[WASM] Failed to pre-fetch binary:", e);
+            // Help diagnose common server configuration issues
+            if (e.message && e.message.toLowerCase().includes("content decoding")) {
+                console.error("[WASM] CRITICAL: Content Decoding Failed! The server is likely sending 'Content-Encoding: gzip' for an uncompressed .wasm file. This is a common issue with Vite preview/dev servers.");
+            }
         }
 
         // POLYFILL BYPASS: 


### PR DESCRIPTION
Fixed a runtime crash in `WebGPURenderer` by explicitly initializing `clippingPlanes`. Enhanced WASM loader error logging to identify server-side compression mismatches.

---
*PR created automatically by Jules for task [15405313851034602528](https://jules.google.com/task/15405313851034602528) started by @ford442*