### PR TITLE
Migrate Gameplay Modules to TypeScript

### DIFF
--- a/main.js
+++ b/main.js
@@ -22,7 +22,7 @@ import { getCycleState } from './src/core/cycle.ts';
 import { initWorld, generateMap } from './src/world/generation.ts';
 import { animatedFoliage, foliageGroup, activeVineSwing, foliageClouds, foliageMushrooms } from './src/world/state.ts';
 import { updatePhysics, player, bpmWind } from './src/systems/physics.ts';
-import { fireRainbow, updateBlaster } from './src/gameplay/rainbow-blaster.js';
+import { fireRainbow, updateBlaster } from './src/gameplay/rainbow-blaster.ts';
 import { updateFallingClouds } from './src/foliage/clouds.ts';
 import { cloudBatcher } from './src/foliage/cloud-batcher.ts';
 import { getGroundHeight } from './src/utils/wasm-loader.js';

--- a/plan.md
+++ b/plan.md
@@ -10,12 +10,14 @@
 
 ## Next Steps
 
-1. **Phase 1 (JS -> TS)**: Migrate remaining Logic and Gameplay Modules (`src/foliage/musical_flora.js`, `src/foliage/environment.js`, `src/gameplay/rainbow-blaster.js`) to TypeScript.
+1. **Rare Flora Discovery**: Implement the discovery system for rare plants (unlocking mechanics).
 
 ---
 
 ## Recent Progress
 - **Accomplished:**
+  - **Phase 1 (JS -> TS): Gameplay Modules (`musical_flora`, `environment`, `rainbow-blaster`)**: **Status: Implemented ✅**
+    - *Implementation Details:* Migrated `src/foliage/musical_flora.js`, `src/foliage/environment.js`, and `src/gameplay/rainbow-blaster.js` to TypeScript. Added strict typing for options interfaces and TSL nodes. Updated imports in `main.js`, `src/foliage/index.ts`, and `public/js/perf_instancing.js`. Verified build via `vite build`.
   - **Phase 1 (JS -> TS): Foliage Modules (`clouds`, `cave`, `stars`, `rainbow`, `moon`, `waterfalls`, `celestial-bodies`)**: **Status: Implemented ✅**
     - *Implementation Details:* Migrated 7 foliage modules from JavaScript to TypeScript (`.ts`). Renamed `src/foliage/index.js` to `index.ts` and updated exports. Consolidated imports in `src/systems/weather.ts`, `src/world/generation.ts`, and `main.js`. Added strict typing for creation options and TSL uniforms. Verified build integrity via `vite build`.
   - **Phase 1 (JS -> TS): Core Modules (`src/core/input.ts`, `src/core/cycle.ts`)**: **Status: Implemented ✅**

--- a/public/js/perf_instancing.js
+++ b/public/js/perf_instancing.js
@@ -1,6 +1,6 @@
 import * as THREE from '/node_modules/three/build/three.module.js';
 import { initWasm } from '/src/utils/wasm-loader.js';
-import { musicalFlora } from '/src/foliage/musical_flora.js';
+import { musicalFlora } from '/src/foliage/musical_flora.ts';
 
 const logEl = id('log');
 function id(n){return document.getElementById(n)}

--- a/src/foliage/environment.ts
+++ b/src/foliage/environment.ts
@@ -1,7 +1,18 @@
 import * as THREE from 'three';
+// @ts-ignore
 import { MeshStandardNodeMaterial } from 'three/webgpu';
 import { time, vec3, positionLocal, length, sin, cos } from 'three/tsl';
 import { registerReactiveMaterial, attachReactivity } from './common.ts';
+
+export interface FloatingOrbOptions {
+    color?: number;
+    size?: number;
+}
+
+export interface KickDrumGeyserOptions {
+    color?: number;
+    maxHeight?: number;
+}
 
 export function createMelodyLake(width = 200, depth = 200) {
     const geo = new THREE.PlaneGeometry(width, depth, 64, 64);
@@ -30,7 +41,7 @@ export function createMelodyLake(width = 200, depth = 200) {
     return mesh;
 }
 
-export function createFloatingOrb(options = {}) {
+export function createFloatingOrb(options: FloatingOrbOptions = {}) {
     const { color = 0x87CEEB, size = 0.5 } = options;
     const geo = new THREE.SphereGeometry(size, 8, 8);
     const mat = new THREE.MeshStandardMaterial({ color, emissive: color, emissiveIntensity: 0.8 });
@@ -48,7 +59,7 @@ export function createFloatingOrb(options = {}) {
     return attachReactivity(orb);
 }
 
-export function createFloatingOrbCluster(x, z) {
+export function createFloatingOrbCluster(x: number, z: number) {
     const cluster = new THREE.Group();
     cluster.position.set(x, 5, z);
     for (let i = 0; i < 3; i++) {
@@ -59,7 +70,7 @@ export function createFloatingOrbCluster(x, z) {
     return cluster;
 }
 
-export function createKickDrumGeyser(options = {}) {
+export function createKickDrumGeyser(options: KickDrumGeyserOptions = {}) {
     const { color = 0xFF4500, maxHeight = 5.0 } = options;
     const group = new THREE.Group();
 

--- a/src/foliage/index.ts
+++ b/src/foliage/index.ts
@@ -9,7 +9,7 @@ export * from './trees.ts';
 export * from './clouds.ts';
 export * from './waterfalls.ts';
 export * from './cave.ts';
-export * from './environment.js';
+export * from './environment.ts';
 export * from './fireflies.ts';
 export * from './animation.ts';
 export * from './water.ts';
@@ -41,7 +41,7 @@ export * from './pollen.ts'; // Added Pollen
 export { musicReactivitySystem } from '../systems/music-reactivity.ts';
 
 // Musical flora
-export * from './musical_flora.js';
+export * from './musical_flora.ts';
 export * from './arpeggio-batcher.ts';
 export * from './portamento-batcher.ts';
 


### PR DESCRIPTION
Migrated `src/foliage/musical_flora.js`, `src/foliage/environment.js`, and `src/gameplay/rainbow-blaster.js` to TypeScript. Added strict typing for options interfaces and TSL nodes. Updated imports in `main.js`, `src/foliage/index.ts`, and `public/js/perf_instancing.js`. Verified build via `vite build`.

---
*PR created automatically by Jules for task [220400127273543046](https://jules.google.com/task/220400127273543046) started by @ford442*