### PR TITLE
🎨 Palette: Add Close (X) button to Jukebox overlay

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -23,3 +23,7 @@
 ## 2024-12-05 - Time Synchronization in GPU Animations
 **Learning:** When driving shader animations via a global uniform (`uTime`) but triggering them from JavaScript events (like clicks), using `performance.now()` in JS creates a desync if the shader time is based on accumulated frame deltas (`gameTime`). This results in animations playing at the wrong time or not at all (negative age).
 **Action:** Always use the same time source for JS logic and GPU uniforms. If `uTime` is driven by a custom game loop, access its value in JS (`uTime.value`) instead of using system time (`performance.now()`) for synchronization.
+
+## 2026-02-03 - Close Affordance in Modals
+**Learning:** While a "Close" button at the bottom of a modal is functional, users instinctively look for an "X" icon in the top-right corner to dismiss overlays. Missing this pattern increases cognitive load.
+**Action:** Always include a top-right "X" dismiss action in modal dialogs, even if a bottom button exists, to support standard user behavior patterns.

--- a/index.html
+++ b/index.html
@@ -616,6 +616,7 @@
     <div id="playlist-backdrop" aria-hidden="true"></div>
 
     <div id="playlist-overlay" role="dialog" aria-modal="true" aria-labelledby="playlist-title" tabindex="-1">
+        <button id="playlistCloseX" class="close-icon-btn" aria-label="Close Jukebox">×</button>
         <h2 id="playlist-title">🎵 Jukebox</h2>
         <ul id="playlist-list" aria-label="Current playlist">
         </ul>

--- a/src/core/input.ts
+++ b/src/core/input.ts
@@ -83,6 +83,7 @@ export function initInput(
     const playlistBackdrop = document.getElementById('playlist-backdrop');
     const playlistList = document.getElementById('playlist-list');
     const closePlaylistBtn = document.getElementById('closePlaylistBtn');
+    const playlistCloseX = document.getElementById('playlistCloseX');
     const playlistUploadInput = document.getElementById('playlistUploadInput') as HTMLInputElement | null;
     const openJukeboxBtn = document.getElementById('openJukeboxBtn');
 
@@ -286,6 +287,10 @@ export function initInput(
     // Event Listeners for UI
     if (closePlaylistBtn) {
         closePlaylistBtn.addEventListener('click', togglePlaylist);
+    }
+
+    if (playlistCloseX) {
+        playlistCloseX.addEventListener('click', togglePlaylist);
     }
 
     if (playlistBackdrop) {

--- a/style.css
+++ b/style.css
@@ -87,3 +87,37 @@
     box-shadow: 0 2px 0 rgba(0,0,0,0.1);
     border-bottom: 2px solid #e0e0e0;
 }
+
+/* 🎨 Palette: Playlist Close Button */
+.close-icon-btn {
+    position: absolute;
+    top: 10px;
+    right: 15px;
+    background: none;
+    border: none;
+    font-size: 2em;
+    color: #FF6B6B;
+    cursor: pointer;
+    line-height: 1;
+    padding: 0;
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    transition: transform 0.2s, background 0.2s, color 0.2s;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: 'Fredoka One', cursive, sans-serif;
+    z-index: 10;
+}
+
+.close-icon-btn:hover {
+    background: #FFF0F5;
+    transform: scale(1.1);
+    color: #FF4081;
+}
+
+.close-icon-btn:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px #ffffff, 0 0 0 6px #FF4081;
+}


### PR DESCRIPTION
Added a `<button>` with an "X" icon to the top-right of the Jukebox overlay. 
Styled it with existing design tokens (Fredoka One font, pink colors).
Wired it up to the `togglePlaylist` function in `src/core/input.ts`.
Added a journal entry to `.Jules/palette.md` regarding modal close affordances.
Verified with `pnpm build` and `verify_input_logic.mjs`.


---
*PR created automatically by Jules for task [5771658598685922518](https://jules.google.com/task/5771658598685922518) started by @ford442*