### PR TITLE
🎨 Palette: Add visible volume control buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -31,3 +31,7 @@
 ## 2026-03-12 - Handling Text Overflow in User Content
 **Learning:** When displaying user-generated filenames (like in a playlist), long strings without spaces can break flexbox layouts or push UI controls off-screen.
 **Action:** Always apply `text-overflow: ellipsis`, `overflow: hidden`, and `white-space: nowrap` (along with `min-width: 0` in flex containers) to text elements that display variable content, ensuring layout integrity.
+
+## 2026-06-25 - Mouse Parity for System Controls
+**Learning:** Key system controls (like Volume) often get relegated to keyboard shortcuts, excluding mouse-only or touch users. Reliance on "standard" shortcuts (like +/-) excludes devices without those keys visible (e.g. some tablets).
+**Action:** Ensure every system toggle/adjustment has a visible UI equivalent in the settings menu, using accessible buttons with clear visual states (e.g., disabled when min/max reached).

--- a/index.html
+++ b/index.html
@@ -554,9 +554,11 @@
                 🌙 Switch to Night <span class="key-badge">N</span>
             </button>
 
+            <button id="volDownBtn" class="toggle-button" aria-label="Decrease Volume" aria-keyshortcuts="-">&minus;</button>
             <button id="toggleMuteBtn" class="toggle-button" aria-pressed="false" aria-keyshortcuts="M" aria-label="Mute Audio">
                 🔊 Mute <span class="key-badge">M</span>
             </button>
+            <button id="volUpBtn" class="toggle-button" aria-label="Increase Volume" aria-keyshortcuts="+">&plus;</button>
 
             <button id="openJukeboxBtn" class="toggle-button" aria-keyshortcuts="Q" aria-label="Open Jukebox playlist">
                 Open Jukebox <span class="key-badge">Q</span>

--- a/src/core/input.ts
+++ b/src/core/input.ts
@@ -592,6 +592,8 @@ export function initInput(
     }
 
     const toggleMuteBtn = document.getElementById('toggleMuteBtn');
+    const volDownBtn = document.getElementById('volDownBtn') as HTMLButtonElement | null;
+    const volUpBtn = document.getElementById('volUpBtn') as HTMLButtonElement | null;
 
     // Helper: Update Mute UI
     const updateMuteUI = (isMuted: boolean) => {
@@ -624,6 +626,11 @@ export function initInput(
             updateMuteUI(false);
         }
 
+        // UX: Update Button States (Visual Polish)
+        // Use epsilon for float comparison safety
+        if (volDownBtn) volDownBtn.disabled = (newVol <= 0.01);
+        if (volUpBtn) volUpBtn.disabled = (newVol >= 0.99);
+
         const percentage = Math.round(newVol * 100);
         const icon = newVol === 0 ? '🔇' : newVol < 0.5 ? '🔉' : '🔊';
 
@@ -632,6 +639,24 @@ export function initInput(
             showToast(`Volume: ${percentage}% ${icon}`, icon);
         });
     };
+
+    // Initialize Volume Buttons State
+    if (volDownBtn) volDownBtn.disabled = (audioSystem.volume <= 0.01);
+    if (volUpBtn) volUpBtn.disabled = (audioSystem.volume >= 0.99);
+
+    if (volDownBtn) {
+        volDownBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            adjustVolume(-0.1);
+        });
+    }
+
+    if (volUpBtn) {
+        volUpBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            adjustVolume(0.1);
+        });
+    }
 
     if (toggleMuteBtn) {
         toggleMuteBtn.addEventListener('click', (e) => {


### PR DESCRIPTION
Added visible Volume Down and Volume Up buttons to the main settings menu to improve accessibility for mouse/touch users. The buttons include visual feedback (disabled states at min/max volume) and standard ARIA labels. Verified via Playwright screenshot and build check.

---
*PR created automatically by Jules for task [8687824602138148782](https://jules.google.com/task/8687824602138148782) started by @ford442*