### PR TITLE
🎨 Palette: Add tooltips for shortcut discoverability

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -35,3 +35,7 @@
 ## 2026-06-25 - Mouse Parity for System Controls
 **Learning:** Key system controls (like Volume) often get relegated to keyboard shortcuts, excluding mouse-only or touch users. Reliance on "standard" shortcuts (like +/-) excludes devices without those keys visible (e.g. some tablets).
 **Action:** Ensure every system toggle/adjustment has a visible UI equivalent in the settings menu, using accessible buttons with clear visual states (e.g., disabled when min/max reached).
+
+## 2026-07-15 - Tooltips for Shortcut Discoverability
+**Learning:** In a keyboard-heavy 3D application, users often miss available shortcuts for UI controls (like volume) when the buttons only display icons. While `aria-label` helps screen readers, sighted mouse users have no way to discover these shortcuts without guessing.
+**Action:** Add `title` attributes to all icon-only control buttons that include both the action name and the keyboard shortcut (e.g., "Decrease Volume (-)"), bridging the gap between mouse and keyboard interaction.

--- a/index.html
+++ b/index.html
@@ -546,7 +546,7 @@
 
         <div class="settings settings-container">
             <input type="file" id="musicUpload" accept=".mod,.xm,.it,.s3m" multiple class="visually-hidden">
-            <label for="musicUpload" class="file-label" aria-live="polite">
+            <label for="musicUpload" class="file-label" aria-live="polite" title="Supported formats: .mod, .xm, .it, .s3m">
                 🎵 Upload Music
             </label>
 
@@ -554,11 +554,15 @@
                 🌙 Switch to Night <span class="key-badge">N</span>
             </button>
 
-            <button id="volDownBtn" class="toggle-button" aria-label="Decrease Volume" aria-keyshortcuts="-">&minus;</button>
+            <button id="volDownBtn" class="toggle-button" aria-label="Decrease Volume" aria-keyshortcuts="-" title="Decrease Volume (-)">
+                &minus;
+            </button>
             <button id="toggleMuteBtn" class="toggle-button" aria-pressed="false" aria-keyshortcuts="M" aria-label="Mute Audio">
                 🔊 Mute <span class="key-badge">M</span>
             </button>
-            <button id="volUpBtn" class="toggle-button" aria-label="Increase Volume" aria-keyshortcuts="+">&plus;</button>
+            <button id="volUpBtn" class="toggle-button" aria-label="Increase Volume" aria-keyshortcuts="+" title="Increase Volume (+)">
+                &plus;
+            </button>
 
             <button id="openJukeboxBtn" class="toggle-button" aria-keyshortcuts="Q" aria-label="Open Jukebox playlist">
                 Open Jukebox <span class="key-badge">Q</span>
@@ -626,14 +630,14 @@
     <div id="playlist-backdrop" aria-hidden="true"></div>
 
     <div id="playlist-overlay" role="dialog" aria-modal="true" aria-labelledby="playlist-title" tabindex="-1">
-        <button id="playlistCloseX" class="close-icon-btn" aria-label="Close Jukebox">×</button>
+        <button id="playlistCloseX" class="close-icon-btn" aria-label="Close Jukebox" title="Close Jukebox (Esc)">×</button>
         <h2 id="playlist-title">🎵 Jukebox</h2>
         <ul id="playlist-list" aria-label="Current playlist">
         </ul>
         
         <div class="playlist-controls">
             <input type="file" id="playlistUploadInput" multiple accept=".mod,.xm,.it,.s3m" class="visually-hidden">
-            <label for="playlistUploadInput" class="secondary-button" aria-live="polite">➕ Add Songs</label>
+            <label for="playlistUploadInput" class="secondary-button" aria-live="polite" title="Supported formats: .mod, .xm, .it, .s3m">➕ Add Songs</label>
             <button id="closePlaylistBtn" class="secondary-button" style="background: #FF6B6B;" aria-label="Close Jukebox (Escape)">Close <span class="key-badge">Esc</span></button>
         </div>
         <div style="text-align: center; margin-top: 15px; font-size: 0.85em; color: #666;" aria-hidden="true">


### PR DESCRIPTION
💡 What: Added 'title' attributes to Volume Down/Up buttons, Jukebox Close button, and File Upload labels.
🎯 Why: Sighted mouse users had no way to discover keyboard shortcuts for icon-only buttons, and file format support was hidden until interaction.
♿ Accessibility: Improved discoverability for mouse users and clarity on supported file formats.
📸 Changes: Added native browser tooltips (e.g., "Decrease Volume (-)") to relevant UI elements.

---
*PR created automatically by Jules for task [15119985295342635559](https://jules.google.com/task/15119985295342635559) started by @ford442*