### PR TITLE
🎨 Palette: Improve volume button focus preservation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -43,3 +43,7 @@
 ## 2026-07-28 - Visualizing Ability Cooldowns
 **Learning:** Players often fail to use abilities like Dash or Mines because they lack visual feedback on when they are ready. Relying solely on internal timers or audio cues creates cognitive load and frustration.
 **Action:** Implement always-visible HUD elements for key abilities that include both iconographic representation and dynamic cooldown overlays, synchronized with the game loop state.
+
+## 2026-08-01 - Volume Button Focus Preservation
+**Learning:** The native `disabled` attribute removes elements from the focus order, causing disorientation for keyboard users when a button (like Volume Down) becomes disabled after activation.
+**Action:** Use `aria-disabled="true"` with custom CSS styling to create a "soft disabled" state that preserves focus. Ensure associated click handlers explicitly check this attribute to prevent unwanted actions.

--- a/src/core/input.ts
+++ b/src/core/input.ts
@@ -628,8 +628,8 @@ export function initInput(
 
         // UX: Update Button States (Visual Polish)
         // Use epsilon for float comparison safety
-        if (volDownBtn) volDownBtn.disabled = (newVol <= 0.01);
-        if (volUpBtn) volUpBtn.disabled = (newVol >= 0.99);
+        if (volDownBtn) volDownBtn.setAttribute('aria-disabled', String(newVol <= 0.01));
+        if (volUpBtn) volUpBtn.setAttribute('aria-disabled', String(newVol >= 0.99));
 
         const percentage = Math.round(newVol * 100);
         const icon = newVol === 0 ? '🔇' : newVol < 0.5 ? '🔉' : '🔊';
@@ -640,12 +640,13 @@ export function initInput(
     };
 
     // Initialize Volume Buttons State
-    if (volDownBtn) volDownBtn.disabled = (audioSystem.volume <= 0.01);
-    if (volUpBtn) volUpBtn.disabled = (audioSystem.volume >= 0.99);
+    if (volDownBtn) volDownBtn.setAttribute('aria-disabled', String(audioSystem.volume <= 0.01));
+    if (volUpBtn) volUpBtn.setAttribute('aria-disabled', String(audioSystem.volume >= 0.99));
 
     if (volDownBtn) {
         volDownBtn.addEventListener('click', (e) => {
             e.stopPropagation();
+            if (volDownBtn.getAttribute('aria-disabled') === 'true') return;
             adjustVolume(-0.1);
         });
     }
@@ -653,6 +654,7 @@ export function initInput(
     if (volUpBtn) {
         volUpBtn.addEventListener('click', (e) => {
             e.stopPropagation();
+            if (volUpBtn.getAttribute('aria-disabled') === 'true') return;
             adjustVolume(0.1);
         });
     }

--- a/style.css
+++ b/style.css
@@ -205,3 +205,20 @@
 .ability-slot.ready:active {
     transform: scale(0.9);
 }
+
+/* 🎨 Palette: Soft Disabled State */
+/* Maintains focusability for keyboard users while indicating unavailability */
+.toggle-button[aria-disabled="true"] {
+    opacity: 0.5;
+    cursor: not-allowed;
+    background: #6A5ACD; /* Reset hover color */
+}
+
+.toggle-button[aria-disabled="true"]:hover {
+    background: #6A5ACD;
+    transform: none;
+}
+
+.toggle-button[aria-disabled="true"]:active {
+    transform: none;
+}


### PR DESCRIPTION
This change addresses an accessibility issue where disabling volume buttons (at min/max levels) caused keyboard focus to be lost, disorienting users. 

By switching to a "soft disabled" pattern using `aria-disabled` and preventing the action in the click handler, we preserve the focus on the button while still communicating its unavailable state to both sighted users (via CSS opacity/cursor) and screen readers (via ARIA).

This aligns with Palette's philosophy of making interactions smooth and accessible.

---
*PR created automatically by Jules for task [16233025133567050960](https://jules.google.com/task/16233025133567050960) started by @ford442*