### PR TITLE
🎨 Palette: Interactive Key Hints in Pause Menu

### DIFF
--- a/src/core/input.ts
+++ b/src/core/input.ts
@@ -414,6 +414,28 @@ export function initInput(
 
         // --- UX: Focus Trap for Main Menu (Pause Screen) ---
         if (!isPlaylistOpen && instructions && instructions.style.display !== 'none') {
+            // 🎨 Palette: Interactive Key Hints
+            // Highlight the visual key in the help menu when pressed
+            const keyChar = event.key.toUpperCase();
+            const code = event.code;
+            const keys = instructions.querySelectorAll('kbd.key');
+
+            keys.forEach(k => {
+                const text = (k as HTMLElement).innerText.toUpperCase();
+                // Match by text content or specific codes
+                let match = false;
+                if (text === keyChar) match = true;
+                if (text === 'SPACE' && code === 'Space') match = true;
+                if (text === 'SHIFT' && (code === 'ShiftLeft' || code === 'ShiftRight')) match = true;
+                if (text === 'CTRL' && (code === 'ControlLeft' || code === 'ControlRight')) match = true;
+                if (text === '+' && (code === 'Equal' || code === 'NumpadAdd')) match = true;
+                if (text === '-' && (code === 'Minus' || code === 'NumpadSubtract')) match = true;
+
+                if (match) {
+                    k.classList.add('key-highlight');
+                }
+            });
+
             if (event.code === 'Tab') {
                 const focusable = instructions.querySelectorAll('button, input, [href], select, textarea, [tabindex]:not([tabindex="-1"])');
                 if (focusable.length > 0) {
@@ -526,6 +548,28 @@ export function initInput(
     };
 
     const onKeyUp = function (event: KeyboardEvent) {
+        // 🎨 Palette: Remove Key Hints
+        if (instructions && instructions.style.display !== 'none') {
+            const keyChar = event.key.toUpperCase();
+            const code = event.code;
+            const keys = instructions.querySelectorAll('kbd.key');
+
+            keys.forEach(k => {
+                const text = (k as HTMLElement).innerText.toUpperCase();
+                let match = false;
+                if (text === keyChar) match = true;
+                if (text === 'SPACE' && code === 'Space') match = true;
+                if (text === 'SHIFT' && (code === 'ShiftLeft' || code === 'ShiftRight')) match = true;
+                if (text === 'CTRL' && (code === 'ControlLeft' || code === 'ControlRight')) match = true;
+                if (text === '+' && (code === 'Equal' || code === 'NumpadAdd')) match = true;
+                if (text === '-' && (code === 'Minus' || code === 'NumpadSubtract')) match = true;
+
+                if (match) {
+                    k.classList.remove('key-highlight');
+                }
+            });
+        }
+
         switch (event.code) {
             case 'KeyW': keyStates.forward = false; break;
             case 'KeyA': keyStates.left = false; break;

--- a/style.css
+++ b/style.css
@@ -222,3 +222,20 @@
 .toggle-button[aria-disabled="true"]:active {
     transform: none;
 }
+
+/* 🎨 Palette: Key Hint Feedback */
+kbd.key {
+    transition: transform 0.1s cubic-bezier(0.175, 0.885, 0.32, 1.275),
+                background-color 0.1s ease,
+                box-shadow 0.1s ease;
+}
+
+kbd.key.key-highlight {
+    transform: scale(1.2);
+    background-color: #FF6B6B;
+    color: white;
+    border-color: #FF4081;
+    box-shadow: 0 0 15px rgba(255, 107, 107, 0.6);
+    z-index: 10;
+    position: relative;
+}


### PR DESCRIPTION
Added interactive key highlighting to the pause menu (`#instructions`). When a user presses a key listed in the controls (e.g., W, A, S, D), the corresponding visual key on the screen lights up. This adds a layer of polish and helps users verify their input is working.

---
*PR created automatically by Jules for task [14910120215005572665](https://jules.google.com/task/14910120215005572665) started by @ford442*