### PR TITLE
Migrate panning-pads and silence-spirits to TypeScript

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -10,13 +10,15 @@
 
 ## Next Steps
 
-1. **Migrate to TypeScript (Phase 1)**: Migrate remaining visual effect modules to TypeScript.
-   - *Target Modules*: `src/foliage/panning-pads.js`, `src/foliage/silence-spirits.js`.
+1. **Migrate to TypeScript (Phase 1)**: Migrate remaining foliage modules to TypeScript.
+   - *Target Modules*: `src/foliage/pines.js`, `src/foliage/glitch.js`, `src/foliage/chromatic.js`.
 
 ---
 
 ## Recent Progress
 - **Accomplished:**
+  - **Migrate to TypeScript (Phase 1): Visual Effects (`panning-pads`, `silence-spirits`)**: **Status: Implemented ✅**
+    - *Implementation Details:* Migrated `src/foliage/panning-pads.js` and `src/foliage/silence-spirits.js` to TypeScript (`.ts`). Added strict typing for `PanningPadOptions`, `SilenceSpiritOptions`, and exported `UnifiedMaterialOptions` from `src/foliage/common.ts` for better type reuse. Updated `src/foliage/index.ts` exports.
   - **Migrate to TypeScript (Phase 1): Visual Effects (`ribbons`, `sparkle-trail`, `lotus`, `aurora`)**: **Status: Implemented ✅**
     - *Implementation Details:* Migrated `src/foliage/ribbons.js`, `src/foliage/sparkle-trail.js`, `src/foliage/lotus.js`, and `src/foliage/aurora.js` to TypeScript (`.ts`). Added strict typing for `RibbonUserData`, `SparkleTrailUserData`, `LotusOptions` and TSL nodes. Updated `src/foliage/index.ts` exports. Verified file presence and imports.
   - **Migrate to TypeScript (Phase 1): Core Effects (`impacts`, `instrument`)**: **Status: Implemented ✅**

--- a/src/foliage/common.ts
+++ b/src/foliage/common.ts
@@ -250,7 +250,7 @@ export const calculateFlowerBloom = Fn(([posNode]) => {
 
 // ------------------------------------------
 
-interface UnifiedMaterialOptions {
+export interface UnifiedMaterialOptions {
     colorNode?: Node;
     deformationNode?: Node;
     roughness?: number;

--- a/src/foliage/index.ts
+++ b/src/foliage/index.ts
@@ -27,8 +27,8 @@ export * from './moon.ts';
 export * from './celestial-bodies.ts';
 export * from './rainbow.ts'; // Added Rainbow
 export * from './aurora.ts'; // .js -> .ts
-export * from './panning-pads.js';
-export * from './silence-spirits.js';
+export * from './panning-pads.ts';
+export * from './silence-spirits.ts';
 export * from './instrument.ts';
 export * from './ribbons.ts'; // .js -> .ts
 export * from './mirrors.ts';

--- a/src/foliage/panning-pads.ts
+++ b/src/foliage/panning-pads.ts
@@ -1,4 +1,4 @@
-// src/foliage/panning-pads.js
+// src/foliage/panning-pads.ts
 
 import * as THREE from 'three';
 import {
@@ -9,15 +9,24 @@ import {
     sharedGeometries,
     createStandardNodeMaterial,
     uPlayerPosition,
-    uTime
+    uTime,
+    UnifiedMaterialOptions
 } from './common.ts';
 import { spawnImpact } from './impacts.ts';
 import {
     color, float, mix, uv, distance, vec2, smoothstep, uniform,
-    positionLocal, positionWorld, vec3
+    positionLocal, positionWorld, vec3,
+    ShaderNodeObject, Node
 } from 'three/tsl';
 
-export function createPanningPad(options = {}) {
+export interface PanningPadOptions {
+    radius?: number;
+    baseColor?: THREE.ColorRepresentation;
+    glowColor?: THREE.ColorRepresentation;
+    panBias?: number;
+}
+
+export function createPanningPad(options: PanningPadOptions = {}): THREE.Group {
     const {
         radius = 1.0,
         baseColor = 0x2E8B57,
@@ -57,7 +66,7 @@ export function createPanningPad(options = {}) {
     // 1. The Pad (Flattened Cylinder)
     // We want a mercury/holographic look.
     // Use OilSlick preset but tweak for "mercury" (high metalness, high smoothness)
-    const padMat = createUnifiedMaterial(0xCCCCCC, {
+    const padMatOpts: UnifiedMaterialOptions = {
         roughness: 0.1,
         metalness: 0.9,
         iridescenceStrength: 0.8,
@@ -65,9 +74,11 @@ export function createPanningPad(options = {}) {
         bumpStrength: 0.05,
         noiseScale: 4.0,
         sheen: 0.5,
-        sheenColor: glowColor,
+        sheenColor: glowColor instanceof THREE.Color ? glowColor : new THREE.Color(glowColor),
         deformationNode: squashDeformation // ⚡ JUICE: Apply TSL Squash
-    });
+    };
+
+    const padMat = createUnifiedMaterial(0xCCCCCC, padMatOpts);
     registerReactiveMaterial(padMat);
 
     const pad = new THREE.Mesh(sharedGeometries.unitCylinder, padMat);

--- a/src/foliage/silence-spirits.ts
+++ b/src/foliage/silence-spirits.ts
@@ -1,4 +1,4 @@
-// src/foliage/silence-spirits.js
+// src/foliage/silence-spirits.ts
 
 import * as THREE from 'three';
 import { MeshStandardNodeMaterial } from 'three/webgpu';
@@ -14,7 +14,11 @@ import {
     uPlayerPosition
 } from './common.ts';
 
-export function createSilenceSpirit(options = {}) {
+export interface SilenceSpiritOptions {
+    scale?: number;
+}
+
+export function createSilenceSpirit(options: SilenceSpiritOptions = {}): THREE.Group {
     const group = new THREE.Group();
     const { scale = 1.0 } = options;
 


### PR DESCRIPTION
Migrated `panning-pads` and `silence-spirits` to TypeScript as part of the ongoing Phase 1 migration. This includes strict typing for options interfaces (`PanningPadOptions`, `SilenceSpiritOptions`) and proper export of `UnifiedMaterialOptions` from `common.ts` to ensure type safety across foliage modules. The project plan has been updated to mark these as complete and target remaining foliage modules for the next step.

---
*PR created automatically by Jules for task [12593727855471625734](https://jules.google.com/task/12593727855471625734) started by @ford442*