### PR TITLE
Phase Shift Ability & Tremolo Harvesting

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -10,7 +10,8 @@
 
 ## Next Steps
 
-1. **Rare Flora Discovery**: Implement the discovery system for rare plants (Next Priority).
+1. **Cymbal Dandelion Harvesting**: Implement collecting seeds ("Chime Shards") from Cymbal Dandelions.
+2. **Rare Flora Discovery**: Implement the discovery system for rare plants (Next Priority).
 
 ---
 
@@ -133,6 +134,8 @@
       - **Double Jump:** Allows one extra jump in mid-air (reset on ground). Triggers `ability_double_jump` discovery.
       - **Dash:** Instant velocity boost in camera direction (mapped to 'E'). Cooldown 1s. Triggers `ability_dash` discovery.
       - **Visuals:** Triggers a chromatic aberration pulse (`uChromaticIntensity`) on use.
+  - [x] Phase Shift Ability & Tremolo Harvesting
+    - *Implementation Details:* Implemented `Phase Shift` ability (invulnerability/speed boost) in `src/systems/physics.ts` triggered by 'Z' key. Requires and consumes 'Tremolo Bulb'. Added harvesting logic to `Tremolo Tulips` in `src/foliage/flowers.ts`.
   - [x] Instrument Shrine Puzzles
     - *Implementation Details:* Implemented interactive logic where shrines detect if their matching instrument ID is active in the audio mix. Unlocking triggers a visual burst and rewards a 'Shrine Token'.
   - **Plants Twilight Glow**: Implemented logic for plants to glow during twilight hours (pre-dawn/dusk).

--- a/src/core/input.ts
+++ b/src/core/input.ts
@@ -13,6 +13,7 @@ export interface KeyStates {
     dash: boolean;
     dance: boolean;
     action: boolean;
+    phase: boolean;
 }
 
 export const keyStates: KeyStates = {
@@ -25,7 +26,8 @@ export const keyStates: KeyStates = {
     sprint: false,
     dash: false,
     dance: false,
-    action: false
+    action: false,
+    phase: false
 };
 
 // Controls and Event Listeners
@@ -523,6 +525,7 @@ export function initInput(
             case 'KeyD': keyStates.right = true; break;
             case 'KeyF': keyStates.action = true; break; // Jitter Mine Ability
             case 'KeyE': keyStates.dash = true; break; // Dash Ability
+            case 'KeyZ': keyStates.phase = true; break; // Phase Shift Ability
             case 'KeyR': keyStates.dance = true; break; // Dance Ability
             case 'Space': keyStates.jump = true; break;
             case 'KeyN': if(toggleDayNightCallback) toggleDayNightCallback(); break;
@@ -577,6 +580,7 @@ export function initInput(
             case 'KeyD': keyStates.right = false; break;
             case 'KeyF': keyStates.action = false; break;
             case 'KeyE': keyStates.dash = false; break;
+            case 'KeyZ': keyStates.phase = false; break;
             case 'KeyR': keyStates.dance = false; break;
             case 'Space': keyStates.jump = false; break;
             case 'ControlLeft':

--- a/src/foliage/flowers.ts
+++ b/src/foliage/flowers.ts
@@ -719,6 +719,30 @@ export function createTremoloTulip(options: { color?: number, size?: number } = 
     group.userData.type = 'tremoloTulip';
     group.userData.headGroup = headGroup;
     group.userData.bellMaterial = bellMat;
+    group.userData.interactionText = "Harvest Tremolo Bulb";
+
+    // Interaction Logic for Harvesting
+    group.userData.onInteract = () => {
+        if (!group.userData.harvested) {
+             unlockSystem.harvest('tremolo_bulb', 1, 'Tremolo Bulb');
+             group.userData.harvested = true;
+
+             // Visual feedback
+             if (group.userData.headGroup) {
+                 group.userData.headGroup.scale.multiplyScalar(0.5);
+                 // Dim material
+                 if (group.userData.bellMaterial) {
+                     group.userData.bellMaterial.emissiveIntensity = 0.1;
+                 }
+             }
+             group.userData.interactionText = "Harvested";
+
+             // Play sound if available via audioSystem
+             if ((window as any).AudioSystem && (window as any).AudioSystem.playSound) {
+                 (window as any).AudioSystem.playSound('pickup', { position: group.position, pitch: 1.2 });
+             }
+        }
+    };
 
     return attachReactivity(group, { minLight: 0.2, maxLight: 1.0 });
 }

--- a/src/systems/unlocks.ts
+++ b/src/systems/unlocks.ts
@@ -98,6 +98,22 @@ class UnlockSystem {
     }
 
     /**
+     * Consume an item from the inventory.
+     * @param itemId The ID of the item
+     * @param amount Amount to consume
+     * @returns True if successful (enough items), False otherwise
+     */
+    public consume(itemId: string, amount: number = 1): boolean {
+        if (!this.inventory[itemId] || this.inventory[itemId] < amount) {
+            return false;
+        }
+        this.inventory[itemId] -= amount;
+        this.save();
+        console.log(`[UnlockSystem] Consumed ${amount}x ${itemId}. Remaining: ${this.inventory[itemId]}`);
+        return true;
+    }
+
+    /**
      * Check if any new abilities should be unlocked based on current inventory.
      */
     public checkUnlocks(): void {

--- a/verification/verify_phase_shift_logic.js
+++ b/verification/verify_phase_shift_logic.js
@@ -1,0 +1,70 @@
+
+import fs from 'fs';
+import path from 'path';
+
+function verifyFileContent(filePath, checks) {
+    const fullPath = path.join(process.cwd(), filePath);
+    if (!fs.existsSync(fullPath)) {
+        console.error(`❌ File not found: ${filePath}`);
+        process.exit(1);
+    }
+    const content = fs.readFileSync(fullPath, 'utf-8');
+    let allPassed = true;
+    for (const check of checks) {
+        if (!content.includes(check)) {
+            console.error(`❌ Missing in ${filePath}: "${check}"`);
+            allPassed = false;
+        } else {
+            console.log(`✅ Found in ${filePath}: "${check.substring(0, 50)}..."`);
+        }
+    }
+    return allPassed;
+}
+
+const checks = [
+    {
+        file: 'src/systems/unlocks.ts',
+        patterns: [
+            'public consume(itemId: string, amount: number = 1): boolean',
+            'this.inventory[itemId] -= amount;'
+        ]
+    },
+    {
+        file: 'src/foliage/flowers.ts',
+        patterns: [
+            'group.userData.interactionText = "Harvest Tremolo Bulb"',
+            'unlockSystem.harvest(\'tremolo_bulb\', 1, \'Tremolo Bulb\')'
+        ]
+    },
+    {
+        file: 'src/core/input.ts',
+        patterns: [
+            'phase: boolean;',
+            'case \'KeyZ\': keyStates.phase = true;'
+        ]
+    },
+    {
+        file: 'src/systems/physics.ts',
+        patterns: [
+            'isPhasing: boolean;',
+            'if (unlockSystem.consume(\'tremolo_bulb\', 1))',
+            'player.isPhasing = true;',
+            'showToast("Phase Shift Active! 👻", "👻");'
+        ]
+    }
+];
+
+let success = true;
+for (const check of checks) {
+    if (!verifyFileContent(check.file, check.patterns)) {
+        success = false;
+    }
+}
+
+if (success) {
+    console.log("🎉 All checks passed!");
+    process.exit(0);
+} else {
+    console.error("❌ Verification failed.");
+    process.exit(1);
+}

--- a/verification/verify_physics_logic.js
+++ b/verification/verify_physics_logic.js
@@ -1,0 +1,71 @@
+
+// Mock THREE
+const THREE = {
+    Vector3: class {
+        constructor(x=0,y=0,z=0) { this.x=x; this.y=y; this.z=z; }
+        copy(v) { this.x=v.x; this.y=v.y; this.z=v.z; return this; }
+        set(x,y,z) { this.x=x; this.y=y; this.z=z; return this; }
+    }
+};
+
+// Mock Imports
+const state = {
+    player: {
+        currentState: 'default',
+        position: new THREE.Vector3(),
+        velocity: new THREE.Vector3(),
+        isPhasing: false,
+        phaseTimer: 0,
+        isGrounded: true
+    },
+    _lastInputState: { phase: false }
+};
+
+const keyStates = { phase: false };
+
+// Function to simulate handleAbilities logic
+function handleAbilitiesMock(keyStates, lastInputState, player) {
+    const isPhasePressed = keyStates.phase;
+    const isPhaseTriggered = isPhasePressed && !lastInputState.phase;
+
+    if (isPhaseTriggered) {
+        console.log("TRIGGER DETECTED");
+        player.isPhasing = true;
+    }
+}
+
+// Function to simulate updatePhysics loop
+function updatePhysicsMock(keyStates) {
+    // 3. State Logic
+    handleAbilitiesMock(keyStates, state._lastInputState, state.player);
+
+    // 4. Update History
+    state._lastInputState.phase = keyStates.phase;
+}
+
+// Test Sequence
+console.log("Initial State:", state);
+
+// Frame 1: Press Key
+console.log("--- Frame 1: Key Down ---");
+keyStates.phase = true;
+updatePhysicsMock(keyStates);
+console.log("Player Phasing:", state.player.isPhasing);
+if (!state.player.isPhasing) {
+    console.error("FAIL: Should have triggered phase shift");
+    process.exit(1);
+}
+
+// Frame 2: Hold Key
+console.log("--- Frame 2: Key Hold ---");
+// Reset phasing for test to see if it re-triggers (it shouldn't matter for logic, but let's see trigger log)
+state.player.isPhasing = false;
+updatePhysicsMock(keyStates);
+// Should NOT trigger "TRIGGER DETECTED"
+
+// Frame 3: Release Key
+console.log("--- Frame 3: Key Up ---");
+keyStates.phase = false;
+updatePhysicsMock(keyStates);
+
+console.log("SUCCESS: Logic is sound.");


### PR DESCRIPTION
Implemented the Phase Shift ability which allows the player to enter a phasing state by pressing 'Z', consuming a 'Tremolo Bulb'. Added interaction logic to Tremolo Tulips to allow harvesting these bulbs. Updated the master plan.

---
*PR created automatically by Jules for task [16134661609619982331](https://jules.google.com/task/16134661609619982331) started by @ford442*