### PR TITLE
🎨 Palette: Improve controls documentation and accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -600,6 +600,12 @@
                     <dt><kbd class="key">E</kbd></dt>
                     <dd>Dash (Requires Energy)</dd>
 
+                    <dt><kbd class="key">F</kbd></dt>
+                    <dd>Jitter Mine (Cooldown)</dd>
+
+                    <dt><kbd class="key">Z</kbd></dt>
+                    <dd>Phase Shift (Requires Bulb)</dd>
+
                     <dt><kbd class="key">R</kbd></dt>
                     <dd>Dance Mode (Unlocks Cursor)</dd>
 
@@ -654,12 +660,12 @@
     <div id="reticle-label" aria-live="polite"></div>
 
     <div id="ability-hud" role="region" aria-label="Abilities">
-        <div class="ability-slot" id="ability-dash" title="Dash (E)" role="button" tabindex="0" aria-label="Dash Ability (E)">
+        <div class="ability-slot" id="ability-dash" title="Dash (E)" role="button" tabindex="0" aria-label="Dash Ability (E)" aria-keyshortcuts="E">
             <span class="ability-key">E</span>
             <span class="ability-icon" aria-hidden="true">💨</span>
             <div class="cooldown-overlay"></div>
         </div>
-        <div class="ability-slot" id="ability-mine" title="Jitter Mine (F)" role="button" tabindex="0" aria-label="Jitter Mine Ability (F)">
+        <div class="ability-slot" id="ability-mine" title="Jitter Mine (F)" role="button" tabindex="0" aria-label="Jitter Mine Ability (F)" aria-keyshortcuts="F">
             <span class="ability-key">F</span>
             <span class="ability-icon" aria-hidden="true">👾</span>
             <div class="cooldown-overlay"></div>


### PR DESCRIPTION
💡 What: Added missing 'Jitter Mine' (F) and 'Phase Shift' (Z) instructions to the help menu and added aria-keyshortcuts to HUD ability slots.
🎯 Why: Users were unaware of the F and Z abilities, and screen reader users had no way of knowing the shortcuts for the visible HUD buttons.
📸 Before/After: The 'Abilities' section of the help menu now lists all 5 abilities instead of just 3.
♿ Accessibility: Added aria-keyshortcuts='E' and aria-keyshortcuts='F' to the HUD buttons.

---
*PR created automatically by Jules for task [2326498051359346045](https://jules.google.com/task/2326498051359346045) started by @ford442*