### PR TITLE
🎨 Palette: Add Keyboard 'Enter' Support for Start/Resume

### DIFF
--- a/main.js
+++ b/main.js
@@ -758,7 +758,7 @@ initWasm().then(async (wasmLoaded) => {
     const startButton = document.getElementById('startButton');
     if (startButton) {
         startButton.disabled = false;
-        startButton.innerText = 'Enter World 🍭';
+        startButton.innerHTML = 'Enter World 🍭 <span class="key-badge">Enter</span>';
         startButton.focus();
         
         startButton.addEventListener('click', () => {

--- a/src/core/input.ts
+++ b/src/core/input.ts
@@ -368,7 +368,7 @@ export function initInput(
             if (title) title.innerText = 'Game Paused ⏸️';
 
             if (startButton) {
-                startButton.innerText = 'Resume Exploration 🚀';
+                startButton.innerHTML = 'Resume Exploration 🚀 <span class="key-badge">Enter</span>';
                 requestAnimationFrame(() => startButton.focus());
             }
         }
@@ -412,7 +412,7 @@ export function initInput(
                 // Pressing Escape again should manually bring up the menu.
                 if (instructions) instructions.style.display = 'flex';
                 if (startButton) {
-                    startButton.innerText = 'Resume Exploration 🚀';
+                    startButton.innerHTML = 'Resume Exploration 🚀 <span class="key-badge">Enter</span>';
                     startButton.focus();
                 }
                 return;
@@ -422,6 +422,16 @@ export function initInput(
             if (instructions && instructions.style.display !== 'none') {
                 controls.lock();
                 return;
+            }
+        }
+
+        // Enter: Resume/Start if menu is visible and button is active
+        if (event.code === 'Enter') {
+            if (!isPlaylistOpen && instructions && instructions.style.display !== 'none') {
+                if (startButton && !startButton.disabled && document.activeElement !== startButton) {
+                    startButton.click();
+                    event.preventDefault();
+                }
             }
         }
 


### PR DESCRIPTION
This change adds a small but impactful UX improvement:
1.  **Visual Hint**: The primary Call-to-Action button ("Enter World" / "Resume Exploration") now displays a `<span class="key-badge">Enter</span>` hint, making it clear that the Enter key can be used.
2.  **Keyboard Accessibility**: A global `Enter` key listener was added to the pause menu logic. This ensures that users can start or resume the game by pressing Enter, even if focus was temporarily lost from the button (e.g., by clicking on the background).

This aligns with the goal of making the interface more intuitive and accessible for keyboard users.
The implementation uses existing styles (`.key-badge`) and fits seamlessly into the existing input handling logic.

---
*PR created automatically by Jules for task [112310658594910996](https://jules.google.com/task/112310658594910996) started by @ford442*