### PR TITLE
Migrate main.js to TypeScript

### DIFF
--- a/index.html
+++ b/index.html
@@ -678,7 +678,7 @@
     </div>
 
     <canvas id="glCanvas" role="region" aria-label="Game World: Use mouse and keyboard to navigate"></canvas>
-    <script type="module" src="main.js"></script>
+    <script type="module" src="src/main.ts"></script>
 </body>
 
 </html>

--- a/plan.md
+++ b/plan.md
@@ -10,12 +10,14 @@
 
 ## Next Steps
 
-1. **Migrate `main.js` to TypeScript**: Convert the main entry point to TypeScript to complete the Phase 1 migration and ensure full type safety across the core loop.
+1. **Weather-Cycle Integration**: Implement time-of-day weather patterns (morning mist, afternoon storms) in `src/systems/weather.ts` and `src/main.ts` to fully synchronize the weather system with the day/night cycle.
 
 ---
 
 ## Recent Progress
 - **Accomplished:**
+  - **Migrate `main.js` to TypeScript**: **Status: Implemented ✅**
+    - *Implementation Details:* Converted the main entry point to `src/main.ts`. Defined global type definitions in `src/types/global.d.ts` for window augmentations and untyped JS modules. Updated `index.html` to point to the new TypeScript entry file and verified the build. This completes the core Phase 1 migration.
   - **Pattern-Change Seasons Logic**: **Status: Implemented ✅**
     - *Implementation Details:* Verified data flow of `order`/`row` from AudioWorklet to `AudioSystem`. Implemented logic in `src/systems/weather.ts` to cycle `targetPaletteMode` (Standard -> Neon -> Standard -> Glitch) based on the music pattern index (`patternIndex`), driving the global visual theme.
   - **Portamento Pine Slingshot Physics**: **Status: Implemented ✅**
@@ -159,7 +161,7 @@
 ---
 
 ## Migration Roadmap (Summary)
-1. **Phase 1 (JS -> TS):** Typing core data structures and systems. [IN PROGRESS]
+1. **Phase 1 (JS -> TS):** Typing core data structures and systems. [DONE]
 2. **Phase 2 (TS -> ASC):** Offloading hot paths to WASM. [DONE]
 3. **Phase 3 (ASC -> C++):** Specialized solvers.
 4. **Phase 4 (Three.js -> WebGPU):** Raw compute and render pipelines.

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,43 @@
+export {};
+
+declare global {
+  interface Window {
+    setLoadingStatus: (text: string) => void;
+    hideLoadingScreen: () => void;
+    __sceneReady?: boolean;
+    libopenmptReady?: Promise<any>;
+    libopenmpt?: {
+      INITIAL_MEMORY: number;
+      onRuntimeInitialized: () => void;
+    };
+    NativeWebAssembly?: typeof WebAssembly;
+  }
+}
+
+// Declare modules for JS files without types
+declare module '*/src/utils/wasm-loader.js' {
+  export function initWasm(): Promise<boolean>;
+  export function initWasmParallel(): Promise<boolean>;
+  export function isWasmReady(): boolean;
+  export function getGroundHeight(x: number, z: number): number;
+  export const LOADING_PHASES: any;
+}
+
+declare module '*/src/core/init.js' {
+  export function initScene(): any;
+  export function forceFullSceneWarmup(renderer: any, scene: any, camera: any): Promise<void>;
+}
+
+declare module '*/src/utils/profiler.js' {
+  export const profiler: {
+    startFrame(): void;
+    endFrame(): void;
+    measure<T>(name: string, fn: () => T): T;
+    toggle(): void;
+  };
+}
+
+declare module '*/src/foliage/fluid_fog.js' {
+  import { Mesh } from 'three';
+  export function createFluidFog(width?: number, depth?: number): Mesh;
+}


### PR DESCRIPTION
Migrated the main entry point `main.js` to TypeScript (`src/main.ts`). This involved:
1. Creating `src/types/global.d.ts` to handle global variables (`window.libopenmpt`, etc.) and untyped JS module imports.
2. Moving `main.js` content to `src/main.ts` and adjusting all import paths.
3. Adding type annotations to variables and function calls in `src/main.ts`.
4. Updating `index.html` to reference `src/main.ts`.
5. Verifying the build succeeds with `npm run build`.
This completes the Phase 1 JS -> TS migration for the core application loop.

---
*PR created automatically by Jules for task [1219375948889609284](https://jules.google.com/task/1219375948889609284) started by @ford442*