### PR TITLE
🎨 Palette: Add Now Playing to Pause Menu & A11y Improvements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -63,3 +63,7 @@
 ## 2026-08-12 - Throttled Progress Announcements
 **Learning:** Rapidly updating text content for visual smoothness (e.g., "Loading 1%... 2%... 3%") creates an unusable experience for screen reader users, who hear a constant torrent of numbers.
 **Action:** Decouple visual progress (smooth gradients/animations) from semantic progress. Throttle text updates and ARIA announcements to significant milestones (e.g., every 10%) and use `aria-busy="true"` to indicate ongoing processing.
+
+## 2026-08-15 - Live Region Context in Pause Menus
+**Learning:** Players often check the pause menu to see "What is playing?", but audio status (like the current track) is typically hidden in transient toasts or separate menus. This disconnects the audio experience from the game state.
+**Action:** When appropriate, elevate critical "ambient" information (like the current music track) to a persistent spot in the Pause Menu. Ensure this element is accessible via `aria-live` regions but only populated when relevant to avoid clutter.

--- a/index.html
+++ b/index.html
@@ -542,6 +542,9 @@
 
     <div id="instructions">
         <h1>🍭 Candy World</h1>
+        <div id="nowPlayingContainer" class="now-playing-info" aria-live="polite" style="display: none;">
+            <span class="music-note">🎵</span> <span id="nowPlayingText"></span>
+        </div>
         <button id="startButton" class="cta-button" disabled aria-live="polite">
             <span class="spinner" aria-hidden="true"></span>Loading World... 🍭
         </button>

--- a/src/core/input.ts
+++ b/src/core/input.ts
@@ -92,6 +92,10 @@ export function initInput(
     const playlistUploadInput = document.getElementById('playlistUploadInput') as HTMLInputElement | null;
     const openJukeboxBtn = document.getElementById('openJukeboxBtn');
 
+    // Now Playing Elements
+    const nowPlayingContainer = document.getElementById('nowPlayingContainer');
+    const nowPlayingText = document.getElementById('nowPlayingText');
+
     // Ability HUD Elements
     const hudDash = document.getElementById('ability-dash');
     const hudMine = document.getElementById('ability-mine');
@@ -214,7 +218,19 @@ export function initInput(
 
     // Initialize state
     if (audioSystem.getPlaylist) {
-        updateJukeboxButtonState(audioSystem.getPlaylist().length);
+        const playlist = audioSystem.getPlaylist();
+        updateJukeboxButtonState(playlist.length);
+
+        // 🎨 Palette: Restore Now Playing info if music is already running
+        const currentIdx = audioSystem.getCurrentIndex();
+        if (currentIdx >= 0 && playlist[currentIdx]) {
+            if (nowPlayingContainer && nowPlayingText) {
+                const trackName = playlist[currentIdx].name;
+                nowPlayingText.innerText = trackName;
+                nowPlayingContainer.style.display = 'flex';
+                nowPlayingContainer.setAttribute('aria-label', `Now Playing: ${trackName}`);
+            }
+        }
     }
 
     // Hook up AudioSystem callbacks
@@ -230,9 +246,17 @@ export function initInput(
         // Show "Now Playing" toast
         const songs = audioSystem.getPlaylist();
         if (songs && songs[index]) {
+            const trackName = songs[index].name;
             import('../utils/toast.js').then(({ showToast }) => {
-                showToast(`Now Playing: ${songs[index].name}`, '🎵');
+                showToast(`Now Playing: ${trackName}`, '🎵');
             });
+
+            // 🎨 Palette: Update "Now Playing" in Pause Menu
+            if (nowPlayingContainer && nowPlayingText) {
+                nowPlayingText.innerText = trackName;
+                nowPlayingContainer.style.display = 'flex';
+                nowPlayingContainer.setAttribute('aria-label', `Now Playing: ${trackName}`);
+            }
         }
     };
 
@@ -799,10 +823,12 @@ export function initInput(
         if (volDownBtn) {
             volDownBtn.setAttribute('aria-disabled', String(newVol <= 0.01));
             volDownBtn.title = `Decrease Volume (-) • ${percentage}%`;
+            volDownBtn.setAttribute('aria-label', `Decrease Volume (Current: ${percentage}%)`);
         }
         if (volUpBtn) {
             volUpBtn.setAttribute('aria-disabled', String(newVol >= 0.99));
             volUpBtn.title = `Increase Volume (+) • ${percentage}%`;
+            volUpBtn.setAttribute('aria-label', `Increase Volume (Current: ${percentage}%)`);
         }
 
         const icon = newVol === 0 ? '🔇' : newVol < 0.5 ? '🔉' : '🔊';
@@ -818,8 +844,14 @@ export function initInput(
 
     // NEW: Initialize Tooltips
     const initialVolPct = Math.round(audioSystem.volume * 100);
-    if (volDownBtn) volDownBtn.title = `Decrease Volume (-) • ${initialVolPct}%`;
-    if (volUpBtn) volUpBtn.title = `Increase Volume (+) • ${initialVolPct}%`;
+    if (volDownBtn) {
+        volDownBtn.title = `Decrease Volume (-) • ${initialVolPct}%`;
+        volDownBtn.setAttribute('aria-label', `Decrease Volume (Current: ${initialVolPct}%)`);
+    }
+    if (volUpBtn) {
+        volUpBtn.title = `Increase Volume (+) • ${initialVolPct}%`;
+        volUpBtn.setAttribute('aria-label', `Increase Volume (Current: ${initialVolPct}%)`);
+    }
     if (toggleMuteBtn) toggleMuteBtn.title = audioSystem.isMuted ? 'Unmute Audio (M)' : 'Mute Audio (M)';
 
     if (volDownBtn) {

--- a/style.css
+++ b/style.css
@@ -290,3 +290,29 @@ kbd.key.key-highlight {
     min-width: 140px;
     text-align: center;
 }
+
+/* 🎨 Palette: Now Playing Info (Pause Menu) */
+.now-playing-info {
+    font-family: 'Fredoka One', cursive, sans-serif;
+    color: #FF6B6B;
+    background: rgba(255, 255, 255, 0.9);
+    padding: 8px 20px;
+    border-radius: 20px;
+    margin-bottom: 20px;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    font-size: 1.1em;
+    text-shadow: 1px 1px 0 rgba(255,255,255,0.5);
+    border: 2px solid #FFD1DC;
+    max-width: 80%;
+    text-align: center;
+}
+
+.now-playing-info .music-note {
+    font-size: 1.2em;
+    animation: bounce 1s infinite alternate;
+    display: inline-block;
+}


### PR DESCRIPTION
This PR adds a "Now Playing" indicator to the Pause Menu, allowing users to see the current track name without waiting for a toast notification. It also improves the accessibility of volume controls by announcing the current volume percentage to screen readers via updated `aria-label` attributes.

---
*PR created automatically by Jules for task [10614699848140526407](https://jules.google.com/task/10614699848140526407) started by @ford442*