### PR TITLE
Audio-Reactive Terrain Implementation

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -10,13 +10,14 @@
 
 ## Next Steps
 
-1. **Audio-Reactive Terrain**: Implement vertex displacement for terrain chunks based on audio zones or global bass.
-2. **Post-Processing Pipeline**: Implement bloom and color correction using WebGPU post-processing nodes.
+1. **Post-Processing Pipeline**: Implement bloom and color correction using WebGPU post-processing nodes.
 
 ---
 
 ## Recent Progress
 - **Accomplished:**
+  - **Audio-Reactive Terrain**: **Status: Implemented ✅**
+    - *Implementation Details:* Implemented `createTerrainMaterial` in `src/foliage/terrain.ts` using TSL for bass-driven vertex displacement (breathing) and treble-driven sparkles (magic dust). Replaced static MeshPhysicalMaterial in `src/world/generation.ts`.
   - **Procedural Cloud Layer**: **Status: Implemented ✅**
     - *Implementation Details:* Implemented `src/foliage/procedural-sky.ts` to generate a dense, noise-based cloud layer using `CloudBatcher`. Updated `CloudBatcher` to support 20k puffs and dynamic day/night/storm lighting via `uSkyDarkness` and `uTwilight`.
   - **WebGPU Migration (Phase 4): Remaining Foliage Materials**: **Status: Implemented ✅**

--- a/src/foliage/index.ts
+++ b/src/foliage/index.ts
@@ -13,6 +13,7 @@ export * from './environment.ts';
 export * from './fireflies.ts';
 export * from './animation.ts';
 export * from './water.ts';
+export * from './terrain.ts'; // Added Terrain Material
 export * from './lake_features.js';
 export * from './glitch.ts';
 export * from './chromatic.ts';

--- a/src/foliage/terrain.ts
+++ b/src/foliage/terrain.ts
@@ -1,0 +1,81 @@
+import * as THREE from 'three';
+import { MeshStandardNodeMaterial } from 'three/webgpu';
+import {
+    color, float, vec3, Fn, uniform, sin, time, positionLocal,
+    smoothstep, mix, positionWorld, mx_noise_float, normalLocal
+} from 'three/tsl';
+import { CandyPresets, uAudioLow, uAudioHigh, createRimLight } from './common.ts';
+
+/**
+ * Creates an audio-reactive Terrain Material.
+ * Uses TSL for vertex displacement (Breathing) and "Magic Dust" sparkles.
+ *
+ * @param {number | string | THREE.Color} hexColor - Base color of the terrain.
+ * @param {any} options - Material options (roughness, bumpStrength, etc.)
+ * @returns {MeshStandardNodeMaterial}
+ */
+export function createTerrainMaterial(hexColor: number | string | THREE.Color, options: any = {}): MeshStandardNodeMaterial {
+    // 1. Base Material: Clay preset for the "Cute Clay" look
+    // Override with options to match existing ground physics material properties
+    const material = CandyPresets.Clay(hexColor, {
+        roughness: 0.9, // Matte clay
+        bumpStrength: 0.15, // Subtle bump for texture
+        noiseScale: 20.0, // Texture scale
+        triplanar: true, // Avoid UV stretching on large plane
+        ...options
+    });
+
+    // 2. Vertex Displacement (Audio Reactive Breathing)
+    // We want the ground to heave slowly with the bass to feel alive.
+    const displacementLogic = Fn(([pos]: any) => {
+        // Large, slow noise for "breathing" terrain
+        // Scale down position for large features (world scale is 400x400)
+        const noisePos = pos.mul(0.02).add(time.mul(0.2));
+        const breathe = mx_noise_float(noisePos).mul(2.0); // -1 to 1 approx
+
+        // Audio influence: Bass makes the ground swell
+        // Use a smoothed pulse, scaled for visibility but not nausea
+        const pulse = uAudioLow.mul(1.5);
+
+        // Displacement is up (Y) - modulated by breathe pattern
+        return breathe.mul(pulse);
+    });
+
+    const currentPos = material.positionNode || positionLocal;
+    // Use positionWorld for consistent noise across chunks if we had chunks
+    // For a single large plane, it works fine too.
+    const dispY = displacementLogic(positionWorld);
+
+    // Apply displacement to Y (Height)
+    material.positionNode = vec3(currentPos.x, currentPos.y.add(dispY), currentPos.z);
+
+    // 3. Emissive "Magic Dust" (Audio Reactive Sparkles)
+    // High frequency audio triggers sparkles on the ground, visualizing the melody.
+    const sparkleLogic = Fn(() => {
+        // High frequency noise for dust grains
+        const scale = positionWorld.mul(0.8);
+        const t = time.mul(0.5);
+        const noiseVal = mx_noise_float(scale.add(t));
+
+        // Threshold for sparse sparkles (only top 40% of noise peaks)
+        const mask = smoothstep(0.6, 1.0, noiseVal);
+
+        // Audio drive (Highs) - Boost intensity on cymbals/melody
+        const intensity = uAudioHigh.mul(2.0);
+
+        // Color: Gold/Cyan dust mix based on noise
+        // Gold (1.0, 0.8, 0.4) mixed with Cyan (0.0, 1.0, 1.0)
+        const dustColor = mix(vec3(1.0, 0.8, 0.4), vec3(0.0, 1.0, 1.0), noiseVal);
+
+        return dustColor.mul(mask).mul(intensity);
+    });
+
+    // 4. Rim Light for definition (Subtle edge glow)
+    const rim = createRimLight(color(0x444444), float(0.2), float(4.0), normalLocal);
+
+    // Combine emissive sources
+    material.emissiveNode = sparkleLogic().add(rim);
+
+    material.userData.type = 'terrain';
+    return material;
+}

--- a/src/world/generation.ts
+++ b/src/world/generation.ts
@@ -15,7 +15,8 @@ import {
     createRetriggerMushroom,
     createIsland, // Added
     createCaveEntrance,
-    createNeonPollen // Added
+    createNeonPollen, // Added
+    createTerrainMaterial // Added
 } from '../foliage/index.ts';
 import { generateCloudLayer } from '../foliage/procedural-sky.ts';
 import { validateFoliageMaterials } from '../foliage/common.ts';
@@ -161,14 +162,14 @@ export function initWorld(scene: THREE.Scene, weatherSystem: WeatherSystem, load
     }
 
     groundGeo.computeVertexNormals();
-    const groundMat = new THREE.MeshPhysicalMaterial({
-        color: CONFIG.colors.ground,
-        roughness: 0.4,
-        metalness: 0.0,
-        clearcoat: 0.3,
-        clearcoatRoughness: 0.6,
-        flatShading: false,
+
+    // Replaced MeshPhysicalMaterial with Audio-Reactive TSL Material
+    const groundMat = createTerrainMaterial(CONFIG.colors.ground, {
+        roughness: 0.9,
+        bumpStrength: 0.15,
+        noiseScale: 20.0
     });
+
     const ground = new THREE.Mesh(groundGeo, groundMat);
     ground.rotation.x = -Math.PI / 2;
     ground.receiveShadow = true;


### PR DESCRIPTION
Implemented Audio-Reactive Terrain using Three.js TSL `MeshStandardNodeMaterial`. The terrain now features a "breathing" effect where vertices displace vertically based on low-frequency audio energy (Bass) and a coherent noise function. Additionally, high-frequency audio (Treble) triggers emissive "magic dust" sparkles on the surface. This replaces the static `MeshPhysicalMaterial` previously used for the ground. The implementation leverages shared TSL uniforms (`uAudioLow`, `uAudioHigh`) for synchronization with other audio-reactive elements.

---
*PR created automatically by Jules for task [7129879964116305447](https://jules.google.com/task/7129879964116305447) started by @ford442*