### PR TITLE
Add Remove Track Button to Playlist

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -67,3 +67,7 @@
 ## 2026-08-15 - Live Region Context in Pause Menus
 **Learning:** Players often check the pause menu to see "What is playing?", but audio status (like the current track) is typically hidden in transient toasts or separate menus. This disconnects the audio experience from the game state.
 **Action:** When appropriate, elevate critical "ambient" information (like the current music track) to a persistent spot in the Pause Menu. Ensure this element is accessible via `aria-live` regions but only populated when relevant to avoid clutter.
+
+## 2026-08-20 - Focus Management in Dynamic Lists
+**Learning:** When removing an item from a list (like a playlist track) that currently contains the active focus, the browser resets focus to the `body` or a parent, causing keyboard users to lose their place.
+**Action:** Explicitly implementing a "Focus Recovery" strategy is critical for destructive list operations. After removal, programmatically move focus to the nearest logical sibling (next or previous item) or the list container itself to maintain navigation flow.

--- a/src/audio/audio-system.ts
+++ b/src/audio/audio-system.ts
@@ -576,6 +576,44 @@ export class AudioSystem {
             this.playNext(index);
         }
     }
+
+    removeTrack(index: number): void {
+        if (index < 0 || index >= this.playlist.length) return;
+
+        console.log(`[AudioSystem] Removing track ${index}: ${this.playlist[index].name}`);
+
+        const isCurrent = (index === this.currentIndex);
+
+        if (isCurrent) {
+            this.stop(false); // Clean stop
+        }
+
+        // Remove from array
+        this.playlist.splice(index, 1);
+
+        // Adjust index
+        if (this.playlist.length === 0) {
+            this.currentIndex = -1;
+        } else {
+            if (isCurrent) {
+                // Determine new index (wrap if needed, though behavior is usually "play next")
+                let newIndex = index;
+                if (newIndex >= this.playlist.length) {
+                    newIndex = 0; // Loop to start
+                }
+                // Play the track at the new/same index
+                this.playNext(newIndex);
+            } else if (index < this.currentIndex) {
+                // Removed a track before current, shift index down
+                this.currentIndex--;
+            }
+            // If removed after, current index stays same
+        }
+
+        if (this.onPlaylistUpdate) {
+            this.onPlaylistUpdate(this.playlist);
+        }
+    }
     
     getPlaylist(): File[] {
         return this.playlist;

--- a/src/core/input.ts
+++ b/src/core/input.ts
@@ -181,7 +181,39 @@ export function initInput(
                 });
             };
 
+            // Remove Button (UX Improvement)
+            const removeBtn = document.createElement('button');
+            removeBtn.className = 'playlist-remove-btn';
+            removeBtn.innerHTML = '×';
+            removeBtn.title = `Remove ${file.name}`;
+            removeBtn.setAttribute('aria-label', `Remove ${file.name} from playlist`);
+
+            removeBtn.onclick = (e) => {
+                e.stopPropagation();
+                const wasActive = document.activeElement === removeBtn;
+                audioSystem.removeTrack(index);
+                renderPlaylist();
+
+                // UX: Restore Focus to an appropriate element
+                requestAnimationFrame(() => {
+                    const removeBtns = playlistList.querySelectorAll('.playlist-remove-btn');
+                    const playBtns = playlistList.querySelectorAll('.playlist-btn');
+
+                    // Try focusing the next remove button (at same index, since list shifted)
+                    if (removeBtns[index]) {
+                        (removeBtns[index] as HTMLElement).focus();
+                    } else if (removeBtns[index - 1]) {
+                        // Or the previous one
+                        (removeBtns[index - 1] as HTMLElement).focus();
+                    } else if (playBtns[0]) {
+                        // Or the first song
+                        (playBtns[0] as HTMLElement).focus();
+                    }
+                });
+            };
+
             li.appendChild(btn);
+            li.appendChild(removeBtn);
             playlistList.appendChild(li);
         });
         

--- a/style.css
+++ b/style.css
@@ -132,6 +132,47 @@
     min-width: 0;
 }
 
+/* 🎨 Palette: Playlist Remove Button */
+.playlist-remove-btn {
+    background: none;
+    border: none;
+    color: #FFB6C1;
+    font-size: 1.5rem;
+    cursor: pointer;
+    padding: 0 12px;
+    margin-left: 4px;
+    transition: color 0.2s, transform 0.1s;
+    font-family: 'Fredoka One', cursive, sans-serif;
+    line-height: 1;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+}
+
+.playlist-remove-btn:hover {
+    color: #FF5252;
+    background: #FFF0F5;
+    transform: scale(1.1);
+}
+
+.playlist-remove-btn:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px #ffffff, 0 0 0 6px #FF4081;
+    z-index: 5;
+}
+
+/* 🎨 Palette: Active Item Remove Style */
+.playlist-item.active .playlist-remove-btn {
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.playlist-item.active .playlist-remove-btn:hover {
+    color: #fff;
+    background: rgba(255, 255, 255, 0.2);
+}
+
 /* 🎨 Palette: Ability HUD */
 #ability-hud {
     position: fixed;


### PR DESCRIPTION
Added a "Remove" button (×) to each playlist item, allowing users to delete tracks.
- **Backend:** Implemented `AudioSystem.removeTrack(index)` to handle array splicing, playback stopping (if current track), and index adjustment.
- **Frontend:** Updated playlist rendering to include the button.
- **Accessibility:** Implemented focus management so that after deleting an item, focus automatically moves to the next or previous item, preserving keyboard navigation flow. Added ARIA labels.
- **Styling:** Added consistent hover/focus styles for the new button.

---
*PR created automatically by Jules for task [8477251708956317392](https://jules.google.com/task/8477251708956317392) started by @ford442*