### PR TITLE
⚡ Bolt: GPU Offloading & Closure GC Removal

### DIFF
--- a/src/foliage/animation.ts
+++ b/src/foliage/animation.ts
@@ -403,7 +403,13 @@ export function animateFoliage(foliageObject: FoliageObject, time: number, audio
         foliageObject.position.y = y + Math.sin(time * 2 + offset) * 0.1;
     }
     else if (type === 'rain') {
-        const rainChild = foliageObject.children.find(c => c.type === 'Points') as THREE.Points;
+        let rainChild: THREE.Points | null = null;
+        for (let i = 0; i < foliageObject.children.length; i++) {
+            if (foliageObject.children[i].type === 'Points') {
+                rainChild = foliageObject.children[i] as THREE.Points;
+                break;
+            }
+        }
         if (rainChild && rainChild.geometry && rainChild.geometry.attributes.position) {
             const positions = rainChild.geometry.attributes.position.array as Float32Array;
             for (let i = 0; i < positions.length; i += 3) {
@@ -448,28 +454,9 @@ export function animateFoliage(foliageObject: FoliageObject, time: number, audio
         if (plume) {
             plume.visible = eruptionStrength > 0.05;
 
-            if (plume.visible && plume.geometry.attributes.position) {
-                const positions = plume.geometry.attributes.position.array as Float32Array;
-                const velocities = plume.geometry.attributes.velocity.array as Float32Array;
-                const currentMaxH = maxHeight * eruptionStrength;
-
-                for (let i = 0; i < positions.length / 3; i++) {
-                    const idx = i * 3;
-                    const vel = velocities[i];
-
-                    positions[idx + 1] += vel * eruptionStrength * 0.3;
-
-                    const heightRatio = positions[idx + 1] / currentMaxH;
-                    positions[idx] += (Math.random() - 0.5) * 0.02 * heightRatio;
-                    positions[idx + 2] += (Math.random() - 0.5) * 0.02 * heightRatio;
-
-                    if (positions[idx + 1] > currentMaxH || positions[idx + 1] < 0) {
-                        positions[idx] = (Math.random() - 0.5) * 0.2;
-                        positions[idx + 1] = 0;
-                        positions[idx + 2] = (Math.random() - 0.5) * 0.2;
-                    }
-                }
-                plume.geometry.attributes.position.needsUpdate = true;
+            // ⚡ OPTIMIZATION: Plume position logic replaced by TSL in environment.ts
+            if (foliageObject.userData.uEruptionStrength) {
+                foliageObject.userData.uEruptionStrength.value = eruptionStrength;
             }
 
             if ((plume.material as any).opacity !== undefined) {

--- a/src/foliage/environment.ts
+++ b/src/foliage/environment.ts
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { MeshStandardNodeMaterial, PointsNodeMaterial } from 'three/webgpu';
-import { time, vec3, positionLocal, length, sin, cos, color as tslColor } from 'three/tsl';
-import { registerReactiveMaterial, attachReactivity, CandyPresets } from './common.ts';
+import { time, vec3, positionLocal, length, sin, cos, color as tslColor, attribute, float, uniform } from 'three/tsl';
+import { registerReactiveMaterial, attachReactivity, CandyPresets, uTime } from './common.ts';
 
 export interface FloatingOrbOptions {
     color?: number;
@@ -115,6 +115,8 @@ export function createKickDrumGeyser(options: KickDrumGeyserOptions = {}) {
     plumeGeo.setAttribute('normal', new THREE.BufferAttribute(normals, 3));
     plumeGeo.setAttribute('velocity', new THREE.BufferAttribute(velocities, 1));
 
+    const uEruptionStrength = uniform(float(0.0));
+
     const plumeMat = new PointsNodeMaterial({
         color: color,
         size: 0.15,
@@ -123,6 +125,25 @@ export function createKickDrumGeyser(options: KickDrumGeyserOptions = {}) {
         blending: THREE.AdditiveBlending,
         depthWrite: false
     });
+
+    // ⚡ OPTIMIZATION: TSL Node for Plume Animation
+    const velocityAttr = attribute('velocity', 'float');
+    const yOffset = uTime.mul(velocityAttr).mul(5.0).mod(float(maxHeight));
+
+    // Add jitter
+    const jitterX = sin(uTime.mul(10.0).add(velocityAttr.mul(100.0))).mul(0.1);
+    const jitterZ = cos(uTime.mul(12.0).add(velocityAttr.mul(100.0))).mul(0.1);
+
+    const activeMaxH = float(maxHeight).mul(uEruptionStrength);
+
+    // Scale height by eruption strength, and loop within active height
+    const finalY = yOffset.mul(uEruptionStrength);
+
+    plumeMat.positionNode = vec3(
+        positionLocal.x.add(jitterX).mul(uEruptionStrength),
+        finalY,
+        positionLocal.z.add(jitterZ).mul(uEruptionStrength)
+    );
 
     const plume = new THREE.Points(plumeGeo, plumeMat);
     plume.visible = false;
@@ -140,6 +161,7 @@ export function createKickDrumGeyser(options: KickDrumGeyserOptions = {}) {
     group.userData.coreMaterial = coreMat;
     group.userData.maxHeight = maxHeight;
     group.userData.eruptionStrength = 0;
+    group.userData.uEruptionStrength = uEruptionStrength;
 
     return attachReactivity(group);
 }

--- a/src/foliage/waterfalls.ts
+++ b/src/foliage/waterfalls.ts
@@ -128,7 +128,8 @@ export function createWaterfall(startPos: THREE.Vector3, endPos: THREE.Vector3, 
         }
 
         // Animate splashes
-        group.userData.splashes.forEach((s: THREE.Object3D) => {
+        for (let i = 0; i < group.userData.splashes.length; i++) {
+            const s = group.userData.splashes[i];
             s.position.addScaledVector(s.userData.velocity, delta);
             s.userData.velocity.y -= 20.0 * delta; // Heavy gravity
 
@@ -145,7 +146,7 @@ export function createWaterfall(startPos: THREE.Vector3, endPos: THREE.Vector3, 
                      s.userData.velocity.set((Math.random()-0.5)*2, Math.random()*8 + 2, (Math.random()-0.5)*2);
                 }
             }
-        });
+        }
     };
 
     return group;

--- a/src/systems/physics.core.ts
+++ b/src/systems/physics.core.ts
@@ -240,7 +240,8 @@ export function calculateWaterLevel(
     let waterLevel = -100;
 
     // Check cave water gates (using scratch vector to avoid GC)
-    foliageCaves.forEach(cave => {
+    for (let i = 0; i < foliageCaves.length; i++) {
+        const cave = foliageCaves[i];
         if (cave.userData.isBlocked) {
             const gatePos = _scratchGatePos
                 .copy(cave.userData.gatePosition)
@@ -249,7 +250,7 @@ export function calculateWaterLevel(
                 waterLevel = gatePos.y + 5; // Water exists here
             }
         }
-    });
+    }
 
     // Check standard Lake Water Level (Y=1.5) if inside lake bounds
     // BUT NOT if on the island (island is above water)

--- a/src/systems/physics.ts
+++ b/src/systems/physics.ts
@@ -548,9 +548,10 @@ function updateDefaultState(delta: number, camera: THREE.Camera, controls: any, 
         cppPhysicsInitialized = true;
     }
 
-    vineSwings.forEach(v => {
+    for (let i = 0; i < vineSwings.length; i++) {
+        const v = vineSwings[i];
         if (v !== activeVineSwing) v.update(player as any, delta, null);
-    });
+    }
 
     if (Date.now() - lastVineDetachTime > 500) {
         checkVineAttachment(camera);


### PR DESCRIPTION
Replaced JS `Array.forEach` usages in hot loops (like physics and waterfalls update) with classic `for` loops to prevent repeated closure allocation and GC spikes. Moved the `geyserErupt` CPU particle animation loop entirely to the GPU via a custom Three.js TSL Node Material, substantially relieving the CPU of per-vertex manipulation load every frame.

---
*PR created automatically by Jules for task [4167716036677344820](https://jules.google.com/task/4167716036677344820) started by @ford442*