### PR TITLE
⚡ Bolt: Optimize getPlayerState allocations

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -45,6 +45,10 @@ const _scratchBaseFog = new THREE.Color();
 const _scratchSunVector = new THREE.Vector3();
 const _scratchAuroraColor = new THREE.Color();
 
+// ⚡ OPTIMIZATION: Scratch vectors to prevent GC spikes on mouse click
+const _scratchClickDir = new THREE.Vector3();
+const _scratchClickOrigin = new THREE.Vector3();
+
 const _interactionLists: (any[] | null)[] = [null, null, null]; // Reusable array for interaction lists
 
 // --- Initialization Pipeline ---
@@ -262,11 +266,10 @@ window.addEventListener('mousedown', (e) => {
 
             // If interaction didn't handle it, fire rainbow blaster
             if (!handled) {
-                const dir = new THREE.Vector3();
-                camera.getWorldDirection(dir);
-                const origin = camera.position.clone().add(dir.clone().multiplyScalar(1.0));
-                origin.y -= 0.2; // Lower slightly
-                fireRainbow(scene, origin, dir);
+                camera.getWorldDirection(_scratchClickDir);
+                _scratchClickOrigin.copy(camera.position).addScaledVector(_scratchClickDir, 1.0);
+                _scratchClickOrigin.y -= 0.2; // Lower slightly
+                fireRainbow(scene, _scratchClickOrigin, _scratchClickDir);
             }
         }
     }

--- a/src/systems/physics.ts
+++ b/src/systems/physics.ts
@@ -124,6 +124,8 @@ const _scratchCamRight = new THREE.Vector3();
 const _scratchMoveVec = new THREE.Vector3();
 const _scratchTargetVel = new THREE.Vector3();
 const _scratchUp = new THREE.Vector3(0, 1, 0);
+// ⚡ OPTIMIZATION: Shared scratch object for WASM state reads to avoid GC spikes
+const _scratchPlayerState = { x: 0, y: 0, z: 0, vx: 0, vy: 0, vz: 0 };
 
 // C++ Physics Init Flag
 let cppPhysicsInitialized = false;
@@ -611,9 +613,9 @@ function updateDefaultState(delta: number, camera: THREE.Camera, controls: any, 
 
     if (onGround >= 0) {
         // C++ Success
-        const newState = getPlayerState();
-        player.position.set(newState.x, newState.y, newState.z);
-        player.velocity.set(newState.vx, newState.vy, newState.vz);
+        getPlayerState(_scratchPlayerState);
+        player.position.set(_scratchPlayerState.x, _scratchPlayerState.y, _scratchPlayerState.z);
+        player.velocity.set(_scratchPlayerState.vx, _scratchPlayerState.vy, _scratchPlayerState.vz);
 
         // Reset jump key if we successfully jumped (velocity.y > 0)
         // But only if we were grounded before (normal jump)

--- a/src/utils/wasm-loader.d.ts
+++ b/src/utils/wasm-loader.d.ts
@@ -81,7 +81,7 @@ export function updatePhysicsCPP(delta: number, inputX: number, inputZ: number, 
 export function initPhysics(x: number, y: number, z: number): void;
 export function addObstacle(type: number, x: number, y: number, z: number, r: number, h: number, p1: number, p2: number, p3: boolean): void;
 export function setPlayerState(x: number, y: number, z: number, vx: number, vy: number, vz: number): void;
-export function getPlayerState(): { x: number, y: number, z: number, vx: number, vy: number, vz: number };
+export function getPlayerState(out?: { x: number, y: number, z: number, vx: number, vy: number, vz: number }): { x: number, y: number, z: number, vx: number, vy: number, vz: number };
 
 export function valueNoise2D(x: number, y: number): number;
 export function fbm(x: number, y: number, octaves?: number): number;

--- a/src/utils/wasm-loader.js
+++ b/src/utils/wasm-loader.js
@@ -1131,14 +1131,15 @@ export function setPlayerState(x, y, z, vx, vy, vz) {
     if (f) f(x, y, z, vx, vy, vz);
 }
 
-export function getPlayerState() {
-    const x = getNativeFunc('getPlayerX')();
-    const y = getNativeFunc('getPlayerY')();
-    const z = getNativeFunc('getPlayerZ')();
-    const vx = getNativeFunc('getPlayerVX')();
-    const vy = getNativeFunc('getPlayerVY')();
-    const vz = getNativeFunc('getPlayerVZ')();
-    return { x, y, z, vx, vy, vz };
+// ⚡ OPTIMIZATION: Pass a scratch object to prevent allocating `{ x, y, z, vx, vy, vz }` every frame
+export function getPlayerState(out = {}) {
+    out.x = getNativeFunc('getPlayerX')();
+    out.y = getNativeFunc('getPlayerY')();
+    out.z = getNativeFunc('getPlayerZ')();
+    out.vx = getNativeFunc('getPlayerVX')();
+    out.vy = getNativeFunc('getPlayerVY')();
+    out.vz = getNativeFunc('getPlayerVZ')();
+    return out;
 }
 
 export function valueNoise2D(x, y) {


### PR DESCRIPTION
Bottleneck: "Was creating a new {x,y,z,vx,vy,vz} object every frame in getPlayerState() and 3 new Vector3s on every mouse click."
 
Fix: "Implemented a shared scratch object `_scratchPlayerState` for WASM physics updates, modified `getPlayerState(out)` to accept it, and implemented shared scratch vectors for click logic."
 
Impact: "Eliminated continuous per-frame object allocations in the hot loop, reducing GC pressure significantly and ensuring stable FPS."

---
*PR created automatically by Jules for task [12093258529075821639](https://jules.google.com/task/12093258529075821639) started by @ford442*