### PR TITLE
feat: Implement interactive Instrument Shrine puzzle mechanics

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -10,12 +10,14 @@
 
 ## Next Steps
 
-1. **Instrument Shrine Puzzle Mechanics**: Implement interactive puzzles where shrine patterns must be matched to bassline instrument IDs.
+1. **Silence Spirits Gameplay Mechanics**: Implement the 5s invisibility buff granted by communing with Silence Spirits during breakdowns.
 
 ---
 
 ## Recent Progress
 - **Accomplished:**
+  - **Instrument Shrine Puzzle Mechanics**: **Status: Implemented ✅**
+    - *Implementation Details:* Updated `src/foliage/instrument.ts` to use TSL uniforms for dynamic pattern generation. Shrines can now be cycled via interaction to "tune" them to different patterns. The logic in `src/foliage/animation.ts` specifically verifies if the tuned ID matches the active bassline instrument (channel 1), fulfilling the puzzle mechanic.
   - **Rare Flora Discovery Visuals**: **Status: Implemented ✅**
     - *Implementation Details:* Added `src/foliage/discovery-effect.ts` to render a TSL-driven magical particle burst (expanding, color-shifting, twinkling) upon rare plant discovery. Hooked into `checkPlayerDiscovery` and instantiated as a deferred visual in `src/main.ts`.
   - **Post-Processing Pipeline (Bloom & Color Correction)**: **Status: Implemented ✅**

--- a/src/foliage/animation.ts
+++ b/src/foliage/animation.ts
@@ -581,14 +581,12 @@ export function animateFoliage(foliageObject: FoliageObject, time: number, audio
 
         // Check audio channels for matching instrument
         if (audioData && audioData.channelData) {
-            for (const ch of audioData.channelData) {
-                // Check if instrument matches and is playing
-                // Note: ch.instrument is 1-based usually in MODs, but our ID is likely 0-based or direct match
-                // We'll assume direct match for now.
-                if (ch.instrument === targetID && (ch.volume || 0) > 0.1) {
-                    isActive = true;
-                    matchedVolume = Math.max(matchedVolume, ch.volume || 0);
-                }
+            // Bassline is typically on channel 1 in our 4-channel MODs (0=Drums, 1=Bass, 2=Melody, 3=Chords)
+            // We check channel 1 specifically to match the "bassline instrument IDs" puzzle requirement.
+            const bassChannel = audioData.channelData[1];
+            if (bassChannel && bassChannel.instrument === targetID && (bassChannel.volume || 0) > 0.05) {
+                isActive = true;
+                matchedVolume = bassChannel.volume || 0;
             }
         }
 
@@ -600,7 +598,8 @@ export function animateFoliage(foliageObject: FoliageObject, time: number, audio
             if (isActive) {
                 foliageObject.userData.interactionText = "Activate Shrine";
             } else {
-                foliageObject.userData.interactionText = `Locked (Need Inst ${targetID})`;
+                // Reset text if it was previously active but the bassline stopped
+                foliageObject.userData.interactionText = `Tune Shrine (Current: ${targetID})`;
             }
         } else {
              foliageObject.userData.interactionText = "Shrine Activated";

--- a/src/foliage/instrument.ts
+++ b/src/foliage/instrument.ts
@@ -6,7 +6,7 @@ import {
 } from './common.ts';
 import {
     color, float, mix, uv, sin, cos,
-    vec3, mx_noise_float
+    vec3, mx_noise_float, uniform
 } from 'three/tsl';
 import { makeInteractive } from '../utils/interaction-utils.ts';
 import { unlockSystem } from '../systems/unlocks.ts';
@@ -38,32 +38,31 @@ export function createInstrumentShrine(options: InstrumentShrineOptions = {}): T
     });
 
     // Custom TSL override for Color based on Instrument ID
-    // We create a procedural pattern
-    const id = float(instrumentID);
+    // We use uniforms so the puzzle pattern can be cycled on interact
+    const uInstrumentID = uniform(instrumentID);
 
     // Pattern Logic:
     // Generate a pattern based on UV and ID
     const pUV = uv().mul(10.0);
 
     // Different math for different ID ranges for variety
-    const patternA = sin(pUV.x.add(id)).mul(cos(pUV.y.add(id))); // Grid-like
-    const patternB = mx_noise_float(vec3(pUV.x, pUV.y, id)); // Noise-like
+    const patternA = sin(pUV.x.add(uInstrumentID)).mul(cos(pUV.y.add(uInstrumentID))); // Grid-like
+    const patternB = mx_noise_float(vec3(pUV.x, pUV.y, uInstrumentID)); // Noise-like
 
     // Mix based on ID modulo
     // We can't use modulo easily in TSL without some work, so let's just use sin(id) to mix
-    const mixFactor = sin(id.mul(0.5)).add(1.0).mul(0.5); // 0 to 1
+    const mixFactor = sin(uInstrumentID.mul(0.5)).add(1.0).mul(0.5); // 0 to 1
 
     const pattern = mix(patternA, patternB, mixFactor);
 
     // Colorize
-    // Map ID to Hue (Calculate in JS since ID is constant per instance)
+    // Map ID to Hue and pass via Uniform to allow dynamic updating
     const jsHue = (instrumentID * 0.1) % 1.0;
     const jsColor = new THREE.Color().setHSL(jsHue, 1.0, 0.5);
-
-    const baseCol = color(jsColor);
+    const uBaseColor = uniform(jsColor);
 
     // Apply pattern to emissive
-    shrineMat.emissiveNode = baseCol.mul(pattern.add(0.5).mul(2.0)); // Glow
+    shrineMat.emissiveNode = uBaseColor.mul(pattern.add(0.5).mul(2.0)); // Glow
 
     // Geometry: Monolith
     const geo = new THREE.BoxGeometry(1, 3, 1);
@@ -101,7 +100,12 @@ export function createInstrumentShrine(options: InstrumentShrineOptions = {}): T
     // Puzzle State
     group.userData.isActive = false; // Is matching instrument playing?
     group.userData.isSolved = false; // Has player activated it?
-    group.userData.interactionText = `Locked (Need Inst ${instrumentID})`; // Shortened for UI fit
+    group.userData.interactionText = `Tune Shrine (Current: ${instrumentID})`; // Shortened for UI fit
+
+    // Store uniforms on userData so they can be updated
+    group.userData.uInstrumentID = uInstrumentID;
+    group.userData.uBaseColor = uBaseColor;
+    group.userData.jsColor = jsColor;
 
     // Reactivity
     attachReactivity(group, { minLight: 0.0, maxLight: 1.0 });
@@ -127,7 +131,7 @@ export function createInstrumentShrine(options: InstrumentShrineOptions = {}): T
 
             // Visual feedback
             _scratchPos.copy(group.position).y += 3.0;
-            spawnImpact(_scratchPos, 'muzzle', jsColor, _scratchUp);
+            spawnImpact(_scratchPos, 'muzzle', group.userData.jsColor, _scratchUp);
 
             // Audio feedback
             if ((window as any).AudioSystem && (window as any).AudioSystem.playSound) {
@@ -142,9 +146,19 @@ export function createInstrumentShrine(options: InstrumentShrineOptions = {}): T
             orbMat.emissiveIntensity = 2.0;
 
         } else {
-             // Locked feedback
-             if ((window as any).AudioSystem && (window as any).AudioSystem.playSound) {
-                 (window as any).AudioSystem.playSound('click', { position: group.position, pitch: 0.5, volume: 0.5 });
+            // Cycle the puzzle ID!
+            group.userData.instrumentID = (group.userData.instrumentID + 1) % 16;
+
+            // Update Uniforms
+            group.userData.uInstrumentID.value = group.userData.instrumentID;
+            group.userData.jsColor.setHSL((group.userData.instrumentID * 0.1) % 1.0, 1.0, 0.5);
+
+            // Interaction Text Update
+            group.userData.interactionText = `Tune Shrine (Current: ${group.userData.instrumentID})`;
+
+            // Audio feedback for cycling
+            if ((window as any).AudioSystem && (window as any).AudioSystem.playSound) {
+                 (window as any).AudioSystem.playSound('click', { position: group.position, pitch: 1.0 + (group.userData.instrumentID * 0.05), volume: 0.5 });
             }
         }
 


### PR DESCRIPTION
Implemented the "Instrument Shrine Puzzle Mechanics" where shrine patterns must be matched to bassline instrument IDs. The user can now interact with the shrines to tune them to different IDs, and the visual pattern cycles dynamically. Once the tuned pattern matches the currently playing bassline instrument, it becomes active and can be unlocked for a reward.

---
*PR created automatically by Jules for task [7334950516070677931](https://jules.google.com/task/7334950516070677931) started by @ford442*