### PR TITLE
🎨 Palette: Add CTA to Analytics Debug Empty State

### DIFF
--- a/src/ui/analytics-debug.ts
+++ b/src/ui/analytics-debug.ts
@@ -484,7 +484,7 @@ class AnalyticsDebugOverlay {
     eventsSection.innerHTML = `
       <div class="analytics-debug-section-title">Recent Events</div>
       <div class="analytics-debug-events" id="analytics-events-log">
-        <div class="analytics-debug-empty">No events yet...</div>
+        <div class="analytics-debug-empty">No events yet...<br><br><button class="analytics-debug-button" id="analytics-test-event-btn"><span aria-hidden="true">🔔</span> Send Test Event</button></div>
       </div>
     `;
     content.appendChild(eventsSection);
@@ -619,6 +619,17 @@ class AnalyticsDebugOverlay {
           analytics.clear();
           this.eventLog = [];
           this.refresh();
+        }
+      });
+    }
+
+    // Event delegation for dynamically added buttons (like the CTA in empty state)
+    if (this.elements?.eventsSection) {
+      this.elements.eventsSection.addEventListener('click', (e) => {
+        const target = e.target as HTMLElement;
+        const button = target.closest('#analytics-test-event-btn');
+        if (button) {
+          trackEvent('test_event', { source: 'debug_ui' });
         }
       });
     }
@@ -873,7 +884,7 @@ class AnalyticsDebugOverlay {
     
     if (this.eventLog.length === 0) {
       container.innerHTML = `
-        <div class="analytics-debug-empty">No events yet...</div>
+        <div class="analytics-debug-empty">No events yet...<br><br><button class="analytics-debug-button" id="analytics-test-event-btn"><span aria-hidden="true">🔔</span> Send Test Event</button></div>
       `;
       return;
     }


### PR DESCRIPTION
💡 What: Added a clear Call-To-Action (CTA) button ("Send Test Event") to the empty state of the Analytics Debug panel. Clicking the button logs a test event to populate the view.

🎯 Why: As noted in Palette's journal, "Empty states without a clear next action lead to user confusion." The previous "No events yet..." message left users stranded with an empty screen and no obvious way to generate data. The new CTA makes the debug panel immediately interactive.

📸 Before/After: (See Playwright Verification Videos)
Before: A static gray text block saying "No events yet..."
After: The text accompanied by a styled `.analytics-debug-button` that users can click to trigger `trackEvent('test_event')`.

♿ Accessibility:
- The new CTA uses a native `<button>` element ensuring keyboard focusability.
- The decorative bell emoji is correctly marked with `aria-hidden="true"` to prevent screen reader noise.
- The button uses existing `.analytics-debug-button` classes, ensuring consistent contrast and focus-visible states.

---
*PR created automatically by Jules for task [1845681138009878317](https://jules.google.com/task/1845681138009878317) started by @ford442*