### PR TITLE
🎨 Palette: Add ARIA label to Discovery Log close button

### DIFF
--- a/src/systems/discovery.ts
+++ b/src/systems/discovery.ts
@@ -134,6 +134,7 @@ class DiscoverySystem {
 
         const closeBtn = document.createElement('button');
         closeBtn.innerText = '✕';
+        closeBtn.setAttribute('aria-label', 'Close discovery log');
         closeBtn.style.position = 'absolute';
         closeBtn.style.top = '15px';
         closeBtn.style.right = '20px';


### PR DESCRIPTION
💡 What: Added an `aria-label="Close discovery log"` to the `✕` button inside the Discovery Log overlay.
🎯 Why: The close button only had the text content "✕", which screen readers would read as "times" or similar, making it confusing for non-visual users to understand its purpose. This adds context and improves accessibility.
♿ Accessibility: Ensures WCAG compliance by properly labeling icon-only interactive elements.

---
*PR created automatically by Jules for task [5281455987180456873](https://jules.google.com/task/5281455987180456873) started by @ford442*