### PR TITLE
⚡ Bolt: Zero-Allocation LOD Updates

### DIFF
--- a/BOLT'S JOURNAL - PERFORMANCE LEARNINGS.md
+++ b/BOLT'S JOURNAL - PERFORMANCE LEARNINGS.md
@@ -7,3 +7,6 @@
 ## 2024-05-XX - Zero-Allocation Matrix Batching
 **Learning:** Calling `Object3D.updateMatrix()` and `mesh.setMatrixAt()` inside update loops or batch generation code causes significant CPU overhead and garbage collection (GC) spikes because they instantiate intermediate objects and allocate arrays under the hood.
 **Action:** For all `InstancedMesh` batchers, construct `Matrix4` locally using zero-allocation scratch variables (`_scratchMatrix.compose(pos, quat, scale)`) and copy the result directly to the underlying buffer memory using `_scratchMatrix.toArray(mesh.instanceMatrix.array, index * 16)`. Always follow up with `mesh.instanceMatrix.needsUpdate = true`.
+## 2026-04-12 - Zero-Allocation LOD Map Updates
+**Learning:** Instantiating Maps and Arrays on every frame for batching updates (like `new Map()` and `[].push()`) creates significant garbage collection spikes, violating Bolt's Zero-Allocation standard.
+**Action:** Use pre-allocated nested Maps as class properties (e.g., `this._lodUpdates`) and track active elements via a `count` variable instead of pushing to or resetting arrays, passing this count to downstream buffer updates to ensure stale data is ignored.

--- a/src/core/main.ts
+++ b/src/core/main.ts
@@ -54,7 +54,8 @@ if (oldOverlay) {
 }
 
 // --- Enable Startup Profiler ---
-const loadingScreen = initLoadingScreen({ debug: false, theme: 'candy' });
+// The symbol "loadingScreen" was declared twice, causing a TS error. The second one is commented out.
+// const loadingScreen = initLoadingScreen({ debug: false, theme: 'candy' });
 
 enableStartupProfiler({
     slowPhaseThreshold: 100,

--- a/src/foliage/lod.ts
+++ b/src/foliage/lod.ts
@@ -335,6 +335,8 @@ export class FoliageLODManager {
 
     // Instance counts per LOD level per geometry type
     private lodCounts: Map<string, Map<LODLevel, number>> = new Map();
+    // ⚡ OPTIMIZATION: Pre-allocated buffers for LOD updates to prevent GC spikes
+    private _lodUpdates: Map<string, Map<LODLevel, { indices: number[]; matrices: THREE.Matrix4[]; colors: THREE.Color[]; count: number }>> = new Map();
 
     // Temporary objects for calculations (to avoid GC)
     private _tempVec3 = new THREE.Vector3();
@@ -548,18 +550,27 @@ export class FoliageLODManager {
             }
         }
 
-        // Temporary storage for batch updates
-        const lodUpdates = new Map<string, Map<LODLevel, { indices: number[]; matrices: THREE.Matrix4[]; colors: THREE.Color[] }>>();
-
-        // Initialize update structure
+        // Initialize pre-allocated update structure if needed
         for (const geomType of this.lodMeshes.keys()) {
-            lodUpdates.set(geomType, new Map());
-            for (let lod = 0; lod < 3; lod++) {
-                lodUpdates.get(geomType)!.set(lod as LODLevel, {
-                    indices: [],
-                    matrices: [],
-                    colors: []
-                });
+            if (!this._lodUpdates.has(geomType)) {
+                this._lodUpdates.set(geomType, new Map());
+                for (let lod = 0; lod < 3; lod++) {
+                    this._lodUpdates.get(geomType)!.set(lod as LODLevel, {
+                        indices: [],
+                        matrices: [],
+                        colors: [],
+                        count: 0
+                    });
+                }
+            } else {
+                // Just reset counts to 0 instead of allocating new arrays
+                for (let lod = 0; lod < 3; lod++) {
+                    const updateData = this._lodUpdates.get(geomType)!.get(lod as LODLevel);
+                    if (updateData) {
+                        updateData.count = 0;
+                        // ⚡ OPTIMIZATION: We don't null out arrays or recreate them, just reset count
+                    }
+                }
             }
         }
 
@@ -576,28 +587,29 @@ export class FoliageLODManager {
                 continue;
             }
 
-            // Add to appropriate LOD update batch
-            const geomUpdates = lodUpdates.get(data.geometryType);
+            // Add to appropriate LOD update batch (using pre-allocated arrays)
+            const geomUpdates = this._lodUpdates.get(data.geometryType);
             if (geomUpdates) {
                 const lodUpdate = geomUpdates.get(newLOD);
                 if (lodUpdate) {
-                    lodUpdate.indices.push(id);
-                    lodUpdate.matrices.push(data.matrix);
-                    lodUpdate.colors.push(data.color);
+                    const idx = lodUpdate.count++;
+                    lodUpdate.indices[idx] = id;
+                    lodUpdate.matrices[idx] = data.matrix;
+                    lodUpdate.colors[idx] = data.color;
                 }
             }
         }
 
         // Apply updates to InstancedMeshes
-        for (const [geomType, geomUpdates] of lodUpdates) {
+        for (const [geomType, geomUpdates] of this._lodUpdates) {
             for (let lod = 0; lod < 3; lod++) {
                 const lodLevel = lod as LODLevel;
                 const update = geomUpdates.get(lodLevel);
                 const mesh = this.lodMeshes.get(geomType)?.get(lodLevel);
 
                 if (update && mesh) {
-                    this.updateInstancedMesh(mesh, update.matrices, update.colors);
-                    this.lodCounts.get(geomType)?.set(lodLevel, update.matrices.length);
+                    this.updateInstancedMesh(mesh, update.matrices, update.colors, update.count);
+                    this.lodCounts.get(geomType)?.set(lodLevel, update.count);
                 }
             }
         }
@@ -612,9 +624,10 @@ export class FoliageLODManager {
     private updateInstancedMesh(
         mesh: THREE.InstancedMesh,
         matrices: THREE.Matrix4[],
-        colors: THREE.Color[]
+        colors: THREE.Color[],
+        elementCount: number
     ): void {
-        const count = Math.min(matrices.length, mesh.instanceMatrix.count);
+        const count = Math.min(elementCount, mesh.instanceMatrix.count);
         mesh.count = count;
 
         for (let i = 0; i < count; i++) {


### PR DESCRIPTION
Bottleneck: The `FoliageLODManager.update` loop was allocating new nested Maps and Arrays on every frame (up to 60 times a second), causing severe Garbage Collection (GC) spikes and micro-stutters during gameplay.

Fix: Refactored `update` to use a pre-allocated class property `_lodUpdates`. Instead of creating new arrays and using `.push()`, the system now reuses existing buffers and tracks active elements using a lightweight `count` integer. This count is then safely passed to `updateInstancedMesh` to ensure stale data is ignored. Also resolved a TS duplicate declaration issue in `main.ts` that blocked compilation.

Impact: Completely eliminated per-frame map/array allocations in the Foliage LOD system, significantly reducing GC pressure and stabilizing frame rates.

---
*PR created automatically by Jules for task [13531465895860506443](https://jules.google.com/task/13531465895860506443) started by @ford442*