### PR TITLE
🎨 Palette: Add tooltip to disabled start button

### DIFF
--- a/index.html
+++ b/index.html
@@ -608,7 +608,7 @@
     <div id="nowPlayingContainer" class="now-playing-info" aria-live="polite" style="display: none;">
         <span class="music-note" aria-hidden="true">🎵</span> <span id="nowPlayingText"></span>
     </div>
-    <button id="startButton" class="cta-button" disabled aria-live="polite">
+    <button id="startButton" class="cta-button" disabled aria-live="polite" title="Please wait while game assets load...">
         <span class="spinner" aria-hidden="true"></span>Loading World... 🍭
     </button>
 </div>
@@ -681,7 +681,7 @@
         <div id="nowPlayingContainer" class="now-playing-info" aria-live="polite" style="display: none;">
             <span class="music-note" aria-hidden="true">🎵</span> <span id="nowPlayingText"></span>
         </div>
-        <button id="startButton" class="cta-button" disabled aria-live="polite">
+        <button id="startButton" class="cta-button" disabled aria-live="polite" title="Please wait while game assets load...">
             <span class="spinner" aria-hidden="true"></span>Loading World... 🍭
         </button>
 

--- a/src/core/main.ts
+++ b/src/core/main.ts
@@ -257,6 +257,7 @@ initWasm().then(async (wasmLoaded) => {
     const startButton = document.getElementById('startButton') as HTMLButtonElement | null;
     if (startButton) {
         startButton.disabled = false;
+        startButton.removeAttribute('title');
         startButton.innerHTML = 'Enter World <span aria-hidden="true">🍭</span> <span class="key-badge" aria-hidden="true">Enter</span>';
         startButton.focus();
 
@@ -265,6 +266,7 @@ initWasm().then(async (wasmLoaded) => {
 
             // UX: Show loading state immediately to prevent "freeze" feeling
             startButton.disabled = true;
+            startButton.setAttribute('title', 'Generating world...');
             startButton.innerHTML = '<span class="spinner" aria-hidden="true"></span>Generating... <span aria-hidden="true">🍭</span>';
 
             // Defer execution slightly to let the UI update
@@ -321,6 +323,7 @@ initWasm().then(async (wasmLoaded) => {
 
                 // CRITICAL: Re-enable the button so that "Resume" works later (and checks in input.js pass)
                 startButton.disabled = false;
+                startButton.removeAttribute('title');
                 startButton.style.background = ''; // Reset style
 
                 // Note: The pointer lock will happen automatically via input system

--- a/src/utils/wasm-loader-core.ts
+++ b/src/utils/wasm-loader-core.ts
@@ -896,6 +896,7 @@ export async function initWasm(): Promise<boolean> {
     const startButton = document.getElementById('startButton');
     if (startButton) {
         (startButton as HTMLButtonElement).disabled = true;
+        startButton.setAttribute('title', 'Please wait while game assets load...');
         startButton.style.cursor = 'wait';
     }
 
@@ -910,6 +911,7 @@ export async function initWasm(): Promise<boolean> {
 
     if (startButton) {
         (startButton as HTMLButtonElement).disabled = false;
+        startButton.removeAttribute('title');
         startButton.textContent = 'Start Exploration 🚀';
         startButton.style.cursor = 'pointer';
     }


### PR DESCRIPTION
💡 What: Added a `title` attribute to the "Start Exploration" / "Enter World" button (`#startButton`) to provide a tooltip explaining its disabled state.
🎯 Why: Disabled buttons that don't explain why they are disabled can be confusing. The tooltip ("Please wait while game assets load...") gives users immediate feedback on why the button cannot be clicked.
📸 Before/After: The button previously showed a loading spinner but no hover tooltip. Now, hovering over it reveals the reason it's disabled.
♿ Accessibility: Improved feedback for users navigating via mouse or screen readers (by providing additional context on the disabled state).

---
*PR created automatically by Jules for task [15865380823197684993](https://jules.google.com/task/15865380823197684993) started by @ford442*