### PR TITLE
🎨 Palette: [UX improvement] Trap focus inside Accessibility Menu

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -23,3 +23,6 @@
 ## 2024-04-13 - Audio System Juice
 **Learning:** Candy World synthesizes its own sound effects (jumps, impacts, UI clicks) procedurally using the Web Audio API rather than relying on external `.wav` or `.mp3` assets to keep the package lightweight and stylized.
 **Action:** When adding new physics or interaction events, trigger them via `(window as any).AudioSystem.playSound('type')` and use the built-in procedural oscillators in `src/audio/audio-system.ts`.
+## 2026-04-15 - Accessibility Menu Focus Trapping
+**Learning:** The Accessibility Menu needed a robust focus trap to ensure keyboard navigation remained within the modal while it was open, preventing users from accidentally tabbing out into the underlying game canvas or other UI elements.
+**Action:** Replaced the simple `this.a11y.trapFocus(this.container)` call with the `trapFocusInside` utility from `interaction-utils.ts`, securely binding and unbinding the focus trap during the menu's lifecycle.

--- a/src/ui/accessibility-menu.ts
+++ b/src/ui/accessibility-menu.ts
@@ -21,6 +21,7 @@ import {
   CrosshairStyle,
 } from '../systems/accessibility';
 import { announce, announceValueChange } from './announcer';
+import { trapFocusInside } from '../utils/interaction-utils.ts';
 
 // ============================================================================
 // Menu Section Types
@@ -62,6 +63,7 @@ export class AccessibilityMenu {
   private focusIndex = 0;
   private boundKeyHandler: (e: KeyboardEvent) => void;
   private saveButton: HTMLButtonElement | null = null;
+  private releaseFocusTrap: (() => void) | null = null;
 
   constructor() {
     this.a11y = getAccessibilitySystem();
@@ -81,7 +83,7 @@ export class AccessibilityMenu {
     
     // Trap focus
     if (this.container) {
-      this.a11y.trapFocus(this.container);
+      this.releaseFocusTrap = trapFocusInside(this.container);
       announce('Accessibility menu opened. Use Tab to navigate, Enter to select.', 'polite');
     }
 
@@ -95,8 +97,9 @@ export class AccessibilityMenu {
     if (!this.isOpen) return;
 
     // Release focus
-    if (this.container) {
-      this.a11y.releaseFocus(this.container);
+    if (this.releaseFocusTrap) {
+      this.releaseFocusTrap();
+      this.releaseFocusTrap = null;
     }
 
     // Remove elements


### PR DESCRIPTION
🎨 Palette: [UX improvement] Trap focus inside Accessibility Menu

💡 What: Implemented `trapFocusInside` for the newest overlay menu (Accessibility Menu).
🎯 Why: To ensure keyboard focus remains trapped inside the menu while it is open, preventing users from accidentally interacting with the game or other UI elements behind the modal.
♿ Accessibility: This improves keyboard navigation and ensures a compliant focus trap for screen reader and keyboard users.

---
*PR created automatically by Jules for task [9514750923973138693](https://jules.google.com/task/9514750923973138693) started by @ford442*