### PR TITLE
♿ Aria: [Audio Controls Screen Reader Support]

### DIFF
--- a/weekly_plan.md
+++ b/weekly_plan.md
@@ -2,3 +2,5 @@
 - [Testing Debt] When attempting to run `pnpm test` and `pnpm run test:integration`, tests failed because `verify.py` and `verify_wasm_particle_bounds.js` are completely missing from the filesystem. Action Item: Restore, rewrite, or safely remove these broken commands from package.json.
 - [Tech Debt] In `src/core/init.js`, we fall back to string literals (`'display-p3'`, `'srgb'`) for `outputColorSpace` because `THREE.DisplayP3ColorSpace` and `THREE.SRGBColorSpace` resulted in TS/build warnings with the current `three` version. When updating Three.js, ensure these are reverted to the proper enum.
 - [Planning Debt] Review and fix all plan files (e.g., plan.md, IMPLEMENTATION_PLAN_MUSICAL_ECOSYSTEM.md). Goal is to archive or delete completed tasks since practically all listed features and migrations are currently marked as 'Implemented'.
+
+Note on Accessibility (ARIA): The `Announcer` system in `src/ui/announcer.ts` dynamically injects `aria-live` regions into the DOM instead of relying solely on statically written HTML tags. This was discussed during the audio controls ARIA implementation.


### PR DESCRIPTION
💡 What: Added `aria-live` screen reader announcements when adjusting game volume or toggling mute.
🎯 Why: Previously, changing the volume or muting the game via keyboard shortcuts or UI buttons provided visual feedback (toasts, UI state) but lacked explicit non-visual feedback for screen reader users. This makes the audio controls fully accessible and understandable without relying on visual changes.
♿ Accessibility: Leveraged the existing `Announcer` system (which dynamically creates `aria-live="polite"` regions) to broadcast "Audio Muted", "Audio Unmuted", and "Volume: X%" strings upon user interaction.

---
*PR created automatically by Jules for task [3546078198458416309](https://jules.google.com/task/3546078198458416309) started by @ford442*