### PR TITLE
♿ Aria: [Volume Feedback]

### DIFF
--- a/src/core/input/audio-controls.ts
+++ b/src/core/input/audio-controls.ts
@@ -5,6 +5,7 @@
 
 import { AudioSystem } from '../../audio/audio-system';
 import { keyStates } from './input-types.ts';
+import { announce, announceValueChange } from '../../ui/announcer.ts';
 
 let audioSystemRef: AudioSystem | null = null;
 
@@ -87,6 +88,8 @@ export const toggleMute = () => {
         showToast(isMuted ? "Audio Muted 🔇" : "Audio Unmuted 🔊", isMuted ? '🔇' : '🔊');
     });
     
+    announce(isMuted ? "Audio Muted" : "Audio Unmuted", "polite");
+
     return isMuted;
 };
 
@@ -127,6 +130,8 @@ export const adjustVolume = (delta: number) => {
     import('../../utils/toast.js').then(({ showToast }) => {
         showToast(`Volume: ${percentage}% ${icon}`, icon);
     });
+
+    announceValueChange('Volume', percentage, 0, 100);
 };
 
 /**


### PR DESCRIPTION
💡 What: Added screen reader announcements when the volume is adjusted or the mute state is toggled using the HUD buttons or hotkeys.
🎯 Why: Previously, users relying on screen readers had no auditory feedback when changing the volume or muting the game. This change ensures they are immediately informed of the new audio state.
♿ Accessibility: Utilized the existing `announce` and `announceValueChange` utilities from the `Announcer` system to securely and politely inject updates into the DOM's `aria-live` region.

---
*PR created automatically by Jules for task [4686592434150718120](https://jules.google.com/task/4686592434150718120) started by @ford442*