### PR TITLE
🎨 Palette: [Accessibility Polish] Add focus trap to Discovery Log

### DIFF
--- a/src/systems/discovery.ts
+++ b/src/systems/discovery.ts
@@ -3,6 +3,7 @@
 import { showToast } from '../utils/toast.js';
 import { DISCOVERY_MAP } from './discovery_map.ts';
 import { discoveryPersistence } from './discovery-persistence.ts';
+import { trapFocusInside } from '../utils/interaction-utils.ts';
 
 /**
  * Manages the discovery of rare flora and environmental features.
@@ -143,7 +144,14 @@ class DiscoverySystem {
         closeBtn.style.color = 'white';
         closeBtn.style.fontSize = '24px';
         closeBtn.style.cursor = 'pointer';
+
+        let releaseFocusTrap: (() => void) | null = null;
+
         closeBtn.onclick = () => {
+            if (releaseFocusTrap) {
+                releaseFocusTrap();
+                releaseFocusTrap = null;
+            }
             overlay.remove();
         };
         logContainer.appendChild(closeBtn);
@@ -184,6 +192,9 @@ class DiscoverySystem {
         logContainer.appendChild(grid);
         overlay.appendChild(logContainer);
         document.body.appendChild(overlay);
+
+        // Trap focus inside the overlay
+        releaseFocusTrap = trapFocusInside(overlay);
 
         // Focus close button for accessibility
         closeBtn.focus();


### PR DESCRIPTION
🎨 Palette: [Accessibility Polish] Add focus trap to Discovery Log

Visual Change: None directly, this modifies the focus behavior.
Juice Factor: Improved accessibility handling. The Discovery Log modal now traps keyboard focus correctly, preventing tab traversal from bleeding out into the background game elements. Users can now securely use Escape and standard Tab navigation while exploring the log.
Technical: Imported `trapFocusInside` from `src/utils/interaction-utils.ts` and attached it to the dynamically generated Discovery Log DOM overlay element (`overlay`), maintaining focus confinement strictly within it, and executing the cleanup function reliably within the close handler.

---
*PR created automatically by Jules for task [18090700735000367570](https://jules.google.com/task/18090700735000367570) started by @ford442*