### PR TITLE
♿ Aria: [Now Playing Announcement]

### DIFF
--- a/src/core/input/playlist-manager.ts
+++ b/src/core/input/playlist-manager.ts
@@ -7,6 +7,7 @@ import { AudioSystem } from '../../audio/audio-system';
 import { PointerLockControls } from 'three/examples/jsm/controls/PointerLockControls.js';
 import { trapFocusInside } from '../../utils/interaction-utils.ts';
 import { formatSongTitle, filterValidMusicFiles } from './input-types.ts';
+import { announce } from '../../ui/announcer.ts';
 
 // State
 let isPlaylistOpen = false;
@@ -102,6 +103,9 @@ export function initPlaylistManager(
 
             // 🎨 Palette: Update Browser Tab Title
             document.title = `🎵 ${trackName} - Candy World`;
+
+            // ♿ Aria: Announce the new track to screen readers dynamically
+            announce(`Now Playing: ${trackName}`, 'polite');
         }
     };
 


### PR DESCRIPTION
💡 What: Added dynamic screen reader announcements for track changes in the Jukebox using the `announce` utility.
🎯 Why: Relying on static text updates inside an `aria-live` region can sometimes be unreliable across different ATs, and memory rules emphasize using the `Announcer` singleton.
♿ Accessibility: Ensures that visually impaired users get a reliable, polite notification when a new song starts playing in the game.

---
*PR created automatically by Jules for task [9156125790983356359](https://jules.google.com/task/9156125790983356359) started by @ford442*