### PR TITLE
🏗️ Architect: [Phase 4 Compute Shader] Pollen compute node dispatch

### DIFF
--- a/IMPLEMENTATION_PLAN_MUSICAL_ECOSYSTEM.md
+++ b/IMPLEMENTATION_PLAN_MUSICAL_ECOSYSTEM.md
@@ -62,7 +62,7 @@ Three.js Renderer -> WebGPU RenderPipeline (Raw Draw Calls)
 ## Next Steps
 
 1. **Verify Data Flow**: Ensure `AudioSystem` correctly extracts and passes `order`/`row` data from the worklet to drive the Pattern-Change logic reliably.
-2. **Target 4: Phase 4 Compute Shader Migration (fireflies.ts)**
+2. **Target 4: Phase 4 Compute Shader Migration (fireflies.ts & pollen.ts)**
    - **Status: Implemented ✅**
-   - *Implementation Details: Integrated `createIntegratedFireflies` into `src/world/generation.ts` and wired its logic directly to `updateAllIntegratedSystems` within the `animate()` loop in `src/core/game-loop.ts`, effectively shifting the fireflies' rendering entirely from a CPU-heavy process to use WebGPU compute shaders.*
-3. **Identify Phase 4 Targets**: Find specific visual features that are still heavily reliant on CPU and transition them to WebGPU Compute Shaders (GPGPU). Candidates include `pollen.ts`.
+   - *Implementation Details: Integrated `createIntegratedFireflies` and `createIntegratedPollen` into `src/world/generation.ts`. Wired the existing TSL compute node for pollen natively into the `game-loop.ts` render graph to execute the WGSL compute shader every frame.*
+3. **Identify Phase 4 Targets**: Find specific visual features that are still heavily reliant on CPU and transition them to WebGPU Compute Shaders (GPGPU). Candidates include `rain.ts` and `sparks.ts`.

--- a/src/core/game-loop.ts
+++ b/src/core/game-loop.ts
@@ -592,8 +592,10 @@ export function animate() {
     }
 
     for (const obj of animatedFoliage) {
-        if (obj.userData.type === 'waterfall' && obj.userData.computeNode) {
-            rendererRef.compute(obj.userData.computeNode);
+        if (obj.userData.computeNode) {
+            if (obj.userData.type === 'waterfall' || obj.userData.isPollen) {
+                rendererRef.compute(obj.userData.computeNode);
+            }
         }
     }
     updateImpacts(rendererRef, t);


### PR DESCRIPTION
Wired the existing TSL compute node for the `pollen` feature natively into the `game-loop.ts` render graph to execute the WGSL compute shader every frame. Also updated `IMPLEMENTATION_PLAN_MUSICAL_ECOSYSTEM.md` to mark this Phase 4 Compute Shader Migration step as completed and documented the native integration.

---
*PR created automatically by Jules for task [9262852110719696016](https://jules.google.com/task/9262852110719696016) started by @ford442*