### PR TITLE
♿ Aria: [Accessibility Menu Focus Return]

### DIFF
--- a/src/ui/accessibility-menu.ts
+++ b/src/ui/accessibility-menu.ts
@@ -64,6 +64,7 @@ export class AccessibilityMenu {
   private boundKeyHandler: (e: KeyboardEvent) => void;
   private saveButton: HTMLButtonElement | null = null;
   private releaseFocusTrap: (() => void) | null = null;
+  private lastFocusedElement: HTMLElement | null = null;
 
   constructor() {
     this.a11y = getAccessibilitySystem();
@@ -77,6 +78,8 @@ export class AccessibilityMenu {
   open(): void {
     if (this.isOpen) return;
     
+    this.lastFocusedElement = document.activeElement as HTMLElement;
+
     this.createMenu();
     this.isOpen = true;
     document.addEventListener('keydown', this.boundKeyHandler);
@@ -101,6 +104,11 @@ export class AccessibilityMenu {
       this.releaseFocusTrap();
       this.releaseFocusTrap = null;
     }
+
+    if (this.lastFocusedElement && typeof this.lastFocusedElement.focus === 'function') {
+      this.lastFocusedElement.focus();
+    }
+    this.lastFocusedElement = null;
 
     // Remove elements
     if (this.overlay && this.overlay.parentNode) {


### PR DESCRIPTION
💡 What:
Captured the currently focused element (`document.activeElement`) when opening the Accessibility Menu and restored focus to that element upon closing the menu.

🎯 Why:
To comply with WCAG 2.4.3 Focus Order. Previously, when the menu closed, focus was dropped, often returning users to the top of the document (`<body>`). By restoring focus to the button that opened the menu, we ensure a seamless and logical navigation experience for keyboard and screen reader users.

♿ Accessibility:
Proper focus management ensures context is maintained for assistive technologies when exiting modals.

---
*PR created automatically by Jules for task [10579723893932160263](https://jules.google.com/task/10579723893932160263) started by @ford442*