### PR TITLE
🎨 Palette: [Accessibility Improvement] Fix Focus Restoration

### DIFF
--- a/src/systems/discovery.ts
+++ b/src/systems/discovery.ts
@@ -13,6 +13,7 @@ import { trapFocusInside } from '../utils/interaction-utils.ts';
  */
 class DiscoverySystem {
     private discoveredItems: Set<string>;
+    private lastFocusedElement: HTMLElement | null = null;
 
     constructor() {
         this.discoveredItems = new Set<string>();
@@ -96,8 +97,14 @@ class DiscoverySystem {
         let existingLog = document.getElementById('discovery-log-overlay');
         if (existingLog) {
             existingLog.remove();
+            if (this.lastFocusedElement && typeof this.lastFocusedElement.focus === 'function') {
+                this.lastFocusedElement.focus();
+                this.lastFocusedElement = null;
+            }
             return; // Toggle behavior
         }
+
+        this.lastFocusedElement = document.activeElement as HTMLElement | null;
 
         const overlay = document.createElement('div');
         overlay.id = 'discovery-log-overlay';
@@ -153,6 +160,11 @@ class DiscoverySystem {
                 releaseFocusTrap = null;
             }
             overlay.remove();
+
+            if (this.lastFocusedElement && typeof this.lastFocusedElement.focus === 'function') {
+                this.lastFocusedElement.focus();
+                this.lastFocusedElement = null;
+            }
         };
         logContainer.appendChild(closeBtn);
 

--- a/src/ui/save-menu/save-menu.ts
+++ b/src/ui/save-menu/save-menu.ts
@@ -66,6 +66,7 @@ export class SaveMenu {
     private onCloseCallback?: () => void;
     private keydownHandler: (e: KeyboardEvent) => void;
     private releaseFocusTrap: (() => void) | null = null;
+    private lastFocusedElement: HTMLElement | null = null;
 
     constructor(options: SaveMenuOptions = {}) {
         this.currentMode = options.mode || 'full';
@@ -103,6 +104,8 @@ export class SaveMenu {
     async show(): Promise<void> {
         if (this.container) return;
         
+        this.lastFocusedElement = document.activeElement as HTMLElement | null;
+
         this.container = document.createElement('div');
         this.container.className = 'candy-save-menu';
         
@@ -142,6 +145,12 @@ export class SaveMenu {
             this.container?.remove();
             this.container = null;
             document.removeEventListener('keydown', this.keydownHandler);
+
+            if (this.lastFocusedElement && typeof this.lastFocusedElement.focus === 'function') {
+                this.lastFocusedElement.focus();
+                this.lastFocusedElement = null;
+            }
+
             this.onCloseCallback?.();
         }, 200);
     }


### PR DESCRIPTION
🎨 Palette: [Accessibility Improvement] Fix Focus Restoration

Visual Change:
None visually, but significantly improves interaction order and flow.

"Juice" Factor:
Modals now fluidly return the user back to the exact button they clicked when opening them. This maintains unbroken keyboard and screen reader flow when entering and exiting settings menus, avoiding jarring leaps to the top of the document.

Technical:
Implemented document.activeElement capturing in `save-menu.ts` and `discovery.ts` before creating the overlay/menu elements, and explicitly called `.focus()` on the captured element when destroying the UI layers. This complies with WCAG 2.4.3 Focus Order and mirrors the correct `trapFocusInside` teardown pattern already used in the `AccessibilityMenu`.

---
*PR created automatically by Jules for task [9702869653852241971](https://jules.google.com/task/9702869653852241971) started by @ford442*