### PR TITLE
⚡ Bolt: Fix VRAM Leak in Mushroom Replacements

### DIFF
--- a/src/foliage/mushrooms.ts
+++ b/src/foliage/mushrooms.ts
@@ -184,6 +184,18 @@ export function replaceMushroomWithGiant(scene: THREE.Scene, oldMushroom: THREE.
 
     // Remove old logic object
     oldMushroom.parent.remove(oldMushroom);
+    // ⚡ OPTIMIZATION: Call .dispose() on geometries and materials when removing from scene to prevent VRAM leak.
+    oldMushroom.traverse((child: THREE.Object3D) => {
+        const mesh = child as THREE.Mesh;
+        if (mesh.geometry) mesh.geometry.dispose();
+        if (mesh.material) {
+            if (Array.isArray(mesh.material)) {
+                mesh.material.forEach((m: THREE.Material) => m.dispose());
+            } else {
+                (mesh.material as THREE.Material).dispose();
+            }
+        }
+    });
 
     // Current Time for pop animation
     const now = performance.now() / 1000.0;


### PR DESCRIPTION
Bottleneck: When replacing mushrooms with giants, the old mushroom was removed from the scene via `scene.remove(mesh)`, but its underlying `geometry` and `materials` were never disposed, leading to VRAM leaks.
Fix: Added a `.traverse()` call to safely invoke `.dispose()` on all child geometries and materials right after removing the parent object from the scene.
Impact: Plugged a VRAM leak during dynamic gameplay changes.

---
*PR created automatically by Jules for task [11929590779367877342](https://jules.google.com/task/11929590779367877342) started by @ford442*