### PR TITLE
chore(plan): restructure weekly_plan.md to routine template

### DIFF
--- a/weekly_plan.md
+++ b/weekly_plan.md
@@ -1,6 +1,37 @@
-- Investigate and restore missing test scripts: verify.py and verify_wasm_particle_bounds.js.
-- [Testing Debt] When attempting to run `pnpm test` and `pnpm run test:integration`, tests failed because `verify.py` and `verify_wasm_particle_bounds.js` are completely missing from the filesystem. Action Item: Restore, rewrite, or safely remove these broken commands from package.json.
-- [Tech Debt] In `src/core/init.js`, we fall back to string literals (`'display-p3'`, `'srgb'`) for `outputColorSpace` because `THREE.DisplayP3ColorSpace` and `THREE.SRGBColorSpace` resulted in TS/build warnings with the current `three` version. When updating Three.js, ensure these are reverted to the proper enum.
-- [Planning Debt] Review and fix all plan files (e.g., plan.md, IMPLEMENTATION_PLAN_MUSICAL_ECOSYSTEM.md). Goal is to archive or delete completed tasks since practically all listed features and migrations are currently marked as 'Implemented'.
+# candy_world — Weekly Plan
 
-Note on Accessibility (ARIA): The `Announcer` system in `src/ui/announcer.ts` dynamically injects `aria-live` regions into the DOM instead of relying solely on statically written HTML tags. This was discussed during the audio controls ARIA implementation.
+## Today's focus
+**2026-04-21 — Testing Debt: restore a real `npm test` path.**
+`package.json` currently stubs `test` and `test:wasm` with `echo` statements pointing at missing files (`verify.py`, `verify_wasm_particle_bounds.js`). The stack has Playwright installed and tracker/physics work landing almost daily — shipping without any runnable test gate is the biggest foundational risk on the board. Goal today: either restore the missing verifiers or replace them with a minimal Playwright smoke + WASM bounds check that actually runs in `npm test` / `npm run test:integration`.
+
+## Ideas
+<!--
+Write ideas here during the week as they come to you.
+Routine prioritizes these over generated ideas.
+Format: - [ ] Short description (optional: more context on next line indented)
+Routine will mark picked items as "[in progress — YYYY-MM-DD]".
+-->
+- [ ] [in progress — 2026-04-21] **Testing Debt** — Restore `verify.py` and `verify_wasm_particle_bounds.js`, or rewrite/safely remove these broken commands from `package.json`. Both files are completely missing from the filesystem; `pnpm test` and `pnpm run test:integration` currently `echo` skip messages (see commit c8091ff).
+- [ ] **Three.js ColorSpace enum regression** — In `src/core/init.js` we fall back to string literals (`'display-p3'`, `'srgb'`) for `outputColorSpace` because `THREE.DisplayP3ColorSpace` / `THREE.SRGBColorSpace` produced TS/build warnings with the current `three` version. When updating Three.js, revert to the proper enum.
+- [ ] **Planning Debt — archive completed plan files** — Review and prune `plan.md`, `IMPLEMENTATION_PLAN_MUSICAL_ECOSYSTEM.md`, and the 30+ other `*.md` planning/summary docs at repo root. Practically all listed features/migrations are currently marked 'Implemented' — keep what's still live, archive the rest under `docs/archive/`.
+
+## Backlog
+<!--
+Unfinished items, known bugs, deferred ideas.
+Routine maintains this automatically — you can add items too.
+-->
+- [ ] Accessibility note: `Announcer` in `src/ui/announcer.ts` dynamically injects `aria-live` regions rather than relying on static HTML — future ARIA work should use the dynamic path, not add static tags.
+
+## Done
+<!--
+Completed items, routine archives here with date.
+Prune occasionally when this gets long.
+-->
+<!-- No items archived by the routine yet. First run — historical completions live in git log. -->
+
+## Last run
+<!-- Routine writes summary here each run. Overwrites previous. -->
+Date: 2026-04-21 (first routine run in template form)
+Mode: User Idea
+Focus: Testing Debt — restore a real `npm test` path
+Outcome: TBD


### PR DESCRIPTION
## Summary
- Migrate `weekly_plan.md` from a flat debt-note list into the routine template shape (Today's focus / Ideas / Backlog / Done / Last run) so the weekly planner has a stable file to read and write.
- No content dropped — the three existing debt items (Testing, Three.js ColorSpace enum, Planning Debt) moved into `Ideas`; the `Announcer` ARIA note moved into `Backlog`.
- **Today's focus** set to the Testing Debt item: `npm test` and `npm run test:wasm` are currently `echo` stubs pointing at missing files (`verify.py`, `verify_wasm_particle_bounds.js`) — the plan is to restore a real Playwright smoke + WASM bounds check rather than keep the stubs.

## Mode
User Idea — picked Testing Debt over the other two Ideas because every active focus area (music reactivity, TSL shaders, dual-WASM physics) iterates faster once there's a runnable test gate.

## Test plan
- [ ] Verify `weekly_plan.md` renders correctly on GitHub
- [ ] No functional code changed — build/tests unaffected by this PR

## Follow-ups (not in this PR)
- Actual restoration of `npm test` / `npm run test:wasm` / `npm run test:integration` — tracked as the active Idea in `weekly_plan.md`.