### PR TITLE
🎨 Palette: [Accessibility + TSL Optimization]

### DIFF
--- a/src/foliage/trees.ts
+++ b/src/foliage/trees.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import { foliageMaterials, registerReactiveMaterial, attachReactivity, pickAnimation, createClayMaterial, createGradientMaterial, sharedGeometries, uAudioLow, uWindSpeed, calculatePlayerPush, createStandardNodeMaterial, createJuicyRimLight } from './index.ts';
+import { foliageMaterials, registerReactiveMaterial, attachReactivity, pickAnimation, createClayMaterial, createGradientMaterial, sharedGeometries, uAudioLow, uWindSpeed, calculatePlayerPush, createStandardNodeMaterial, createJuicyRimLight, getCachedProceduralMaterial } from './index.ts';
 import { color as tslColor, mix, float, sin, cos, vec3, positionLocal, positionWorld, time, normalWorld } from 'three/tsl';
 import { uTwilight } from './sky.ts';
 import { createBerryCluster } from './berries.ts';
@@ -632,8 +632,12 @@ export function createSwingableVine(options: SwingableVineOptions = {}): THREE.G
     const segmentCount = 8;
     const segLen = length / segmentCount;
 
+    const vineMat = getCachedProceduralMaterial(`swingable_vine_${color}`, color, () => {
+        return createClayMaterial(color);
+    });
+
     for (let i = 0; i < segmentCount; i++) {
-        const mat = createClayMaterial(color);
+        const mat = vineMat;
         const segmentGroup = new THREE.Group();
         segmentGroup.position.y = -i * segLen;
 

--- a/src/ui/analytics-debug.ts
+++ b/src/ui/analytics-debug.ts
@@ -16,6 +16,7 @@
 
 import { analytics, trackEvent } from '../systems/analytics';
 import type { FPSHistogram, FrameTimePercentiles } from '../systems/analytics';
+import { trapFocusInside } from '../utils/interaction-utils.ts';
 
 // =============================================================================
 // Types & Interfaces
@@ -366,6 +367,8 @@ class AnalyticsDebugOverlay {
   private updateInterval: number | null = null;
   private eventLog: Array<{ time: string; type: string; props: string }> = [];
   private maxEventLog = 50;
+  private releaseFocusTrap: (() => void) | null = null;
+  private lastFocusedElement: HTMLElement | null = null;
 
   constructor() {
     this.injectStyles();
@@ -649,9 +652,13 @@ class AnalyticsDebugOverlay {
   show(): void {
     if (this.isVisible) return;
     
+    this.lastFocusedElement = document.activeElement as HTMLElement;
     this.elements = this.createElements();
     this.isVisible = true;
     
+    // Trap focus inside the overlay
+    this.releaseFocusTrap = trapFocusInside(this.elements.container);
+
     // Start update loop
     this.refresh();
     this.updateInterval = window.setInterval(() => {
@@ -667,6 +674,16 @@ class AnalyticsDebugOverlay {
   hide(): void {
     if (!this.isVisible || !this.elements) return;
     
+    // Release focus trap and restore focus
+    if (this.releaseFocusTrap) {
+      this.releaseFocusTrap();
+      this.releaseFocusTrap = null;
+    }
+    if (this.lastFocusedElement && typeof this.lastFocusedElement.focus === 'function') {
+      this.lastFocusedElement.focus();
+    }
+    this.lastFocusedElement = null;
+
     this.elements.container.remove();
     this.elements = null;
     this.isVisible = false;


### PR DESCRIPTION
Visual Change: No overt visual change to gameplay, but the analytics debug overlay now properly traps keyboard focus when opened, complying with accessibility guidelines.

"Juice" Factor: Enhances UX for keyboard users by preventing focus from leaking into the underlying document when the debug overlay is active. Restores focus back to the previously active element upon closing.

Technical:
- **Accessibility:** Implemented `trapFocusInside` in `AnalyticsDebugOverlay`. Captured `document.activeElement` upon opening and restored focus on close.
- **Batching Optimization:** Modified `createSwingableVine` to avoid instantiating a new `createClayMaterial` during a loop segment layout. Lifted material creation out of the loop and wrapped it in `getCachedProceduralMaterial()` to apply a module-level material cache, directly eliminating WebGPU compilation stutters when instances of this tree type load.

---
*PR created automatically by Jules for task [10816506594981640989](https://jules.google.com/task/10816506594981640989) started by @ford442*