### PR TITLE
🎨 Palette: UI Accessibility & Focus Trap Polish

### DIFF
--- a/src/ui/analytics-debug.ts
+++ b/src/ui/analytics-debug.ts
@@ -16,6 +16,7 @@
 
 import { analytics, trackEvent } from '../systems/analytics';
 import type { FPSHistogram, FrameTimePercentiles } from '../systems/analytics';
+import { trapFocusInside } from '../utils/interaction-utils.ts';
 
 // =============================================================================
 // Types & Interfaces
@@ -366,6 +367,7 @@ class AnalyticsDebugOverlay {
   private updateInterval: number | null = null;
   private eventLog: Array<{ time: string; type: string; props: string }> = [];
   private maxEventLog = 50;
+  private releaseFocusTrap: (() => void) | null = null;
 
   constructor() {
     this.injectStyles();
@@ -658,6 +660,7 @@ class AnalyticsDebugOverlay {
       this.refresh();
     }, 1000);
     
+    this.releaseFocusTrap = trapFocusInside(this.elements.container);
     trackEvent('debug_overlay_opened', {});
   }
 
@@ -667,6 +670,11 @@ class AnalyticsDebugOverlay {
   hide(): void {
     if (!this.isVisible || !this.elements) return;
     
+    if (this.releaseFocusTrap) {
+      this.releaseFocusTrap();
+      this.releaseFocusTrap = null;
+    }
+
     this.elements.container.remove();
     this.elements = null;
     this.isVisible = false;

--- a/src/ui/save-menu/save-menu.ts
+++ b/src/ui/save-menu/save-menu.ts
@@ -108,6 +108,9 @@ export class SaveMenu {
 
         this.container = document.createElement('div');
         this.container.className = 'candy-save-menu';
+        this.container.setAttribute('role', 'dialog');
+        this.container.setAttribute('aria-modal', 'true');
+        this.container.setAttribute('aria-labelledby', 'save-menu-title');
         
         // Add click outside to close
         this.container.addEventListener('click', (e) => {
@@ -221,7 +224,7 @@ export class SaveMenu {
         }
 
         this.container.innerHTML = `
-            <div class="candy-save-menu__container" role="dialog" aria-modal="true" aria-labelledby="save-menu-title">
+            <div class="candy-save-menu__container">
                 ${this.renderHeader()}
                 ${this.currentMode === 'full' ? this.renderTabs(tabs) : ''}
                 <div id="panel-${this.currentTab}" role="tabpanel" aria-labelledby="tab-${this.currentTab}" class="candy-save-menu__content">


### PR DESCRIPTION
🎨 Palette: UI Accessibility & Focus Trap Polish

Visual Change: No visible change.
"Juice" Factor: Ensures overlay menus (Analytics Debug, Save Menu) properly trap keyboard focus for screen readers and keyboard users, improving the overall UX.
Technical:
- Added `trapFocusInside` to `AnalyticsDebugOverlay`.
- Fixed `SaveMenu` so `role="dialog"` and `aria-modal="true"` are applied directly to the persistent outer container instead of being destroyed/recreated during `innerHTML` renders, fixing screen reader context loss.

---
*PR created automatically by Jules for task [15027907515552525137](https://jules.google.com/task/15027907515552525137) started by @ford442*