### PR TITLE
♿ Aria: [Save Menu Loading States]

### DIFF
--- a/src/ui/save-menu/save-menu-styles.ts
+++ b/src/ui/save-menu/save-menu-styles.ts
@@ -243,6 +243,27 @@ export const MENU_STYLES = `
     outline-offset: 2px;
 }
 
+.candy-save-slot__btn[aria-busy="true"],
+.candy-save-menu__btn[aria-busy="true"] {
+    cursor: wait !important;
+    position: relative;
+    pointer-events: none;
+    opacity: 0.8;
+}
+
+.candy-save-slot__btn[aria-busy="true"] .spinner,
+.candy-save-menu__btn[aria-busy="true"] .spinner {
+    display: inline-block;
+    width: 1em;
+    height: 1em;
+    border: 2px solid rgba(255, 255, 255, 0.3);
+    border-radius: 50%;
+    border-top-color: #fff;
+    animation: spin 1s ease-in-out infinite;
+    margin-right: 5px;
+    vertical-align: middle;
+}
+
 /* Action Buttons */
 .candy-save-menu__actions {
     display: flex;

--- a/src/ui/save-menu/save-menu.ts
+++ b/src/ui/save-menu/save-menu.ts
@@ -375,7 +375,7 @@ export class SaveMenu {
                 const el = e.currentTarget as HTMLElement;
                 const action = el.dataset.action;
                 const slotId = el.dataset.slot!;
-                this.handleSlotAction(action!, slotId);
+                this.handleSlotAction(action!, slotId, el);
             });
         });
 
@@ -420,7 +420,7 @@ export class SaveMenu {
         }
     }
 
-    private async handleSlotAction(action: string, slotId: string): Promise<void> {
+    private async handleSlotAction(action: string, slotId: string, btnElement?: HTMLElement): Promise<void> {
         // Create bound save function for callbacks
         const boundSaveToSlot = async (id: string) => {
             const result = await saveSystem.save(id);
@@ -440,7 +440,8 @@ export class SaveMenu {
             this.onSaveCallback,
             () => this.refreshSlots(),
             () => this.render(),
-            (tab) => this.switchTab(tab)
+            (tab) => this.switchTab(tab),
+            btnElement
         );
     }
 

--- a/src/ui/save-menu/save-slots.ts
+++ b/src/ui/save-menu/save-slots.ts
@@ -158,8 +158,63 @@ export async function handleSlotAction(
     onSaveCallback?: (slotId: string) => void,
     refreshSlots?: () => Promise<void>,
     render?: () => void,
-    switchTab?: (tab: 'load' | 'save' | 'settings' | 'import-export') => void
+    switchTab?: (tab: 'load' | 'save' | 'settings' | 'import-export') => void,
+    btnElement?: HTMLElement
 ): Promise<void> {
+
+    // Set busy state if button was provided
+    if (btnElement) {
+        btnElement.setAttribute('aria-busy', 'true');
+        btnElement.style.pointerEvents = 'none';
+        btnElement.style.opacity = '0.7';
+        const originalText = btnElement.innerHTML;
+        btnElement.innerHTML = '<span class="spinner" aria-hidden="true"></span>...';
+
+        // Setup cleanup to restore state
+        const cleanup = () => {
+            btnElement.removeAttribute('aria-busy');
+            btnElement.style.pointerEvents = '';
+            btnElement.style.opacity = '';
+            btnElement.innerHTML = originalText;
+        };
+
+        try {
+            switch (action) {
+                case 'load':
+                    await loadSave(slotId, onLoadCallback, menu);
+                    break;
+                case 'save':
+                    await saveToSlot(slotId, onSaveCallback, refreshSlots, render);
+                    break;
+                case 'overwrite':
+                    if (!confirm('Are you sure you want to overwrite this save? This cannot be undone.')) {
+                        cleanup();
+                        return;
+                    }
+                    await saveToSlot(slotId, onSaveCallback, refreshSlots, render);
+                    break;
+                case 'export':
+                    await exportSlot(slotId, menu);
+                    break;
+                case 'delete':
+                    if (confirm('Are you sure you want to delete this save?')) {
+                        const result = await saveSystem.delete(slotId);
+                        if (result) {
+                            import('../../utils/toast.js').then(({ showToast }) => {
+                                showToast('Save deleted', '🗑️', 3000);
+                            });
+                            await refreshSlots?.();
+                            render?.();
+                        }
+                    }
+                    break;
+            }
+        } finally {
+            cleanup();
+        }
+        return;
+    }
+
     switch (action) {
         case 'load':
             await loadSave(slotId, onLoadCallback, menu);


### PR DESCRIPTION
💡 What: Added visual and semantic loading states to save/load buttons during asynchronous operations.
🎯 Why: Without visual feedback, users might double-click buttons or think the game has frozen when saving or loading takes a moment.
♿ Accessibility: Uses the `aria-busy="true"` attribute to notify screen readers that the element is processing, while also preventing double-clicks via pointer-events and adding a visual spinner.

---
*PR created automatically by Jules for task [16286678908292567393](https://jules.google.com/task/16286678908292567393) started by @ford442*