### PR TITLE
♿ Aria: [Jukebox Empty State Focus]

### DIFF
--- a/src/core/input/playlist-manager.ts
+++ b/src/core/input/playlist-manager.ts
@@ -290,6 +290,12 @@ export function renderPlaylist(): void {
                 } else if (playBtns[0]) {
                     // Or the first song
                     (playBtns[0] as HTMLElement).focus();
+                } else {
+                    // Fallback to empty state button if list is now empty
+                    const emptyBtn = playlistList!.querySelector('button.secondary-button');
+                    if (emptyBtn) {
+                        (emptyBtn as HTMLElement).focus();
+                    }
                 }
             });
         };


### PR DESCRIPTION
💡 What: Added focus management logic for the empty state in the Jukebox playlist.

🎯 Why: When keyboard users removed the last song in the Jukebox playlist, focus was previously lost (dropping back to the document body). This left screen reader users without immediate context about the new state of the playlist. 

♿ Accessibility: Added fallback focus to explicitly target the `secondary-button` inside the empty state `li` when `removeBtns[index]`, `removeBtns[index - 1]`, and `playBtns[0]` fail to exist. This announces the "Your playlist is empty" state and ensures smooth keyboard navigation flow.

---
*PR created automatically by Jules for task [11840357952601408886](https://jules.google.com/task/11840357952601408886) started by @ford442*