### PR TITLE
🎨 Palette: [Accessibility Polish] Trap Focus in Loading Screen

### DIFF
--- a/src/ui/loading-screen.ts
+++ b/src/ui/loading-screen.ts
@@ -12,6 +12,7 @@
  */
 
 import './loading-screen.css';
+import { trapFocusInside } from '../utils/interaction-utils.ts';
 
 // =============================================================================
 // TYPES & INTERFACES
@@ -142,6 +143,9 @@ export class LoadingScreen {
     private onSkipCallbacks: Set<(phaseId: string) => void> = new Set();
     private onCompleteCallbacks: Set<() => void> = new Set();
     private onProgressCallbacks: Set<(progress: LoadingProgress) => void> = new Set();
+
+    private releaseFocusTrap: (() => void) | null = null;
+    private lastFocusedElement: HTMLElement | null = null;
 
     constructor(options: LoadingScreenOptions = {}) {
         this.options = {
@@ -320,6 +324,13 @@ export class LoadingScreen {
         this.isVisible = true;
         this.isComplete = false;
         
+        this.lastFocusedElement = document.activeElement as HTMLElement;
+        if (this.container) {
+            this.container.setAttribute('tabindex', '-1');
+            this.container.setAttribute('aria-modal', 'true');
+            this.releaseFocusTrap = trapFocusInside(this.container);
+        }
+
         // Trigger reflow for animation
         requestAnimationFrame(() => {
             if (this.overlay) {
@@ -757,6 +768,15 @@ export class LoadingScreen {
     }
 
     private destroy(): void {
+        if (this.releaseFocusTrap) {
+            this.releaseFocusTrap();
+            this.releaseFocusTrap = null;
+        }
+        if (this.lastFocusedElement && typeof this.lastFocusedElement.focus === 'function') {
+            this.lastFocusedElement.focus();
+            this.lastFocusedElement = null;
+        }
+
         if (this.overlay && this.overlay.parentNode) {
             this.overlay.parentNode.removeChild(this.overlay);
         }


### PR DESCRIPTION
Visual Change: The loading screen now acts as a true modal dialog. It correctly manages focus so that keyboard users cannot accidentally interact with the background UI elements while the world is generating.

"Juice" Factor: This polish significantly improves the game feel for keyboard and screen reader users by trapping focus within the active overlay, offering a more robust and responsive accessibility experience.

Technical: Added `trapFocusInside` to `LoadingScreen.show()`, tracking the previously focused element (`lastFocusedElement`) to restore it gracefully on `destroy()`. `aria-modal="true"` and `tabindex="-1"` attributes were added to the container element in `LoadingScreen.ts` as per ARIA guidelines.

---
*PR created automatically by Jules for task [12759643397576895929](https://jules.google.com/task/12759643397576895929) started by @ford442*