### PR TITLE
♿ Aria: [Accessibility - Button Loading States]

### DIFF
--- a/src/ui/save-menu/save-menu.ts
+++ b/src/ui/save-menu/save-menu.ts
@@ -494,6 +494,7 @@ export class SaveMenu {
         const originalWidth = btnElement.offsetWidth;
 
         const setWorkingState = () => {
+            btnElement.setAttribute('aria-busy', 'true');
             btnElement.disabled = true;
             btnElement.style.width = `${originalWidth}px`;
             btnElement.style.justifyContent = 'center';
@@ -501,6 +502,7 @@ export class SaveMenu {
         };
 
         const restoreState = () => {
+            btnElement.removeAttribute('aria-busy');
             btnElement.disabled = false;
             btnElement.style.width = '';
             btnElement.style.justifyContent = '';


### PR DESCRIPTION
💡 What: Added aria-busy to action buttons in Save Menu during operations.
🎯 Why: Buttons lacked screen-reader feedback during async operations like save imports/exports.
♿ Accessibility: Added `aria-busy` toggling for dynamic async states on save menu buttons.

---
*PR created automatically by Jules for task [9542337563742220276](https://jules.google.com/task/9542337563742220276) started by @ford442*