### PR TITLE
🎨 Palette: [Accessibility Polish] Add focus trap to Save Menu

### DIFF
--- a/src/ui/save-menu/save-menu.ts
+++ b/src/ui/save-menu/save-menu.ts
@@ -129,6 +129,8 @@ export class SaveMenu {
         // Load slots
         await this.refreshSlots();
         this.render();
+
+        this.releaseFocusTrap = trapFocusInside(this.container);
     }
 
     /**
@@ -137,6 +139,11 @@ export class SaveMenu {
     close(): void {
         if (!this.container) return;
         
+        if (this.releaseFocusTrap) {
+            this.releaseFocusTrap();
+            this.releaseFocusTrap = null;
+        }
+
         // Add exit animation
         this.container.style.animation = 'fadeIn 0.2s ease reverse';
         
@@ -218,11 +225,6 @@ export class SaveMenu {
         
         const tabs = this.getTabs();
         
-        if (this.releaseFocusTrap) {
-            this.releaseFocusTrap();
-            this.releaseFocusTrap = null;
-        }
-
         this.container.innerHTML = `
             <div class="candy-save-menu__container">
                 ${this.renderHeader()}
@@ -234,7 +236,6 @@ export class SaveMenu {
         `;
         
         this.attachEventListeners();
-        this.releaseFocusTrap = trapFocusInside(this.container);
     }
 
     private getTabs(): { id: MenuTab; label: string; icon: string }[] {


### PR DESCRIPTION
Visual Change: The Save Menu now correctly traps focus within its overlay, preventing keyboard users from tabbing to underlying game elements (like the canvas or HUD) while the menu is open.

"Juice" Factor: This improves accessibility and keyboard navigation significantly. Users can now tab smoothly through the save slots, tabs, and buttons without accidentally interacting with the game behind the modal. 

Technical: Extracted the `trapFocusInside` call from the `render()` method, which could be called multiple times due to tab switching or re-renders, and moved it to the `show()` and `close()` lifecycle methods. This prevents memory leaks and ensures the focus trap is managed properly at the modal container level.

---
*PR created automatically by Jules for task [6155959285379332771](https://jules.google.com/task/6155959285379332771) started by @ford442*