### PR TITLE
♿ Aria: [UX improvement] Add keyboard navigation to Save Menu tabs

### DIFF
--- a/src/gameplay/jitter-mines.ts
+++ b/src/gameplay/jitter-mines.ts
@@ -50,6 +50,11 @@ class JitterMineSystem {
         // Don't eagerly evaluate in constructor to prevent barrel file module load errors
     }
 
+    /**
+     * Idempotent initialization of all WebGPU / TSL resources.
+     * This is deferred so TSL node math never runs during module load or
+     * constructor execution, preventing scope-loss and mangling crashes.
+     */
     init() {
         if (this.initialized) return;
         this.initialized = true;
@@ -65,16 +70,7 @@ class JitterMineSystem {
                 time: 0
             });
         }
-    }
 
-    /**
-     * Idempotent initialization of all WebGPU / TSL resources.
-     * This is deferred so TSL node math never runs during module load or
-     * constructor execution, preventing scope-loss and mangling crashes.
-     */
-    init() {
-        if (this._initialized) return;
-        this._initialized = true;
 
         const geometry = new THREE.IcosahedronGeometry(MINE_RADIUS, 0);
 

--- a/src/ui/loading-screen.ts
+++ b/src/ui/loading-screen.ts
@@ -113,8 +113,6 @@ export class LoadingScreen {
     private progressFill: HTMLElement | null = null;
     private percentageText: HTMLElement | null = null;
     private taskText: HTMLElement | null = null;
-    private releaseFocusTrap: (() => void) | null = null;
-    private lastFocusedElement: HTMLElement | null = null;
     private timeText: HTMLElement | null = null;
     private skipButton: HTMLButtonElement | null = null;
     private spinner: HTMLElement | null = null;

--- a/src/ui/save-menu/save-menu.ts
+++ b/src/ui/save-menu/save-menu.ts
@@ -418,6 +418,30 @@ export class SaveMenu {
         } else if (this.listeningKeybind) {
             e.preventDefault();
             this.updateKeybind(this.listeningKeybind, e.key.toLowerCase());
+            return;
+        }
+
+        // ♿ Aria: Keyboard navigation for Tabs (Left/Right Arrows)
+        if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+            const activeElement = document.activeElement as HTMLElement;
+            if (activeElement && activeElement.getAttribute('role') === 'tab') {
+                e.preventDefault();
+                const tabs = Array.from(this.container?.querySelectorAll('[role="tab"]') || []) as HTMLElement[];
+                const currentIndex = tabs.indexOf(activeElement);
+                if (currentIndex >= 0) {
+                    let nextIndex = e.key === 'ArrowRight' ? currentIndex + 1 : currentIndex - 1;
+                    if (nextIndex >= tabs.length) nextIndex = 0;
+                    if (nextIndex < 0) nextIndex = tabs.length - 1;
+
+                    const nextTab = tabs[nextIndex];
+                    nextTab.focus();
+
+                    const tabId = nextTab.dataset.tab as MenuTab;
+                    if (tabId) {
+                        this.switchTab(tabId);
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
💡 What: Added Arrow-Key (Left/Right) keyboard navigation support to the Save Menu tabs.

🎯 Why: The Save Menu implemented the ARIA `tablist` and `tab` roles, but did not implement the required keyboard navigation pattern. Keyboard users and screen readers expect Left/Right arrow keys to navigate between tabs within a tablist, but previously the UI only responded to mouse clicks.

♿ Accessibility: Intercepts `ArrowLeft` and `ArrowRight` on elements with `role="tab"`, determines the next/previous tab index wrapping around boundaries, moves DOM focus to the new tab, and automatically triggers the internal tab switch event to keep the UI synchronized.

*Note: Cleaned up a few minor pre-existing TypeScript duplicate initialization build errors blocking the verification tests.*

---
*PR created automatically by Jules for task [18392927104911300697](https://jules.google.com/task/18392927104911300697) started by @ford442*