### PR TITLE
⚡ Bolt: Pre-filter CPU animated foliage

### DIFF
--- a/src/core/game-loop.ts
+++ b/src/core/game-loop.ts
@@ -63,7 +63,7 @@ import { WeatherState } from '../systems/weather-types.ts';
 import { InteractionSystem } from '../systems/interaction.ts';
 import { AudioSystem } from '../audio/audio-system.ts';
 import { BeatSync } from '../audio/beat-sync.ts';
-import { animatedFoliage, foliageClouds, foliageMushrooms } from '../world/state.ts';
+import { animatedFoliage, cpuAnimatedFoliage, foliageClouds, foliageMushrooms } from '../world/state.ts';
 import { getCycleState } from './cycle.ts';
 import {
     CYCLE_DURATION,
@@ -547,7 +547,7 @@ export function animate() {
     const fluidFog = getFluidFog();
 
     profiler.measure('MusicReact', () => {
-        musicReactivitySystem.update(t, delta, audioState, weatherSystemRef!, animatedFoliage, cameraRef!, isNightNow, isDeepNight);
+        musicReactivitySystem.update(t, delta, audioState, weatherSystemRef!, cpuAnimatedFoliage, cameraRef!, isNightNow, isDeepNight);
         if (melodyRibbon) updateMelodyRibbons(melodyRibbon, delta, audioState);
         profiler.measure('Particles', () => {
             _scratchParticleAudioData.low = audioState?.kickTrigger || 0;

--- a/src/systems/music-reactivity.ts
+++ b/src/systems/music-reactivity.ts
@@ -214,7 +214,7 @@ export class MusicReactivitySystem {
         deltaTime: number,
         audioState: AudioData | null,
         weatherSystem: IWeatherSystem,
-        animatedFoliage: FoliageObject[],
+        cpuAnimatedFoliage: FoliageObject[],
         camera: THREE.Camera,
         isNight: boolean,
         isDeepNight: boolean
@@ -226,7 +226,7 @@ export class MusicReactivitySystem {
         this.updateTwilightGlow(time);
 
         // 3. Update Foliage Animation Loop
-        if (animatedFoliage && camera) {
+        if (cpuAnimatedFoliage && camera) {
             // Update Frustum for Culling
             _projScreenMatrix.multiplyMatrices(camera.projectionMatrix, camera.matrixWorldInverse);
             _frustum.setFromProjectionMatrix(_projScreenMatrix);
@@ -239,25 +239,10 @@ export class MusicReactivitySystem {
             let culledByFrustum = 0;
             let rendered = 0;
 
-            for (let i = 0; i < animatedFoliage.length; i++) {
-                const obj = animatedFoliage[i];
+            for (let i = 0; i < cpuAnimatedFoliage.length; i++) {
+                const obj = cpuAnimatedFoliage[i];
                 if (!obj) continue;
                 totalObjects++;
-
-                // ⚡ OPTIMIZATION: Skip Batched Objects (Corrected Implementation)
-                // If isBatched is true, we rely on the Batcher (InstancedMesh + TSL) to handle animations.
-                // We skip CPU-side animateFoliage call to save cycles.
-                if (obj.userData.isBatched ||
-                    obj.userData.type === 'mushroom' ||
-                    obj.userData.type === 'lanternFlower' ||
-                    obj.userData.type === 'arpeggio_fern' ||
-                    obj.userData.type === 'portamento_pine' ||
-                    obj.userData.type === 'prismRoseBush' ||
-                    obj.userData.isFlower) {
-                    // We treat them as rendered for metrics, but skip CPU animation logic
-                    rendered++;
-                    continue;
-                }
 
                 // ⚡ PERFORMANCE: Size-based culling distances
                 let cullDistance = 150; // Default

--- a/src/world/generation.ts
+++ b/src/world/generation.ts
@@ -29,7 +29,7 @@ import { unlockSystem } from '../systems/unlocks.ts';
 import { spawnImpact } from '../foliage/impacts.ts';
 import { makeInteractive } from '../utils/interaction-utils.ts';
 import {
-    animatedFoliage, obstacles, foliageGroup, foliageMushrooms,
+    animatedFoliage, cpuAnimatedFoliage, obstacles, foliageGroup, foliageMushrooms,
     foliageClouds, foliageTrampolines, foliagePanningPads, foliageGeysers, foliageTraps, foliagePortamentoPines, vineSwings, worldGroup
 } from './state.ts';
 import mapData from '../../assets/map.json';
@@ -240,6 +240,16 @@ export function safeAddFoliage(
     if (animatedFoliage.length > 3000) return; // ⚡ PERFORMANCE: Raised limit from 1000 to 3000 for more musical objects
     foliageGroup.add(obj);
     animatedFoliage.push(obj);
+
+    if (!(obj.userData.isBatched ||
+        obj.userData.type === 'mushroom' ||
+        obj.userData.type === 'lanternFlower' ||
+        obj.userData.type === 'arpeggio_fern' ||
+        obj.userData.type === 'portamento_pine' ||
+        obj.userData.type === 'prismRoseBush' ||
+        obj.userData.isFlower)) {
+        cpuAnimatedFoliage.push(obj);
+    }
 
     // Add to JS obstacles (legacy/backup)
     if (isObstacle) {

--- a/src/world/state.ts
+++ b/src/world/state.ts
@@ -3,6 +3,7 @@ import { VineSwing } from '../foliage/trees.ts';
 import { FoliageObject } from '../foliage/types.ts';
 
 export const animatedFoliage: FoliageObject[] = [];
+export const cpuAnimatedFoliage: FoliageObject[] = [];
 export const obstacles: THREE.Object3D[] = [];
 
 // Optimization: Categorized arrays for faster collision/logic


### PR DESCRIPTION
Bottleneck: "The `musicReactivitySystem.update()` loop was iterating over thousands of batched foliage objects every frame."
Fix: "Created a `cpuAnimatedFoliage` sub-array to strictly track objects needing CPU animation, bypassing batched objects entirely."
Impact: "Eliminates O(N) iterations over non-animated foliage in the hot path, improving JS frame consistency."

---
*PR created automatically by Jules for task [7778716635183773287](https://jules.google.com/task/7778716635183773287) started by @ford442*