### PR TITLE
♿ Aria: [UX improvement] Add keyboard support to ability slots

### DIFF
--- a/src/core/input/input.ts
+++ b/src/core/input/input.ts
@@ -501,6 +501,15 @@ export function initInput(
                 triggerAbility('dash');
             }
         });
+        hudDash.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                e.stopPropagation();
+                if (hudDash.getAttribute('aria-disabled') !== 'true') {
+                    triggerAbility('dash');
+                }
+            }
+        });
         // Add keyboard activation for accessibility (Enter/Space)
         hudDash.addEventListener('keydown', (e) => {
             if (e.key === 'Enter' || e.key === ' ') {
@@ -529,6 +538,15 @@ export function initInput(
                 }
             }
         });
+        hudMine.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                e.stopPropagation();
+                if (hudMine.getAttribute('aria-disabled') !== 'true') {
+                    triggerAbility('action');
+                }
+            }
+        });
     }
 
     if (hudPhase) {
@@ -536,6 +554,15 @@ export function initInput(
             e.stopPropagation();
             if (hudPhase.getAttribute('aria-disabled') !== 'true') {
                 triggerAbility('phase');
+            }
+        });
+        hudPhase.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                e.stopPropagation();
+                if (hudPhase.getAttribute('aria-disabled') !== 'true') {
+                    triggerAbility('phase');
+                }
             }
         });
         hudPhase.addEventListener('keydown', (e) => {


### PR DESCRIPTION
💡 What: Added keyboard activation support (Enter and Space) to the ability HUD slots.
🎯 Why: To comply with WCAG requirements and ensure keyboard users can trigger abilities (Dash, Jitter Mine, Phase Shift) directly via the UI elements that have the `role="button"` attribute.
♿ Accessibility: Handled `keydown` events for `Enter` and `Space` on elements with `role="button"` and `tabindex="0"`.

---
*PR created automatically by Jules for task [4310358033915926597](https://jules.google.com/task/4310358033915926597) started by @ford442*