### PR TITLE
♿ Aria: [UX improvement] Fix focus drop in UI menus on re-render

### DIFF
--- a/src/ui/accessibility-menu.ts
+++ b/src/ui/accessibility-menu.ts
@@ -1205,12 +1205,30 @@ export class AccessibilityMenu {
 
   private refreshMainPanel(): void {
     const main = this.container?.querySelector('main');
+
+    // Track focus before replacing content
+    const activeElement = document.activeElement;
+    const wasFocusedInside = this.container?.contains(activeElement);
+
     if (main) {
       main.id = `panel-${this.currentSection}`;
       main.setAttribute('aria-labelledby', `tab-${this.currentSection}`);
       this.renderSection(main, this.currentSection);
     }
     this.updateSidebarSelection();
+
+    // Restore focus if it was dropped
+    if (wasFocusedInside && (!document.activeElement || document.activeElement === document.body)) {
+      let activeTab = this.container?.querySelector(`[role="tab"][aria-selected="true"]`) as HTMLElement;
+      if (!activeTab) activeTab = this.container?.querySelector(`button[aria-selected="true"]`) as HTMLElement;
+
+      if (activeTab) {
+        activeTab.focus();
+      } else {
+        const firstFocusable = this.container?.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])') as HTMLElement;
+        if (firstFocusable) firstFocusable.focus();
+      }
+    }
   }
 
   private updateSidebarSelection(): void {

--- a/src/ui/save-menu/save-menu.ts
+++ b/src/ui/save-menu/save-menu.ts
@@ -225,6 +225,10 @@ export class SaveMenu {
         
         const tabs = this.getTabs();
         
+        // Track focus before rendering
+        const activeElement = document.activeElement;
+        const wasFocusedInside = this.container.contains(activeElement);
+
         this.container.innerHTML = `
             <div class="candy-save-menu__container">
                 ${this.renderHeader()}
@@ -236,6 +240,18 @@ export class SaveMenu {
         `;
         
         this.attachEventListeners();
+
+        // Restore focus if it was dropped
+        if (wasFocusedInside && (!document.activeElement || document.activeElement === document.body)) {
+            const activeTab = this.container.querySelector(`[role="tab"][aria-selected="true"]`) as HTMLElement;
+            if (activeTab) {
+                activeTab.focus();
+            } else {
+                // Fallback to first focusable element
+                const firstFocusable = this.container.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])') as HTMLElement;
+                if (firstFocusable) firstFocusable.focus();
+            }
+        }
     }
 
     private getTabs(): { id: MenuTab; label: string; icon: string }[] {


### PR DESCRIPTION
What:
Modified `AccessibilityMenu.refreshMainPanel` and `SaveMenu.render` to track and restore keyboard focus. If replacing the inner DOM causes the currently focused element to be destroyed (losing focus to `document.body`), focus is now programmatically shifted back to the active tab button or the first focusable element.

Why:
Previously, switching tabs or dynamically re-rendering contents inside these overlay menus would destroy the focused DOM node. When the browser loses the focused element, it forcibly dumps focus back to the `<body>` tag. This completely broke the `trapFocusInside` implementation, forcing keyboard and screen reader users to navigate all the way back through the DOM to find the menu again.

Accessibility:
By restoring focus logically after `innerHTML` modifications, we ensure the focus trap remains intact and the user journey is uninterrupted, dramatically improving UX for keyboard navigation and screen readers.

---
*PR created automatically by Jules for task [16614147425803131966](https://jules.google.com/task/16614147425803131966) started by @ford442*