### PR TITLE
♿ Aria: [UX improvement] - Arrow key navigation for Accessibility Menu tabs

### DIFF
--- a/src/ui/accessibility-menu.ts
+++ b/src/ui/accessibility-menu.ts
@@ -1154,6 +1154,31 @@ export class AccessibilityMenu {
     if (event.key === 'Escape') {
       this.close();
       event.preventDefault();
+      return;
+    }
+
+    // ♿ Aria: Keyboard navigation for Tabs (Up/Down Arrows)
+    if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
+        const activeElement = document.activeElement as HTMLElement;
+        if (activeElement && activeElement.getAttribute('role') === 'tab') {
+            event.preventDefault();
+            const tabs = Array.from(this.container?.querySelectorAll('[role="tab"]') || []) as HTMLElement[];
+            const currentIndex = tabs.indexOf(activeElement);
+            if (currentIndex >= 0) {
+                let nextIndex = event.key === 'ArrowDown' ? currentIndex + 1 : currentIndex - 1;
+                if (nextIndex >= tabs.length) nextIndex = 0;
+                if (nextIndex < 0) nextIndex = tabs.length - 1;
+
+                const nextTab = tabs[nextIndex];
+                nextTab.focus();
+
+                // Assuming tab id is like 'tab-presets' and section is 'presets'
+                const tabIdMatch = nextTab.id.match(/^tab-(.+)$/);
+                if (tabIdMatch && tabIdMatch[1]) {
+                    this.switchSection(tabIdMatch[1] as MenuSection);
+                }
+            }
+        }
     }
   }
 

--- a/weekly_plan.md
+++ b/weekly_plan.md
@@ -38,3 +38,4 @@ Date: 2026-04-28
 Mode: Fix First
 Focus: Resolve the two inherited test-infrastructure bugs (TSL `mul` crash + Jukebox headless timeout) so `npm test` passes from a clean install.
 Outcome: TBD
+- ✅ Implemented Arrow Key navigation for Accessibility Menu Tabs


### PR DESCRIPTION
💡 What: Added arrow key navigation (Up/Down) to cycle through sections within the Accessibility Menu.

🎯 Why: To improve usability for keyboard/screen-reader users, allowing intuitive navigation between menu tabs.

♿ Accessibility: Trapped arrow key events specifically within the tablist to manage focus and sync the visually active tab section with the keyboard focus state.

---
*PR created automatically by Jules for task [7732999109830331800](https://jules.google.com/task/7732999109830331800) started by @ford442*