### PR TITLE
Implement rain-driven foliage growth & spreading

### DIFF
--- a/IMPLEMENTATION_PLAN_MUSICAL_ECOSYSTEM.md
+++ b/IMPLEMENTATION_PLAN_MUSICAL_ECOSYSTEM.md
@@ -37,10 +37,10 @@ This phased plan outlines a progressive migration to stronger typing, offloading
   - Run WGSL compute passes to update particle/physics buffers on a `gpuDevice`.
   - Use a `THREE.BufferAttribute` pointing to the GPU buffer for rendering.
 
-- **Stage B — Custom Render Passes** [DEPRECATED - Superseded by TSL & InstancedMesh Batching]
+- ~~**Stage B — Custom Render Passes**~~ [DEPRECATED - Superseded by TSL & InstancedMesh Batching]
   - Replace specific materials with `RawShaderMaterial` / WebGPU pipelines (e.g., cloud or terrain draws).
 
-- **Stage C — Scene Graph Replacement** [DEPRECATED - Superseded by TSL & InstancedMesh Batching]
+- ~~**Stage C — Scene Graph Replacement**~~ [DEPRECATED - Superseded by TSL & InstancedMesh Batching]
   - Once compute + custom render passes are in place, migrate scene hierarchy to an ECS in WASM and call `device.queue.submit()` directly.
 
 ---
@@ -62,12 +62,5 @@ Three.js Renderer -> WebGPU RenderPipeline (Raw Draw Calls)
 
 ## Next Steps
 
-1. **Verify Data Flow**: Ensure `AudioSystem` correctly extracts and passes `order`/`row` data from the worklet to drive the Pattern-Change logic reliably.
-   - **Status: Implemented ✅**
-   - *Implementation Details: Verified and routed tracker `order` and `row` from the WASM worklet up to the main thread `VisualState` (`patternIndex` and `row`). Audio data correctly propagates to `musicReactivitySystem` inside the main game loop.*
-2. **Target 4: Phase 4 Compute Shader Migration (fireflies.ts & pollen.ts)**
-   - **Status: Implemented ✅**
-   - *Implementation Details: Integrated `createIntegratedFireflies` and `createIntegratedPollen` into `src/world/generation.ts`. Wired the existing TSL compute node for pollen natively into the `game-loop.ts` render graph to execute the WGSL compute shader every frame.*
-3. **Identify Phase 4 Targets**: Find specific visual features that are still heavily reliant on CPU and transition them to WebGPU Compute Shaders (GPGPU). Candidates include `rain.ts` and `sparks.ts`.
-   - **Status: Implemented ✅**
-   - *Implementation Details: Migrated `rain.ts` and `berries.ts` to `ComputeParticleSystem` and integrated `createIntegratedSparks` and `createIntegratedBerries` into `src/world/generation.ts`. Upgraded `ComputeParticleSystem` to strictly enforce WebGPU layout logic and added direct `spawn`/`burst` API via `device.queue.writeBuffer` for zero-allocation interaction.*
+1. **Foliage Growth & Rain-Driven Spreading**
+   - Foliage can spread into empty areas during/after rain according to local spawning rules.

--- a/patch_ecosystem.py
+++ b/patch_ecosystem.py
@@ -1,0 +1,63 @@
+import os
+
+with open("src/systems/weather/weather-ecosystem.ts", "r") as f:
+    content = f.read()
+
+# Make sure spawnNearbyFoliage and FoliageGrowthOptions are imported
+if "spawnNearbyFoliage" not in content:
+    content = content.replace("import { createMushroom } from '../../foliage/mushrooms.ts';", "import { createMushroom } from '../../foliage/mushrooms.ts';\nimport { FoliageGrowthOptions } from '../../foliage/types.ts';\nimport { spawnNearbyFoliage } from '../../world/generation.ts';")
+    content = content.replace("import { foliageClouds, getGroundHeight } from '../../world/state.ts';", "import { foliageClouds, getGroundHeight, cpuAnimatedFoliage } from '../../world/state.ts';")
+
+new_handle_spawning = """
+    /**
+     * Handle spawning logic based on favorability scores
+     */
+    handleSpawning(time: number, fungiScore: number, lanternScore: number, globalLight: number, onSpawnFoliage: ((object: any, isNew: boolean, duration: number) => void) | null, isRaining: boolean): void {
+        if (time - this._lastSpawnCheck < this._spawnThrottle) return;
+        this._lastSpawnCheck = time;
+
+        if (fungiScore > 0.8) {
+            if (Math.random() < 0.4) this.spawnFoliage('mushroom', true, onSpawnFoliage);
+        }
+        if (lanternScore > 0.6) {
+            if (Math.random() < 0.3) this.spawnFoliage('lantern', false, onSpawnFoliage);
+        }
+        if (globalLight > 0.7 && fungiScore < 0.3) {
+             if (Math.random() < 0.2) this.spawnFoliage('flower', false, onSpawnFoliage);
+        }
+
+        // Feature: Rain-Driven Spreading
+        if (isRaining && Math.random() < 0.2) {
+            const growthOptions: FoliageGrowthOptions = {
+                spawnRadius: 10,
+                spawnChanceBase: 0.3,
+                maxOffspring: 2,
+                growthWindowMs: 5000,
+                densityLimit: 5
+            };
+
+            // Pick a random adult plant from cpuAnimatedFoliage to spread
+            if (cpuAnimatedFoliage && cpuAnimatedFoliage.length > 0) {
+                const adultIndex = Math.floor(Math.random() * cpuAnimatedFoliage.length);
+                const adultPlant = cpuAnimatedFoliage[adultIndex];
+
+                // Only spread mushrooms or flowers
+                if (adultPlant && adultPlant.userData && (adultPlant.userData.type === 'mushroom' || adultPlant.userData.isFlower)) {
+                     // Throttle per-plant spreading
+                     const lastSpawn = adultPlant.userData.lastSpawnTime || 0;
+                     if (Date.now() - lastSpawn > growthOptions.growthWindowMs) {
+                         const typeToSpawn = adultPlant.userData.type === 'mushroom' ? 'mushroom' : 'flower';
+                         spawnNearbyFoliage(adultPlant, typeToSpawn, growthOptions, this.weatherSystem);
+                         adultPlant.userData.lastSpawnTime = Date.now();
+                     }
+                }
+            }
+        }
+    }
+"""
+
+import re
+content = re.sub(r'    /\*\*\n     \* Handle spawning logic based on favorability scores\n     \*/\n    handleSpawning\([\s\S]*?(?=    /\*\*\n     \* Spawn a single foliage object)', new_handle_spawning, content)
+
+with open("src/systems/weather/weather-ecosystem.ts", "w") as f:
+    f.write(content)

--- a/patch_ecosystem_import.py
+++ b/patch_ecosystem_import.py
@@ -1,0 +1,12 @@
+import os
+import re
+
+with open("src/systems/weather/weather-ecosystem.ts", "r") as f:
+    content = f.read()
+
+# Make sure cpuAnimatedFoliage is imported properly
+if "import { cpuAnimatedFoliage } from '../../world/state.ts';" not in content:
+    content = "import { cpuAnimatedFoliage } from '../../world/state.ts';\n" + content
+
+with open("src/systems/weather/weather-ecosystem.ts", "w") as f:
+    f.write(content)

--- a/patch_generation.py
+++ b/patch_generation.py
@@ -1,0 +1,78 @@
+import os
+
+with open("src/world/generation.ts", "r") as f:
+    content = f.read()
+
+# Add FoliageGrowthOptions import
+if "FoliageGrowthOptions" not in content:
+    content = content.replace("import { createMushroom } from '../foliage/mushrooms.ts';", "import { createMushroom } from '../foliage/mushrooms.ts';\nimport { FoliageGrowthOptions } from '../foliage/types.ts';")
+
+# Add helper function for spawning nearby
+new_function = """
+
+export function spawnNearbyFoliage(parentPlant: THREE.Object3D, type: string, options: FoliageGrowthOptions, weatherSystem: WeatherSystem | null = null): void {
+    if (animatedFoliage.length > 3000) return; // Hard cap
+
+    const maxAttempts = 5;
+    for (let i = 0; i < options.maxOffspring; i++) {
+        if (Math.random() > options.spawnChanceBase) continue;
+
+        let valid = false;
+        let nx = 0, nz = 0;
+
+        for (let a = 0; a < maxAttempts; a++) {
+            const angle = Math.random() * Math.PI * 2;
+            const dist = (Math.random() * 0.5 + 0.5) * options.spawnRadius;
+            nx = parentPlant.position.x + Math.cos(angle) * dist;
+            nz = parentPlant.position.z + Math.sin(angle) * dist;
+
+            if (isPositionValid(nx, nz, 1.0)) {
+                // Check local density
+                let localCount = 0;
+                // Use a simple distance check against a subset or the WASM grid if available
+                for (const plant of cpuAnimatedFoliage) {
+                    if (!plant || !plant.position) continue;
+                    const dx = plant.position.x - nx;
+                    const dz = plant.position.z - nz;
+                    if (dx*dx + dz*dz < options.spawnRadius * options.spawnRadius) {
+                        localCount++;
+                    }
+                }
+
+                if (localCount < options.densityLimit) {
+                    valid = true;
+                    break;
+                }
+            }
+        }
+
+        if (valid) {
+            const groundY = getUnifiedGroundHeight(nx, nz);
+            let obj: THREE.Object3D | null = null;
+
+            if (type === 'flower') {
+                obj = createFlower();
+            } else if (type === 'mushroom') {
+                obj = createMushroom({ size: 'regular', scale: 0.8 });
+            }
+
+            if (obj) {
+                obj.position.set(nx, groundY, nz);
+                obj.userData.age = 0;
+                obj.userData.lastSpawnTime = Date.now();
+                safeAddFoliage(obj, false, 0.5, weatherSystem);
+
+                // If it's a batcher-registered object, it will be added to the batcher.
+                // However, safeAddFoliage might push it to arrays that get batched.
+                // The weather ecosystem will handle registering mushrooms.
+            }
+        }
+    }
+}
+"""
+
+if "spawnNearbyFoliage" not in content:
+    content = content + new_function
+
+with open("src/world/generation.ts", "w") as f:
+    f.write(content)

--- a/patch_plan.sh
+++ b/patch_plan.sh
@@ -1,0 +1,1 @@
+sed -i 's/   - \*\*Status: Implemented ✅\*\*/   - \*\*Status: Implemented ✅\*\*/g' IMPLEMENTATION_PLAN_MUSICAL_ECOSYSTEM.md

--- a/patch_types.py
+++ b/patch_types.py
@@ -1,0 +1,19 @@
+import os
+
+with open("src/foliage/types.ts", "r") as f:
+    content = f.read()
+
+new_interface = """
+export interface FoliageGrowthOptions {
+    spawnRadius: number;
+    spawnChanceBase: number;
+    maxOffspring: number;
+    growthWindowMs: number;
+    densityLimit: number;
+}
+
+"""
+
+if "FoliageGrowthOptions" not in content:
+    with open("src/foliage/types.ts", "a") as f:
+        f.write("\n" + new_interface)

--- a/patch_weather.py
+++ b/patch_weather.py
@@ -1,0 +1,10 @@
+import os
+
+with open("src/systems/weather/weather.ts", "r") as f:
+    content = f.read()
+
+content = content.replace("this.ecosystemManager.handleSpawning(time, fungiFavorability, lanternFavorability, globalLight, this.onSpawnFoliage);", "const isRaining = this.state === WeatherState.RAIN || this.state === WeatherState.STORM;\n        this.ecosystemManager.handleSpawning(time, fungiFavorability, lanternFavorability, globalLight, this.onSpawnFoliage, isRaining);")
+content = content.replace("this.ecosystemManager.handleSpawning(time, fungiScore, lanternScore, globalLight, this.onSpawnFoliage);", "const isRaining = this.state === WeatherState.RAIN || this.state === WeatherState.STORM;\n        this.ecosystemManager.handleSpawning(time, fungiScore, lanternScore, globalLight, this.onSpawnFoliage, isRaining);")
+
+with open("src/systems/weather/weather.ts", "w") as f:
+    f.write(content)

--- a/src/foliage/types.ts
+++ b/src/foliage/types.ts
@@ -95,3 +95,12 @@ export interface FoliageObject extends THREE.Object3D {
     children: FoliageObject[];
     material?: FoliageMaterial | FoliageMaterial[];
 }
+
+
+export interface FoliageGrowthOptions {
+    spawnRadius: number;
+    spawnChanceBase: number;
+    maxOffspring: number;
+    growthWindowMs: number;
+    densityLimit: number;
+}

--- a/src/systems/weather/weather-ecosystem.ts
+++ b/src/systems/weather/weather-ecosystem.ts
@@ -1,9 +1,12 @@
+import { cpuAnimatedFoliage } from '../../world/state.ts';
 // src/systems/weather/weather-ecosystem.ts
 // Ecosystem management: cloud-mushroom interactions, spawning, waterfalls
 
 import * as THREE from 'three';
 import { getGroundHeight, uploadMushroomSpecs, batchMushroomSpawnCandidates, readSpawnCandidates, isWasmReady } from '../../utils/wasm-loader.js';
 import { createMushroom } from '../../foliage/mushrooms.ts';
+import { FoliageGrowthOptions } from '../../foliage/types.ts';
+import { spawnNearbyFoliage } from '../../world/generation.ts';
 import { createLanternFlower } from '../../foliage/flowers.ts';
 import { cleanupReactivity } from '../../foliage/foliage-reactivity.ts';
 import { updateCloudAttraction, isCloudOverTarget } from '../../foliage/clouds.ts';
@@ -230,10 +233,11 @@ export class EcosystemManager {
         }
     }
 
+
     /**
      * Handle spawning logic based on favorability scores
      */
-    handleSpawning(time: number, fungiScore: number, lanternScore: number, globalLight: number, onSpawnFoliage: ((object: any, isNew: boolean, duration: number) => void) | null): void {
+    handleSpawning(time: number, fungiScore: number, lanternScore: number, globalLight: number, onSpawnFoliage: ((object: any, isNew: boolean, duration: number) => void) | null, isRaining: boolean): void {
         if (time - this._lastSpawnCheck < this._spawnThrottle) return;
         this._lastSpawnCheck = time;
 
@@ -246,8 +250,35 @@ export class EcosystemManager {
         if (globalLight > 0.7 && fungiScore < 0.3) {
              if (Math.random() < 0.2) this.spawnFoliage('flower', false, onSpawnFoliage);
         }
-    }
 
+        // Feature: Rain-Driven Spreading
+        if (isRaining && Math.random() < 0.2) {
+            const growthOptions: FoliageGrowthOptions = {
+                spawnRadius: 10,
+                spawnChanceBase: 0.3,
+                maxOffspring: 2,
+                growthWindowMs: 5000,
+                densityLimit: 5
+            };
+
+            // Pick a random adult plant from cpuAnimatedFoliage to spread
+            if (cpuAnimatedFoliage && cpuAnimatedFoliage.length > 0) {
+                const adultIndex = Math.floor(Math.random() * cpuAnimatedFoliage.length);
+                const adultPlant = cpuAnimatedFoliage[adultIndex];
+
+                // Only spread mushrooms or flowers
+                if (adultPlant && adultPlant.userData && (adultPlant.userData.type === 'mushroom' || adultPlant.userData.isFlower)) {
+                     // Throttle per-plant spreading
+                     const lastSpawn = adultPlant.userData.lastSpawnTime || 0;
+                     if (Date.now() - lastSpawn > growthOptions.growthWindowMs) {
+                         const typeToSpawn = adultPlant.userData.type === 'mushroom' ? 'mushroom' : 'flower';
+                         spawnNearbyFoliage(adultPlant, typeToSpawn, growthOptions, this.weatherSystem);
+                         adultPlant.userData.lastSpawnTime = Date.now();
+                     }
+                }
+            }
+        }
+    }
     /**
      * Spawn a single foliage object
      */

--- a/src/systems/weather/weather.ts
+++ b/src/systems/weather/weather.ts
@@ -323,7 +323,8 @@ export class WeatherSystem {
         this.updateMushroomGrowth(bassIntensity, globalLight);
 
         // Spawning
-        this.ecosystemManager.handleSpawning(time, fungiFavorability, lanternFavorability, globalLight, this.onSpawnFoliage);
+        const isRaining = this.state === WeatherState.RAIN || this.state === WeatherState.STORM;
+        this.ecosystemManager.handleSpawning(time, fungiFavorability, lanternFavorability, globalLight, this.onSpawnFoliage, isRaining);
         
         // Waterfalls
         this.ecosystemManager.updateMushroomWaterfalls(time, bassIntensity, this.state, this.intensity, this.trackedMushrooms, this.mushroomWaterfalls);
@@ -519,7 +520,8 @@ export class WeatherSystem {
     }
 
     handleSpawning(time: number, fungiScore: number, lanternScore: number, globalLight: number): void {
-        this.ecosystemManager.handleSpawning(time, fungiScore, lanternScore, globalLight, this.onSpawnFoliage);
+        const isRaining = this.state === WeatherState.RAIN || this.state === WeatherState.STORM;
+        this.ecosystemManager.handleSpawning(time, fungiScore, lanternScore, globalLight, this.onSpawnFoliage, isRaining);
     }
 
     updateMushroomWaterfalls(time: number, bassIntensity: number): void {

--- a/src/world/generation.ts
+++ b/src/world/generation.ts
@@ -898,3 +898,64 @@ async function populateProceduralExtras(
 
     console.log("[World] Finished populating procedural extras.");
 }
+
+
+export function spawnNearbyFoliage(parentPlant: THREE.Object3D, type: string, options: FoliageGrowthOptions, weatherSystem: WeatherSystem | null = null): void {
+    if (animatedFoliage.length > 3000) return; // Hard cap
+
+    const maxAttempts = 5;
+    for (let i = 0; i < options.maxOffspring; i++) {
+        if (Math.random() > options.spawnChanceBase) continue;
+
+        let valid = false;
+        let nx = 0, nz = 0;
+
+        for (let a = 0; a < maxAttempts; a++) {
+            const angle = Math.random() * Math.PI * 2;
+            const dist = (Math.random() * 0.5 + 0.5) * options.spawnRadius;
+            nx = parentPlant.position.x + Math.cos(angle) * dist;
+            nz = parentPlant.position.z + Math.sin(angle) * dist;
+
+            if (isPositionValid(nx, nz, 1.0)) {
+                // Check local density
+                let localCount = 0;
+                // Use a simple distance check against a subset or the WASM grid if available
+                for (const plant of cpuAnimatedFoliage) {
+                    if (!plant || !plant.position) continue;
+                    const dx = plant.position.x - nx;
+                    const dz = plant.position.z - nz;
+                    if (dx*dx + dz*dz < options.spawnRadius * options.spawnRadius) {
+                        localCount++;
+                    }
+                }
+
+                if (localCount < options.densityLimit) {
+                    valid = true;
+                    break;
+                }
+            }
+        }
+
+        if (valid) {
+            const groundY = getUnifiedGroundHeight(nx, nz);
+            let obj: THREE.Object3D | null = null;
+
+            if (type === 'flower') {
+                obj = createFlower();
+            } else if (type === 'mushroom') {
+                obj = createMushroom({ size: 'regular', scale: 0.8 });
+            }
+
+            if (obj) {
+                obj.position.set(nx, groundY, nz);
+                obj.userData.age = 0;
+                obj.userData.lastSpawnTime = Date.now();
+                safeAddFoliage(obj, false, 0.5, weatherSystem);
+
+                // If it's a batcher-registered object, it will be added to the batcher.
+                // However, safeAddFoliage might push it to arrays that get batched.
+                // The weather ecosystem will handle registering mushrooms.
+            }
+        }
+    }
+}

--- a/update_md.py
+++ b/update_md.py
@@ -1,0 +1,30 @@
+with open("IMPLEMENTATION_PLAN_MUSICAL_ECOSYSTEM.md", "r") as f:
+    lines = f.readlines()
+
+new_lines = []
+in_next_steps = False
+for line in lines:
+    if line.startswith("## Next Steps"):
+        in_next_steps = True
+        new_lines.append(line)
+        continue
+    if in_next_steps:
+        # Stop at the end of the file or next header
+        if line.startswith("## ") and not line.startswith("## Next Steps"):
+            in_next_steps = False
+            new_lines.append(line)
+        else:
+            # We skip adding the current next steps, to replace them.
+            pass
+    else:
+        new_lines.append(line)
+
+new_steps = """
+1. **Foliage Growth & Rain-Driven Spreading**
+   - Foliage can spread into empty areas during/after rain according to local spawning rules.
+"""
+
+with open("IMPLEMENTATION_PLAN_MUSICAL_ECOSYSTEM.md", "w") as f:
+    for line in new_lines:
+        f.write(line)
+    f.write(new_steps)


### PR DESCRIPTION
Implemented the `Foliage Growth & Rain-Driven Spreading` feature from the project plan. During rain (`isRaining === true`), `EcosystemManager` has a chance to pick an adult plant from `cpuAnimatedFoliage` and use `spawnNearbyFoliage` to propagate new plants (flowers or mushrooms) in nearby empty, valid positions using density checks and throttling via `growthWindowMs`.

---
*PR created automatically by Jules for task [12297079041213648911](https://jules.google.com/task/12297079041213648911) started by @ford442*