### PR TITLE
♿ Aria: [UX improvement] Jukebox empty state keyboard navigation

### DIFF
--- a/patch4.cjs
+++ b/patch4.cjs
@@ -1,0 +1,44 @@
+const fs = require('fs');
+const file = 'src/core/input/playlist-manager.ts';
+let code = fs.readFileSync(file, 'utf8');
+
+const search = `    // UX: Arrow Key Navigation for Playlist
+    if (event.code === 'ArrowDown' || event.code === 'ArrowUp') {
+        const playlistBtns = Array.from(playlistOverlay.querySelectorAll('.playlist-btn')) as HTMLElement[];
+        if (playlistBtns.length > 0) {
+            event.preventDefault(); // Prevent scrolling
+            const currentIndex = playlistBtns.indexOf(document.activeElement as HTMLElement);
+            let nextIndex;
+
+            if (event.code === 'ArrowDown') {
+                nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % playlistBtns.length;
+            } else {
+                nextIndex = currentIndex === -1 ? playlistBtns.length - 1 : (currentIndex - 1 + playlistBtns.length) % playlistBtns.length;
+            }
+            playlistBtns[nextIndex].focus();
+        }
+        return true;
+    }`;
+
+const replace = `    // UX: Arrow Key Navigation for Playlist
+    if (event.code === 'ArrowDown' || event.code === 'ArrowUp') {
+        // Query all visually accessible buttons within the playlist overlay
+        const focusableBtns = Array.from(playlistOverlay.querySelectorAll('button:not([disabled]):not([tabindex="-1"])')).filter(el => (el as HTMLElement).offsetParent !== null) as HTMLElement[];
+        if (focusableBtns.length > 0) {
+            event.preventDefault(); // Prevent scrolling
+            const currentIndex = focusableBtns.indexOf(document.activeElement as HTMLElement);
+            let nextIndex;
+
+            if (event.code === 'ArrowDown') {
+                nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % focusableBtns.length;
+            } else {
+                nextIndex = currentIndex === -1 ? focusableBtns.length - 1 : (currentIndex - 1 + focusableBtns.length) % focusableBtns.length;
+            }
+            focusableBtns[nextIndex].focus();
+        }
+        return true;
+    }`;
+
+code = code.replace(search, replace);
+
+fs.writeFileSync(file, code);

--- a/src/core/input/playlist-manager.ts
+++ b/src/core/input/playlist-manager.ts
@@ -467,18 +467,19 @@ export function handlePlaylistKeyDown(event: KeyboardEvent): boolean {
 
     // UX: Arrow Key Navigation for Playlist
     if (event.code === 'ArrowDown' || event.code === 'ArrowUp') {
-        const playlistBtns = Array.from(playlistOverlay.querySelectorAll('.playlist-btn')) as HTMLElement[];
-        if (playlistBtns.length > 0) {
+        // Query all visually accessible buttons within the playlist overlay
+        const focusableBtns = Array.from(playlistOverlay.querySelectorAll('button:not([disabled]):not([tabindex="-1"])')).filter(el => (el as HTMLElement).offsetParent !== null) as HTMLElement[];
+        if (focusableBtns.length > 0) {
             event.preventDefault(); // Prevent scrolling
-            const currentIndex = playlistBtns.indexOf(document.activeElement as HTMLElement);
+            const currentIndex = focusableBtns.indexOf(document.activeElement as HTMLElement);
             let nextIndex;
 
             if (event.code === 'ArrowDown') {
-                nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % playlistBtns.length;
+                nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % focusableBtns.length;
             } else {
-                nextIndex = currentIndex === -1 ? playlistBtns.length - 1 : (currentIndex - 1 + playlistBtns.length) % playlistBtns.length;
+                nextIndex = currentIndex === -1 ? focusableBtns.length - 1 : (currentIndex - 1 + focusableBtns.length) % focusableBtns.length;
             }
-            playlistBtns[nextIndex].focus();
+            focusableBtns[nextIndex].focus();
         }
         return true;
     }


### PR DESCRIPTION
💡 What: Updated the Arrow key navigation logic within the Jukebox playlist overlay to include all focusable buttons, not just the `.playlist-btn` items.

🎯 Why: Previously, if the playlist was empty, keyboard navigation (Arrow Up/Arrow Down) broke because it only searched for `.playlist-btn` elements. This left keyboard users stranded and unable to navigate to the "Add Songs" or "Close" buttons.

♿ Accessibility: Ensures that keyboard users can smoothly navigate all interactive elements within the Jukebox overlay, regardless of whether the playlist is populated or empty, maintaining WCAG 2.1.1 Keyboard compliance.

---
*PR created automatically by Jules for task [1973960540520073860](https://jules.google.com/task/1973960540520073860) started by @ford442*