### PR TITLE
⚡ Bolt: Eliminate Math.sqrt() in Culling Loops

### DIFF
--- a/src/compute/gpu-culling-system.ts
+++ b/src/compute/gpu-culling-system.ts
@@ -417,12 +417,13 @@ export class GPUCullingSystem {
                 const dx = sx - cameraPos[0];
                 const dy = sy - cameraPos[1];
                 const dz = sz - cameraPos[2];
-                const dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
+                // ⚡ OPTIMIZATION: Converted to pure squared distance check to avoid Math.sqrt() in hot CPU fallback loop.
+                const distSq = dx * dx + dy * dy + dz * dz;
 
                 let lod = 3;
-                if (dist < this.config.lodDistances[0]) lod = 0;
-                else if (dist < this.config.lodDistances[1]) lod = 1;
-                else if (dist < this.config.lodDistances[2]) lod = 2;
+                if (distSq < this.config.lodDistances[0] * this.config.lodDistances[0]) lod = 0;
+                else if (distSq < this.config.lodDistances[1] * this.config.lodDistances[1]) lod = 1;
+                else if (distSq < this.config.lodDistances[2] * this.config.lodDistances[2]) lod = 2;
 
                 visible.push(i);
                 lods.push(lod);

--- a/src/rendering/culling-system-gpu.ts
+++ b/src/rendering/culling-system-gpu.ts
@@ -255,12 +255,14 @@ export class CullingSystemGPU {
         const count = spheres.length / 4;
         const result = new Uint32Array(count);
 
+        // ⚡ OPTIMIZATION: Converted to pure squared distance check to avoid Math.sqrt() in hot CPU fallback loop.
+        const maxDistSq = maxDist * maxDist;
         for (let i = 0; i < count; i++) {
             const dx = spheres[i * 4] - camera.x;
             const dy = spheres[i * 4 + 1] - camera.y;
             const dz = spheres[i * 4 + 2] - camera.z;
-            const dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
-            result[i] = dist <= maxDist ? 1 : 0;
+            const distSq = dx * dx + dy * dy + dz * dz;
+            result[i] = distSq <= maxDistSq ? 1 : 0;
         }
 
         return result;
@@ -286,8 +288,10 @@ export class CullingSystemGPU {
             const dx = cx - camera.x;
             const dy = cy - camera.y;
             const dz = cz - camera.z;
-            const dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
-            if (dist > maxDist) {
+            const distSq = dx * dx + dy * dy + dz * dz;
+
+            // ⚡ OPTIMIZATION: Deferred Math.sqrt() by using squared distance for early-out bounds check.
+            if (distSq > maxDist * maxDist) {
                 result[i] = 0;
                 continue;
             }


### PR DESCRIPTION
Bottleneck: The CPU frustum/distance culling fallback loops in `GPUCullingSystem` and `CullingSystemGPU` were executing thousands of expensive `Math.sqrt()` operations per frame.

Fix: Converted the linear distance logic into pure squared distance checks (`distSq <= maxDist * maxDist` and `distSq < lodDistances[i] * lodDistances[i]`).

Impact: Eliminated CPU math bottlenecks in hot update paths, significantly improving frame-time stability for rendering clusters without relying solely on the GPU query.

---
*PR created automatically by Jules for task [10764643744484865698](https://jules.google.com/task/10764643744484865698) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized culling and LOD selection performance through improved CPU-based distance calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->