### PR TITLE
♿ Aria: [Add aria-busy to loading start button]

### DIFF
--- a/index.html
+++ b/index.html
@@ -685,7 +685,7 @@
         <div id="nowPlayingContainer" class="now-playing-info" aria-live="polite" style="display: none;">
             <span class="music-note" aria-hidden="true">🎵</span> <span id="nowPlayingText"></span>
         </div>
-        <button id="startButton" class="cta-button" disabled aria-live="polite" title="Please wait while game assets load...">
+        <button id="startButton" class="cta-button" disabled aria-live="polite" aria-busy="true" title="Please wait while game assets load...">
             <span class="spinner" aria-hidden="true"></span>Loading World... 🍭
         </button>
 

--- a/src/core/main.ts
+++ b/src/core/main.ts
@@ -269,6 +269,7 @@ initWasm().then(async (wasmLoaded) => {
     if (startButton) {
         startButton.disabled = false;
         startButton.setAttribute('aria-disabled', 'false');
+        startButton.setAttribute('aria-busy', 'false');
         startButton.removeAttribute('title');
         startButton.innerHTML = 'Enter World <span aria-hidden="true">🍭</span> <span class="key-badge" aria-hidden="true">Enter</span>';
         startButton.focus();
@@ -353,6 +354,7 @@ initWasm().then(async (wasmLoaded) => {
                 // CRITICAL: Re-enable the button so that "Resume" works later (and checks in input.js pass)
                 startButton.disabled = false;
                 startButton.setAttribute('aria-disabled', 'false');
+                startButton.setAttribute('aria-busy', 'false');
                 startButton.removeAttribute('title');
                 startButton.style.background = ''; // Reset style
 

--- a/src/utils/wasm-loader-core.ts
+++ b/src/utils/wasm-loader-core.ts
@@ -899,6 +899,7 @@ export async function initWasm(): Promise<boolean> {
     const startButton = document.getElementById('startButton');
     if (startButton) {
         (startButton as HTMLButtonElement).disabled = true;
+        startButton.setAttribute('aria-busy', 'true');
         startButton.setAttribute('title', 'Please wait while game assets load...');
         startButton.style.cursor = 'wait';
     }
@@ -914,6 +915,7 @@ export async function initWasm(): Promise<boolean> {
 
     if (startButton) {
         (startButton as HTMLButtonElement).disabled = false;
+        startButton.setAttribute('aria-busy', 'false');
         startButton.removeAttribute('title');
         startButton.textContent = 'Start Exploration 🚀';
         startButton.style.cursor = 'pointer';


### PR DESCRIPTION
💡 What: Added dynamic `aria-busy` state toggling to the game's start button during the WASM/asset loading phase.

🎯 Why: To provide immediate, semantic feedback to screen reader users that the button is disabled because a background process is currently working, rather than just being un-interactable.

♿ Accessibility: The `aria-busy="true"` attribute is applied by default in the HTML and maintained via TypeScript in `wasm-loader-core.ts` until the application is fully loaded, at which point it is removed / set to `false`.

---
*PR created automatically by Jules for task [17364043753558622530](https://jules.google.com/task/17364043753558622530) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility by enhancing the startup button to properly communicate loading states to screen reader users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->