### PR TITLE
♿ Aria: [Fix] Remove duplicate keydown listeners in HUD to fix ability triggers

### DIFF
--- a/src/core/input/input.ts
+++ b/src/core/input/input.ts
@@ -493,15 +493,6 @@ export function initInput(
                 triggerAbility('dash', hudDash);
             }
         });
-        hudDash.addEventListener('keydown', (e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                e.stopPropagation();
-                if (hudDash.getAttribute('aria-disabled') !== 'true') {
-                    triggerAbility('dash');
-                }
-            }
-        });
         // Add keyboard activation for accessibility (Enter/Space)
         hudDash.addEventListener('keydown', (e) => {
             if (e.key === 'Enter' || e.key === ' ') {
@@ -521,21 +512,13 @@ export function initInput(
                 triggerAbility('action', hudMine); // 'action' corresponds to Jitter Mine (KeyF)
             }
         });
+        // Add keyboard activation for accessibility (Enter/Space)
         hudMine.addEventListener('keydown', (e) => {
             if (e.key === 'Enter' || e.key === ' ') {
                 e.preventDefault();
                 e.stopPropagation();
                 if (hudMine.getAttribute('aria-disabled') !== 'true') {
                     triggerAbility('action', hudMine);
-                }
-            }
-        });
-        hudMine.addEventListener('keydown', (e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                e.stopPropagation();
-                if (hudMine.getAttribute('aria-disabled') !== 'true') {
-                    triggerAbility('action');
                 }
             }
         });
@@ -548,21 +531,13 @@ export function initInput(
                 triggerAbility('phase', hudPhase);
             }
         });
+        // Add keyboard activation for accessibility (Enter/Space)
         hudPhase.addEventListener('keydown', (e) => {
             if (e.key === 'Enter' || e.key === ' ') {
                 e.preventDefault();
                 e.stopPropagation();
                 if (hudPhase.getAttribute('aria-disabled') !== 'true') {
                     triggerAbility('phase', hudPhase);
-                }
-            }
-        });
-        hudPhase.addEventListener('keydown', (e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                e.stopPropagation();
-                if (hudPhase.getAttribute('aria-disabled') !== 'true') {
-                    triggerAbility('phase');
                 }
             }
         });


### PR DESCRIPTION
💡 What: Removed duplicate `keydown` event listeners on the `hudDash`, `hudMine`, and `hudPhase` buttons that were calling `triggerAbility()` without passing the button element itself as a parameter.

🎯 Why: The original code attached two identical listeners to each button for 'Enter' and 'Space' key presses. The first listener incorrectly triggered the ability without passing the DOM element reference. This meant that when a keyboard user triggered an ability, the associated UI element (e.g., the Dash button) would not update its visual cooldown state or its `aria-disabled` state properly, leading to a broken and inconsistent user experience.

♿ Accessibility: Ensures that keyboard users (triggering abilities via Enter/Space) receive the exact same visual feedback and proper ARIA state updates (`aria-disabled`) as mouse users.

---
*PR created automatically by Jules for task [2128309104633044701](https://jules.google.com/task/2128309104633044701) started by @ford442*