### PR TITLE
♿ Palette: [UX improvement] Fix Focus Trap Leaks in Dynamic Overlays

### DIFF
--- a/src/ui/accessibility-menu.ts
+++ b/src/ui/accessibility-menu.ts
@@ -1157,15 +1157,15 @@ export class AccessibilityMenu {
       return;
     }
 
-    // ♿ Aria: Keyboard navigation for Tabs (Up/Down Arrows)
-    if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
+    // ♿ Aria: Keyboard navigation for Tabs (Up/Down/Left/Right Arrows)
+    if (event.key === 'ArrowUp' || event.key === 'ArrowDown' || event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
         const activeElement = document.activeElement as HTMLElement;
         if (activeElement && activeElement.getAttribute('role') === 'tab') {
             event.preventDefault();
             const tabs = Array.from(this.container?.querySelectorAll('[role="tab"]') || []) as HTMLElement[];
             const currentIndex = tabs.indexOf(activeElement);
             if (currentIndex >= 0) {
-                let nextIndex = event.key === 'ArrowDown' ? currentIndex + 1 : currentIndex - 1;
+                let nextIndex = (event.key === 'ArrowDown' || event.key === 'ArrowRight') ? currentIndex + 1 : currentIndex - 1;
                 if (nextIndex >= tabs.length) nextIndex = 0;
                 if (nextIndex < 0) nextIndex = tabs.length - 1;
 
@@ -1253,6 +1253,14 @@ export class AccessibilityMenu {
         const firstFocusable = this.container?.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])') as HTMLElement;
         if (firstFocusable) firstFocusable.focus();
       }
+    }
+
+    // Re-establish focus trap after rendering new DOM
+    if (this.container) {
+      if (this.releaseFocusTrap) {
+        this.releaseFocusTrap();
+      }
+      this.releaseFocusTrap = trapFocusInside(this.container);
     }
   }
 

--- a/src/ui/save-menu/save-menu.ts
+++ b/src/ui/save-menu/save-menu.ts
@@ -129,8 +129,6 @@ export class SaveMenu {
         // Load slots
         await this.refreshSlots();
         this.render();
-
-        this.releaseFocusTrap = trapFocusInside(this.container);
     }
 
     /**
@@ -252,6 +250,12 @@ export class SaveMenu {
                 if (firstFocusable) firstFocusable.focus();
             }
         }
+
+        // Re-establish focus trap after rendering new DOM
+        if (this.releaseFocusTrap) {
+            this.releaseFocusTrap();
+        }
+        this.releaseFocusTrap = trapFocusInside(this.container);
     }
 
     private getTabs(): { id: MenuTab; label: string; icon: string }[] {


### PR DESCRIPTION
**Visual Change:**
No direct visual changes, purely UX and accessibility keyboard navigation improvements for menu overlays.

**"Juice" Factor:**
Fixes overlapping and leaking keyboard focus traps across dynamic re-renders. Tabbed menus now feel extremely snappy and responsive to power users and assistive technologies, eliminating dropped focus and permanently trapped tabs.

**Technical:**
Refactored focus management inside `save-menu.ts` and `accessibility-menu.ts`. Re-applied `trapFocusInside` safely after DOM changes inside `refreshMainPanel` and `render` blocks, and explicitly implemented WCAG standard `ArrowUp`/`ArrowDown`/`ArrowLeft`/`ArrowRight` navigation with `e.preventDefault()` for `role="tablist"` elements to stop the viewport from scrolling unintentionally.

---
*PR created automatically by Jules for task [615349025350877240](https://jules.google.com/task/615349025350877240) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added arrow key navigation support (Up, Down, Left, Right) to the Accessibility Menu, enabling users to cycle through tabs and navigate between sections seamlessly

* **Bug Fixes**
  * Improved focus management in accessibility and save menus to ensure focus containment remains intact following user interactions and interface updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->