### PR TITLE
♿ Aria: [UX improvement] Explicit File Input Button in Save Menu

### DIFF
--- a/src/ui/save-menu/save-menu.ts
+++ b/src/ui/save-menu/save-menu.ts
@@ -343,8 +343,8 @@ export class SaveMenu {
                 <div class="candy-io-area__label" id="import-label">Import Save Data</div>
                 <textarea class="candy-textarea" id="import-area" placeholder="Paste save data here or upload a file..." aria-labelledby="import-label" spellcheck="false"></textarea>
                 <div class="candy-save-menu__actions" style="margin-top: 15px;">
-                    <input type="file" class="candy-file-input" id="import-file" accept=".json,.txt">
-                    <label for="import-file" class="candy-file-label"><span aria-hidden="true">📁</span> Choose File</label>
+                    <input type="file" class="candy-file-input" id="import-file" accept=".json,.txt" tabindex="-1">
+                    <button type="button" class="candy-save-menu__btn candy-save-menu__btn--primary" id="import-file-btn"><span aria-hidden="true">📁</span> Choose File</button>
                     <button class="candy-save-menu__btn candy-save-menu__btn--primary" data-action="import-data">
                         <span aria-hidden="true">📥</span> Import Data
                     </button>
@@ -422,6 +422,11 @@ export class SaveMenu {
         // File input
         const fileInput = this.container.querySelector('#import-file') as HTMLInputElement;
         fileInput?.addEventListener('change', (e) => this.handleFileSelect(e));
+
+        const fileBtn = this.container.querySelector('#import-file-btn') as HTMLButtonElement;
+        if (fileBtn && fileInput) {
+            fileBtn.addEventListener('click', () => fileInput.click());
+        }
     }
 
     private handleKeydown(e: KeyboardEvent): void {


### PR DESCRIPTION
💡 What: Replaced the `<label>` triggering the "Import Data" file input with a `<button type="button">`.

🎯 Why: Screen readers and keyboard navigation (Tab routing) do not properly identify or trigger visually-styled `<label>` elements acting as inputs. Using an explicit `<button>` ensures proper `:focus-visible` styling and reliable Enter/Spacebar keyboard activation without JavaScript native focus traps dropping.

♿ Accessibility: Added `tabindex="-1"` to the hidden `<input type="file">` and utilized `button.click()` programmatic proxying for full WCAG keyboard compliance.

---
*PR created automatically by Jules for task [3248766258406142038](https://jules.google.com/task/3248766258406142038) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the file picker in the import/export interface with a dedicated "Choose File" button to enhance accessibility and user interaction with the feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->