### PR TITLE
🏗️ Architect: [Decoupled Camera from Physics]

### DIFF
--- a/src/core/main.ts
+++ b/src/core/main.ts
@@ -230,6 +230,9 @@ initWasm().then(async (wasmLoaded) => {
     loadingScreen.updateProgress(70, 'Positioning player...');
     const initialGroundY = getUnifiedGroundHeightTyped(camera.position.x, camera.position.z, getGroundHeight);
     camera.position.y = initialGroundY + 1.8;
+    // ⚡ FIX: Sync player explicitly to prevent a massive camera swoop frame 1
+    player.position.copy(camera.position);
+    player.velocity.set(0, 0, 0);
     console.log(`[Startup] Camera positioned at ground height: y=${camera.position.y.toFixed(2)}`);
 
     loadingScreen.updateProgress(100, 'Physics engine ready');

--- a/src/systems/physics/physics.ts
+++ b/src/systems/physics/physics.ts
@@ -183,9 +183,6 @@ export function triggerHarpoon(anchor: THREE.Vector3) {
 
 // Main Physics Update Loop
 export function updatePhysics(delta: number, camera: THREE.Camera, controls: any, keyStates: KeyStates, audioState: AudioState) {
-    // 0. Sync Player State with Camera
-    player.position.copy(camera.position);
-
     // 1. Update Global Environmental Modifiers (Wind, Groove)
     updateEnvironmentalModifiers(delta, audioState);
 
@@ -250,7 +247,10 @@ export function updatePhysics(delta: number, camera: THREE.Camera, controls: any
     }
 
     // Sync back
-    camera.position.copy(player.position);
+    camera.position.x = player.position.x;
+    camera.position.z = player.position.z;
+    // 🎨 PALETTE: Smooth vertical tracking (LERP) for better game feel
+    camera.position.y = THREE.MathUtils.lerp(camera.position.y, player.position.y, Math.min(delta * 15.0, 1.0));
 }
 
 function checkFloraDiscovery(playerPos: THREE.Vector3) {


### PR DESCRIPTION
Removed the forced `player.position.copy(camera.position)` so the camera no longer drives the physics body. The camera now explicitly tracks the player's X and Z coordinates and smoothly LERPs on the Y-axis. Added an initial camera snap to prevent swooping on startup.

---
*PR created automatically by Jules for task [13741636226862048493](https://jules.google.com/task/13741636226862048493) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unwanted camera movement at game startup.

* **Performance**
  * Optimized physics system for faster interaction handling with world elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->