### PR TITLE
⚡ Bolt: [Zero-Copy WASM Memory Bridge - Phase 1]

### DIFF
--- a/emscripten/build.sh
+++ b/emscripten/build.sh
@@ -188,6 +188,7 @@ declare -A ANIMATION_FUNCTIONS=(
     ["fastPow2"]="math"
     
     # Physics functions (physics.cpp)
+    ["initPhysicsMemory"]="physics"
     ["fastDistance"]="physics"
     ["smoothDamp"]="physics"
     ["updateParticles"]="physics"
@@ -386,7 +387,7 @@ else
 fi
 
 LINK_FLAGS="-O3 -std=c++17 -lembind -s USE_PTHREADS=1 -s PTHREAD_POOL_SIZE=4 -s WASM=1 -s WASM_BIGINT=0 \
--s ALLOW_MEMORY_GROWTH=1 -s TOTAL_STACK=16MB -s INITIAL_MEMORY=384MB -s MAXIMUM_MEMORY=256MB $ASSERTION_FLAG -s EXPORT_ES6=1 \
+-s ALLOW_MEMORY_GROWTH=1 -s TOTAL_STACK=16MB -s INITIAL_MEMORY=256MB -s MAXIMUM_MEMORY=512MB $ASSERTION_FLAG -s EXPORT_ES6=1 \
 -s EXPORTED_RUNTIME_METHODS=[\"ccall\",\"cwrap\",\"wasmMemory\"] -s MODULARIZE=1 -s EXPORT_NAME=createCandyNative \
 -s ENVIRONMENT=web,worker -s ERROR_ON_UNDEFINED_SYMBOLS=0 -s SHARED_MEMORY=1 \
 -matomics -fopenmp -msimd128 -mrelaxed-simd -ffast-math -pthread -L$SCRIPT_DIR -lomp"

--- a/emscripten/physics.cpp
+++ b/emscripten/physics.cpp
@@ -9,6 +9,21 @@ extern "C" float fastInvSqrt(float x);
 extern "C" {
 
 // =============================================================================
+// PHYSICS BATCH MEMORY
+// =============================================================================
+float* instanceMatrices = nullptr;
+
+EMSCRIPTEN_KEEPALIVE
+float* initPhysicsMemory(int maxEntities) {
+    if (instanceMatrices != nullptr) {
+        free(instanceMatrices);
+    }
+    instanceMatrices = (float*)malloc(maxEntities * 16 * sizeof(float));
+    return instanceMatrices;
+}
+
+
+// =============================================================================
 // PLAYER & PHYSICS SYSTEM
 // =============================================================================
 


### PR DESCRIPTION
Bottleneck: Serialization overhead when copying instance matrices between the physics thread and the main thread.
Fix: Implemented `initPhysicsMemory` in the Emscripten C++ module to allocate a contiguous block of memory on the WASM heap. This WASM memory is inherently a `SharedArrayBuffer` because of the `USE_PTHREADS` compilation flag. 
Impact: Lays the foundation for the Web Worker to expose this buffer directly to the main thread, eliminating `postMessage` structural cloning and saving significant CPU time and garbage collection per frame.

(Note: Also resolved an existing compilation failure in `emscripten/build.sh` by ensuring `MAXIMUM_MEMORY` is larger than `INITIAL_MEMORY`).

---
*PR created automatically by Jules for task [12890457268568173988](https://jules.google.com/task/12890457268568173988) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized memory configuration in multithreaded builds with adjusted initial and maximum memory allocation limits for improved resource efficiency.

* **New Features**
  * Introduced physics batch memory system for enhanced entity processing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->