### PR TITLE
⚡ Bolt: Fix VRAM leaks caused by undisposed temporary lights

### DIFF
--- a/src/rendering/shader-warmup.ts
+++ b/src/rendering/shader-warmup.ts
@@ -291,7 +291,11 @@ export class ShaderWarmup {
       // this.warmupGeometry is reused so we don't dispose it. However, the temporary mesh is removed.
       if (material instanceof MeshStandardNodeMaterial) {
         scene.children.forEach(child => {
-          if (child instanceof THREE.Light) scene.remove(child);
+          if (child instanceof THREE.Light) {
+             // ⚡ OPTIMIZATION: Disposed temporary warmup lights to prevent VRAM leaks.
+             child.dispose();
+             scene.remove(child);
+          }
         });
       }
       

--- a/src/systems/weather/weather-effects.ts
+++ b/src/systems/weather/weather-effects.ts
@@ -312,6 +312,8 @@ export class EffectsManager {
             }
         }
         if (lightningLight) {
+            // ⚡ OPTIMIZATION: Ensure temporary lights are disposed before removal to prevent VRAM leaks.
+            lightningLight.dispose();
             this.scene.remove(lightningLight);
         }
         if (rainbow) {


### PR DESCRIPTION
Bottleneck: VRAM Leaks and GPU memory exhaustion over time due to missing `.dispose()` calls on temporary `THREE.Light` objects (e.g. `lightningLight` and warmup lights) before removing them from the scene.
Fix: Added explicit `.dispose()` calls to `lightningLight` in `weather-effects.ts` and temporary lights in `shader-warmup.ts` right before calling `scene.remove(child)`.
Impact: Prevented VRAM leaks caused by orphaned shadow-map `WebGLRenderTarget` objects, stabilizing long-term GPU memory usage.

---
*PR created automatically by Jules for task [13585708824019595498](https://jules.google.com/task/13585708824019595498) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory cleanup during shader initialization to prevent resource leaks
  * Enhanced resource disposal in weather effects system to prevent video memory accumulation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->