### PR TITLE
♿ Aria: [UX improvement] Fix energy bar aria attributes

### DIFF
--- a/src/core/hud.ts
+++ b/src/core/hud.ts
@@ -128,7 +128,8 @@ export function updateEnergyBar(
 
     const energyPct = Math.max(0, Math.min(1, playerEnergy / playerMaxEnergy));
     hudEnergyFill.style.width = `${energyPct * 100}%`;
-    hudEnergyContainer.setAttribute('aria-valuenow', (energyPct * 10).toFixed(1));
+    hudEnergyContainer.setAttribute('aria-valuenow', playerEnergy.toFixed(1));
+    hudEnergyContainer.setAttribute('aria-valuemax', playerMaxEnergy.toFixed(1));
 
     // Pulse to the beat when health/energy is low (< 30%)
     if (energyPct < 0.3) {


### PR DESCRIPTION
💡 What: Updated the energy bar's ARIA attributes to use absolute values and dynamically set the maximum value.

🎯 Why: To ensure screen readers announce accurate energy levels instead of an arbitrary scaled value.

♿ Accessibility: Updated `aria-valuenow` and added `aria-valuemax` dynamically, adhering to WCAG 4.1.2.

---
*PR created automatically by Jules for task [7710644345729700213](https://jules.google.com/task/7710644345729700213) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved energy bar accessibility by correcting how current and maximum energy values are reported to assistive technologies, ensuring users receive accurate information about their energy status during gameplay.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/candy_world/pull/763)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->