### PR TITLE
⚡ Bolt: [Memory Rescue] Fix previewMushroom memory leak

### DIFF
--- a/src/core/main.ts
+++ b/src/core/main.ts
@@ -303,6 +303,9 @@ initWasm().then(async (wasmLoaded) => {
                 const idx = animatedFoliage.indexOf(previewMushroom);
                 if (idx > -1) animatedFoliage.splice(idx, 1);
 
+                const idxInter = interactiveObjects.indexOf(previewMushroom);
+                if (idxInter > -1) interactiveObjects.splice(idxInter, 1);
+
                 // Show loading screen for map generation phase
                 loadingScreen.show();
                 loadingScreen.startPhase('map-generation');


### PR DESCRIPTION
Bottleneck: The `previewMushroom` object created during startup was added to the `interactiveObjects` array but was never removed, causing a memory leak as the reference remained alive even after the mushroom was disposed.
Fix: Added logic to splice `previewMushroom` from the `interactiveObjects` array during the startup cleanup process.
Impact: Eliminates a persistent memory leak related to the startup preview mushroom.

---
*PR created automatically by Jules for task [2766678454273468091](https://jules.google.com/task/2766678454273468091) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the startup preview object remained interactive after being removed during world initialization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/candy_world/pull/766)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->