### PR TITLE
♿ Aria: [UX improvement] Accessibility Menu Keyboard Focus

### DIFF
--- a/src/ui/accessibility-menu.ts
+++ b/src/ui/accessibility-menu.ts
@@ -276,9 +276,11 @@ export class AccessibilityMenu {
       btn.type = 'button';
       btn.textContent = section.label;
       btn.id = `tab-${section.id}`;
+      btn.classList.add('a11y-tab');
       btn.setAttribute('role', 'tab');
       btn.setAttribute('aria-selected', (section.id === this.currentSection).toString());
       btn.setAttribute('aria-controls', `panel-${section.id}`);
+      btn.tabIndex = section.id === this.currentSection ? 0 : -1;
       btn.style.cssText = `
         width: 100%;
         padding: 12px 20px;
@@ -1283,6 +1285,7 @@ export class AccessibilityMenu {
       const sections: MenuSection[] = ['presets', 'motor', 'visual', 'cognitive', 'auditory', 'screenReader'];
       const isActive = sections[index] === this.currentSection;
       btn.setAttribute('aria-selected', isActive.toString());
+      btn.tabIndex = isActive ? 0 : -1;
       btn.style.background = isActive ? 'var(--menu-active, #4a4a4a)' : 'transparent';
     });
   }

--- a/style.css
+++ b/style.css
@@ -547,3 +547,10 @@ kbd.key.key-highlight {
 #dpad-backward { border-top-left-radius: 6px;    border-top-right-radius: 6px;    margin-top: 2px;    }
 #dpad-left     { border-top-right-radius: 6px;   border-bottom-right-radius: 6px; margin-right: 2px;  }
 #dpad-right    { border-top-left-radius: 6px;    border-bottom-left-radius: 6px;  margin-left: 2px;   }
+
+/* ♿ Aria: Accessibility Menu Tabs Focus Styling */
+.a11y-tab[tabindex="0"]:focus-visible {
+    outline: 3px solid #fff;
+    outline-offset: -3px;
+    box-shadow: 0 0 12px currentColor;
+}


### PR DESCRIPTION
💡 **What**: Added proper `tabIndex` management for the accessibility menu tabs, ensuring that only the active tab is in the document tab order. Additionally, added focus states so active tabs are properly styled when navigating via keyboard.
🎯 **Why**: Previously, all tabs were left in the standard tab order. Properly managing the `tabIndex` attribute is a standard ARIA pattern for tab lists that helps ensure smooth and accurate keyboard navigation. Keyboard users can navigate to the active tab via `Tab`, and switch between tabs via arrow keys without tabbing through the entire list.
♿ **Accessibility**: The change implements correct ARIA keyboard navigation semantics by toggling `tabindex` between `0` (active) and `-1` (inactive).

---
*PR created automatically by Jules for task [4818191377713854564](https://jules.google.com/task/4818191377713854564) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced keyboard navigation with improved focus management for sidebar tabs
* **Style**
  * Added visible focus indicators with outline styling for keyboard accessibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/candy_world/pull/778)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->