### PR TITLE
♿ Aria: [UX improvement] Save Menu Polish and Empty States

### DIFF
--- a/src/ui/save-menu/save-menu-styles.ts
+++ b/src/ui/save-menu/save-menu-styles.ts
@@ -174,6 +174,7 @@ export const MENU_STYLES = `
 
 .candy-save-slot:active {
     transform: translateY(0) scale(0.98);
+    filter: brightness(0.95);
     transition-duration: 0.05s;
 }
 

--- a/src/ui/save-menu/save-slots.ts
+++ b/src/ui/save-menu/save-slots.ts
@@ -51,7 +51,7 @@ export function renderSlot(
             ` : '<div class="candy-save-slot__info">Click to save</div>'}
             <div class="candy-save-slot__actions">
                 ${forSave || isEmpty ? `
-                    <button class="candy-save-slot__btn candy-save-slot__btn--primary" data-action="${forSave ? 'overwrite' : 'save'}" data-slot="${slot.slotId}" aria-label="${forSave && !isEmpty ? `Overwrite ${slot.slotName}` : `Save to ${slot.slotName}`}">
+                    <button class="candy-save-slot__btn candy-save-slot__btn--primary" data-action="${forSave ? 'overwrite' : 'save'}" data-slot="${slot.slotId}" aria-label="${isEmpty ? `Available Save Slot: ${slot.slotName}` : (forSave ? `Overwrite ${slot.slotName}` : `Save to ${slot.slotName}`)}">
                         ${forSave && !isEmpty ? 'Overwrite' : 'Save'}
                     </button>
                 ` : `
@@ -88,7 +88,7 @@ export function renderLoadTab(
         return `
             <div class="candy-empty-state">
                 <div class="candy-empty-state__icon" aria-hidden="true">📝</div>
-                <div class="candy-empty-state__text">No save files found</div>
+                <div class="candy-empty-state__text">No memories found yet. Embark on a journey to save your progress!</div>
                 ${currentMode === 'full' ? `
                 <div class="candy-save-menu__actions">
                     <button class="candy-save-menu__btn candy-save-menu__btn--primary" data-action="switch-to-save">


### PR DESCRIPTION
💡 **What:** 
- Updated empty state fallback messages and visual styles in the Save Menu.
- Added a `brightness(0.95)` filter to `.candy-save-slot:active` combined with the existing transform scale.
- Changed the empty state text from "No save files found" to "No memories found yet. Embark on a journey to save your progress!".
- Added specific `.aria-label` logic when rendering save slots to announce "Available Save Slot: [Slot Name]" for empty slots to screen readers.

🎯 **Why:** 
To enhance the visual "Game Feel" through responsive clicking (`:active` states) and to improve the empty-state experience with more encouraging copy.

♿ **Accessibility:**
The implementation enhances visual accessibility through distinct active states, and adds semantic screen-reader context to empty slots to reduce ambiguity around whether an empty row is interactable.

---
*PR created automatically by Jules for task [11072208163366733559](https://jules.google.com/task/11072208163366733559) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visual feedback when interacting with save slots

* **User Experience**
  * Improved clarity for identifying available save slots
  * More engaging and thematic messaging when no saves exist

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/candy_world/pull/785)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->