### PR TITLE
fix: eliminate libopenmpt 404, importmap 404s, and audio Promise hang

### DIFF
--- a/index.html
+++ b/index.html
@@ -528,27 +528,24 @@
         }
     </style>
     
-    <script type="importmap">
-        {
-            "imports": {
-                "three": "./node_modules/three/build/three.module.js",
-                "three/webgpu": "./node_modules/three/build/three.webgpu.js",
-                "three/tsl": "./node_modules/three/build/three.tsl.js",
-                "three/examples/jsm/": "./node_modules/three/examples/jsm/"
-            }
-        }
-    </script>
-
     <script>
-        // Use a Promise to notify the app when libopenmpt is ready
+        // Use a Promise to notify the app when libopenmpt is ready.
+        // libopenmpt.js is a wasm2js build — all WASM code is compiled to asm.js,
+        // so no separate .wasm file is fetched. We intercept instantiateWasm to
+        // prevent the fallback fetch(undefined) → 404 path from ever running.
         window.libopenmptReady = new Promise(resolve => {
             window.libopenmpt = {
                 // Limit memory to 32MB to prevent "Array buffer allocation failed"
-                // The library file has been patched to handle this Number without BigInt errors.
-                INITIAL_MEMORY: 33554432, 
-                
+                INITIAL_MEMORY: 33554432,
+
+                // wasm2js: short-circuit the WASM instantiation path so no external
+                // fetch is attempted. The asmFunc (asm.js) takes over automatically.
+                instantiateWasm: function(imports, successCallback) {
+                    return {};
+                },
+
                 onRuntimeInitialized: function () {
-                    console.log('libopenmpt runtime initialized via local script.');
+                    console.log('[libopenmpt] Runtime initialized (wasm2js mode).');
                     resolve(this);
                 }
             };

--- a/src/audio/audio-system.ts
+++ b/src/audio/audio-system.ts
@@ -501,13 +501,31 @@ export class AudioSystem {
         console.log('[AudioSystem] Using ScriptProcessorNode (compatibility mode)');
         if (window.setLoadingStatus) window.setLoadingStatus("Audio ScriptProcessor Ready...");
 
-        // Wait for libopenmpt to be ready
+        // Wait for libopenmpt to be ready — 5 s timeout for Silent Mode fallback
         if (!window.libopenmpt) {
             console.log('[AudioSystem] Waiting for libopenmpt...');
-            await window.libopenmptReady;
+            try {
+                await Promise.race([
+                    window.libopenmptReady,
+                    new Promise<never>((_, reject) =>
+                        setTimeout(() => reject(new Error('libopenmpt init timeout')), 5000)
+                    ),
+                ]);
+            } catch (err) {
+                console.warn('[AudioSystem] WASM failed, starting in Silent Mode:', err);
+                window.libopenmpt = null;
+                this.isReady = true;
+                return;
+            }
         }
 
-        this.libopenmpt = window.libopenmpt!;
+        if (!window.libopenmpt) {
+            console.warn('[AudioSystem] libopenmpt unavailable, starting in Silent Mode.');
+            this.isReady = true;
+            return;
+        }
+
+        this.libopenmpt = window.libopenmpt;
         
         // Create ScriptProcessorNode (4096 samples buffer, 0 inputs, 2 outputs for stereo)
         const bufferSize = 4096;


### PR DESCRIPTION
## Summary

- **Remove `<script type="importmap">`** from `index.html` — pointed to `./node_modules/three/...` which is absent in production `dist/`. Vite already bundles Three.js into the `vendor` chunk, so this block was redundant *and* broke production loads with 404s on every Three.js import.

- **Fix libopenmpt wasm2js 404** — added `Module.instantiateWasm` no-op to the `window.libopenmpt` init object in `index.html`. `libopenmpt.js` is a wasm2js build (all compiled to asm.js); without this hook Emscripten falls through to `fetch(wasmBinaryFile)` where `wasmBinaryFile` is `undefined` (because `findWasmBinary()` is an empty no-op in wasm2js mode), producing a spurious `GET /undefined 404` on every load.

- **Fix audio Promise hang** — wrapped `await window.libopenmptReady` in `audio-system.ts` with a `Promise.race` / 5 000 ms timeout. On timeout or rejection the game logs `[AudioSystem] WASM failed, starting in Silent Mode`, sets `window.libopenmpt = null`, and proceeds — instead of hanging indefinitely at the loading screen.

## Test plan

- [ ] `npm run build` completes without error
- [ ] No `GET /undefined 404` in browser Network tab on fresh load
- [ ] No importmap-related 404s (`/node_modules/three/...`)
- [ ] Killing the network after page load (to simulate libopenmpt timeout) shows "Silent Mode" warning in console and game still starts
- [ ] Normal load: audio plays as before

https://claude.ai/code/session_01AfXWYdyGrMXKUmtjQQAqyh

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfXWYdyGrMXKUmtjQQAqyh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced audio system initialization with timeout protection (5 seconds). If the audio module fails to load, the system gracefully switches to silent mode, allowing the application to continue functioning smoothly. Optimized WASM build configuration for improved reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/candy_world/pull/787)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->