### PR TITLE
refactor: remove redundant TS type annotations in traverse cleanup ca…

### DIFF
--- a/src/core/main.ts
+++ b/src/core/main.ts
@@ -290,14 +290,14 @@ initWasm().then(async (wasmLoaded) => {
             setTimeout(async () => {
                 try {
                 scene.remove(previewMushroom);
-                previewMushroom.traverse((child: THREE.Object3D) => {
+                previewMushroom.traverse((child) => {
                     const mesh = child as THREE.Mesh;
                     if (mesh.geometry) mesh.geometry.dispose();
                     if (mesh.material) {
                         if (Array.isArray(mesh.material)) {
-                            mesh.material.forEach((m: THREE.Material) => m.dispose());
+                            mesh.material.forEach(m => m.dispose());
                         } else {
-                            (mesh.material as THREE.Material).dispose();
+                            mesh.material.dispose();
                         }
                     }
                 });


### PR DESCRIPTION
…llback

TypeScript infers (child) from traverse's signature and (m) from the Array.isArray guard, so explicit annotations were dead weight. Dropping them also prevents acorn/Rollup from choking on the annotations if the esbuild TS-strip pass hasn't run yet (seen as parse error in some build environments).

https://claude.ai/code/session_01AfXWYdyGrMXKUmtjQQAqyh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized resource cleanup when entering the world.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/candy_world/pull/789)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->