### PR TITLE
fix: remove FogExp2 from scene.fog to prevent .density crash on undef…

### DIFF
--- a/src/world/generation.ts
+++ b/src/world/generation.ts
@@ -189,9 +189,14 @@ export function initWorld(scene: THREE.Scene, weatherSystem: WeatherSystem, load
     ground.receiveShadow = true;
     scene.add(ground);
 
-    // 2. OVERRIDE FOG for Compact World
+    // 2. Update fog colour for compact world.
+    // scene.fogNode (set in init.ts) drives actual WebGPU rendering via TSL rangeFog.
+    // Keep scene.fog as THREE.Fog (not FogExp2) so WeatherSystem's stale reference
+    // stays valid and renderer code never has to read FogExp2.density.
     const fogColor = new THREE.Color(CONFIG.colors.fog || 0xFFC5D3);
-    scene.fog = new THREE.FogExp2(fogColor, 0.012);
+    if (scene.fog instanceof THREE.Fog) {
+        scene.fog.color.set(fogColor);
+    }
     scene.background = fogColor;
 
     // Initialize Vegetation Systems


### PR DESCRIPTION
…ined

generation.ts was replacing scene.fog (THREE.Fog) with a new THREE.FogExp2, creating two problems:
1. WeatherSystem captures scene.fog at construction time; the replacement left it holding a stale Fog reference it could never update.
2. Three.js / WebGPU renderer code that reads scene.fog.density during world generation could find an intermediate undefined scene.fog and throw "Cannot read properties of undefined (reading 'density')".

The TSL scene.fogNode set in init.ts already drives all actual WebGPU fog rendering via rangeFog. Keeping scene.fog as THREE.Fog and simply updating its colour is sufficient; no FogExp2 is needed.

https://claude.ai/code/session_01AfXWYdyGrMXKUmtjQQAqyh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fog rendering behavior in the compact world view. The fog color now updates correctly on existing fog objects, removing the previous behavior that replaced them with alternative fog settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/candy_world/pull/790)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->