### PR TITLE
Fix foliageCaves imported from wrong module

### DIFF
--- a/src/systems/physics/physics-updates.ts
+++ b/src/systems/physics/physics-updates.ts
@@ -34,9 +34,9 @@ import {
     uploadCollisionObjects, initDynamicFoliageBridge
 } from '../../utils/wasm-loader.js';
 import {
-    foliageMushrooms, foliageTrampolines, foliageClouds, 
-    foliageTraps, foliageGeysers, foliagePortamentoPines, 
-    foliagePanningPads, animatedFoliage, foliageCaves
+    foliageMushrooms, foliageTrampolines, foliageClouds,
+    foliageTraps, foliageGeysers, foliagePortamentoPines,
+    foliagePanningPads, animatedFoliage
 } from '../../world/state.ts';
 import {
     player,
@@ -49,7 +49,8 @@ import {
     _scratchCamRight,
     _scratchTargetVel,
     _scratchUp,
-    PLAYER_HEIGHT_OFFSET
+    PLAYER_HEIGHT_OFFSET,
+    foliageCaves
 } from './physics-types.js';
 import {
     calculateMovementInput,


### PR DESCRIPTION
## Summary

- `foliageCaves` was being imported from `src/world/state.ts`, where it is not exported
- The correct source is `src/systems/physics/physics-types.ts`, which already defines and exports `foliageCaves: THREE.Object3D[]`
- Moved `foliageCaves` out of the `state.ts` import group and into the existing `physics-types.js` import in `physics-updates.ts`

## Test plan

- [ ] Confirm build succeeds without the \"foliageCaves is not exported\" Vite error
- [ ] Run `npm run test:wasm` to verify physics bounds still pass

https://claude.ai/code/session_01AscJJ2KJT85GuGEdvBZCSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01AscJJ2KJT85GuGEdvBZCSA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No user-facing changes in this release. This update involves internal code organization and does not affect functionality or user experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/candy_world/pull/803?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->