### PR TITLE
Fix missing wasm-batch exports and stray brace in percussion C++

### DIFF
--- a/emscripten/animation_batch_percussion.cpp
+++ b/emscripten/animation_batch_percussion.cpp
@@ -364,18 +364,3 @@ void batchGeyserErupt_c(float* particles, int count, float time, float kick, flo
     }
 }
 
-/**
- * @brief Batch Retrigger Effect (SIMD)
- * 
- * Stutter/retrigger visual effect that creates rapid position jumps.
- * Useful for glitch-style animations synced to audio retrigger effects.
- * 
- * Math: retriggerPhase = frac(time * retriggerSpeed)
- *       jump = sin(retriggerPhase * PI * 2) * intensity * (1.0 - retriggerPhase)
- *       scale = 1.0 + jump * 0.5
- * 
- * The intensity fades over each retrigger cycle creating a decaying stutter.
- */
-EMSCRIPTEN_KEEPALIVE
-
-}

--- a/src/utils/wasm-batch.ts
+++ b/src/utils/wasm-batch.ts
@@ -49,13 +49,32 @@ export {
 
 // Re-export animation wrappers
 export {
+    batchAnimationCalc,
+    batchShiver_c,
+    batchSpring_c,
+    batchFloat_c,
+    batchCloudBob_c,
+    deformWave_c,
+    deformJiggle_c,
+    deformWobble_c,
+    batchUpdateLODMatrices_c,
+    batchScaleMatrices_c,
+    batchFadeColors_c,
+    batchFrustumCull_c,
+    batchDistanceCullIndexed_c,
     batchShiverHighLevel,
     batchSpringHighLevel,
     batchFloatHighLevel,
     batchCloudBobHighLevel,
     batchVineSwayHighLevel,
     batchGeyserEruptHighLevel,
-    batchRetriggerHighLevel
+    batchRetriggerHighLevel,
+    fluidInit,
+    fluidStep,
+    fluidAddDensity,
+    fluidAddVelocity,
+    getFluidDensityView,
+    updateParticlesWASM
 } from './wasm-batch-animation.ts';
 
 // Re-export particle operations


### PR DESCRIPTION
- Re-export all functions from wasm-batch-animation.ts through the wasm-batch.ts barrel so wasm-loader.js can resolve fluidInit and related imports
- Remove orphaned docblock, EMSCRIPTEN_KEEPALIVE, and extraneous closing brace at end of animation_batch_percussion.cpp (the batchRetrigger_simd implementation lives in animation_batch_simd.cpp)

https://claude.ai/code/session_01AscJJ2KJT85GuGEdvBZCSA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused commented code.

* **Refactor**
  * Expanded module exports to include additional animation and fluid simulation components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/candy_world/pull/804?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->