### PR TITLE
Fix type-only re-export of MenuSection and MenuItem

### DIFF
--- a/src/ui/accessibility-menu.ts
+++ b/src/ui/accessibility-menu.ts
@@ -14,7 +14,7 @@
  */
 
 import { AccessibilityMenuHandlers } from './accessibility-menu-handlers';
-export { MenuSection, MenuItem } from './accessibility-menu-core';
+export type { MenuSection, MenuItem } from './accessibility-menu-core';
 export { AccessibilityMenuRendering } from './accessibility-menu-rendering';
 export { AccessibilityMenuHandlers } from './accessibility-menu-handlers';
 


### PR DESCRIPTION
MenuSection is declared as 'export type' in accessibility-menu-core.ts, so Rollup cannot resolve it through a value re-export. Use 'export type' in the barrel so the bundler handles it correctly.

https://claude.ai/code/session_01AscJJ2KJT85GuGEdvBZCSA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal type export handling for the accessibility menu module, with no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/candy_world/pull/805?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->