### PR TITLE
Remove orphaned EMSCRIPTEN_KEEPALIVE and stray brace in melodic C++

### DIFF
--- a/emscripten/animation_batch_melodic.cpp
+++ b/emscripten/animation_batch_melodic.cpp
@@ -437,6 +437,3 @@ void batchPanningBob_c(float* input, int count, float time, float panActivity, f
     }
 }
 
-EMSCRIPTEN_KEEPALIVE
-
-}


### PR DESCRIPTION
Same pattern as percussion: an incomplete stub was left at the end of animation_batch_melodic.cpp with no function body, causing a compiler error. The orphaned comment block was already removed; this removes the leftover macro and extraneous closing brace.

https://claude.ai/code/session_01AscJJ2KJT85GuGEdvBZCSA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed stray code artifact to improve code quality and build cleanliness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/candy_world/pull/806?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->