### PR TITLE
Add forward declarations for percussion and melodic functions in effects

### DIFF
--- a/emscripten/animation_batch_effects.cpp
+++ b/emscripten/animation_batch_effects.cpp
@@ -12,6 +12,19 @@
 
 extern "C" {
 
+// Forward declarations for functions defined in animation_batch_percussion.cpp
+void batchSnareSnap_c(float* input, int count, float time, float snareTrigger, float* output);
+void batchAccordion_c(float* input, int count, float time, float intensity, float* output);
+void batchCymbalShake_c(float* input, int count, float time, float highFreq, float intensity, float* output);
+void batchGeyserErupt_c(float* particles, int count, float time, float kick, float* output);
+
+// Forward declarations for functions defined in animation_batch_melodic.cpp
+void batchFiberWhip_c(float* input, int count, float time, float leadVol, int isActive, float* output);
+void batchSpiralWave_c(float* input, int count, float time, float intensity, float groove, float* output);
+void batchVibratoShake_c(float* input, int count, float time, float vibratoAmount, float intensity, float* output);
+void batchTremoloPulse_c(float* input, int count, float time, float tremoloAmount, float intensity, float* output);
+void batchPanningBob_c(float* input, int count, float time, float panActivity, float intensity, float* output);
+
 // Forward declarations for functions defined in animation_batch_foliage.cpp
 void batchShiver_c(float* input, int count, float time, float intensity, float* output);
 void batchSpring_c(float* input, int count, float time, float intensity, float* output);


### PR DESCRIPTION
The build compiles each .cpp standalone, so effects.cpp needs forward declarations for every function it calls that lives in another file:
- batchSnareSnap_c, batchAccordion_c, batchCymbalShake_c, batchGeyserErupt_c (defined in animation_batch_percussion.cpp)
- batchFiberWhip_c, batchSpiralWave_c, batchVibratoShake_c, batchTremoloPulse_c, batchPanningBob_c (defined in animation_batch_melodic.cpp)

https://claude.ai/code/session_01AscJJ2KJT85GuGEdvBZCSA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code organization updates to support animation batch processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/candy_world/pull/809?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->