### PR TITLE
⚡ Bolt: [GC Spike Fix - Wind Profiler Zero-Allocation]

### DIFF
--- a/src/foliage/wind-compute.ts
+++ b/src/foliage/wind-compute.ts
@@ -387,14 +387,27 @@ export class WindPerformanceProfiler {
             return { averageFPS: 0, minFPS: 0, maxFPS: 0, totalFrames: 0, duration: 0 };
         }
         
-        const fpsValues = this.frameTimings.map(dt => 1000 / Math.max(dt, 0.1));
         const duration = performance.now() - this.profileStartTime;
         
+        // ⚡ OPTIMIZATION: Eliminate .map() and .reduce() arrays to prevent GC spikes in hot paths
+        let sum = 0;
+        let minFPS = Infinity;
+        let maxFPS = -Infinity;
+        const count = this.frameTimings.length;
+
+        for (let i = 0; i < count; i++) {
+            const dt = this.frameTimings[i];
+            const fps = 1000 / Math.max(dt, 0.1);
+            sum += fps;
+            if (fps < minFPS) minFPS = fps;
+            if (fps > maxFPS) maxFPS = fps;
+        }
+
         return {
-            averageFPS: fpsValues.reduce((a, b) => a + b, 0) / fpsValues.length,
-            minFPS: Math.min(...fpsValues),
-            maxFPS: Math.max(...fpsValues),
-            totalFrames: this.frameTimings.length,
+            averageFPS: sum / count,
+            minFPS: minFPS,
+            maxFPS: maxFPS,
+            totalFrames: count,
             duration
         };
     }


### PR DESCRIPTION
Bottleneck: The `windProfiler.stopProfiling()` method was using memory-allocating array methods (`.map()`, `.reduce()`, and spread operators `...`) to calculate FPS statistics, causing potential Garbage Collection (GC) spikes and max call stack errors.
Fix: Replaced the array methods with a single, zero-allocation `for` loop that calculates the sum, min, and max FPS in one pass.
Impact: Eliminated temporary object and array allocations in the performance tracking logic, preventing GC spikes and ensuring stable tracking even with large arrays.

---
*PR created automatically by Jules for task [14440776690256237026](https://jules.google.com/task/14440776690256237026) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved performance profiling calculation efficiency to maintain consistent result accuracy with optimized internal processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/candy_world/pull/813?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->