### PR TITLE
Fix WGSL textureLoad error in wind compute texture

### DIFF
--- a/src/foliage/wind-compute.ts
+++ b/src/foliage/wind-compute.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import { DataTexture, Vector2, Vector4, RGBAFormat, FloatType, NearestFilter, RepeatWrapping } from 'three';
+import { DataTexture, Vector2, Vector4, RGBAFormat, HalfFloatType, NearestFilter, RepeatWrapping } from 'three';
 import { textureStore, instanceIndex, Fn, float, vec4, vec2, ivec2, mx_noise_float, sin, cos, max, min, uniform, floor } from 'three/tsl';
 
 // WGSL-compatible modulo: x - y * floor(x / y)
@@ -83,7 +83,7 @@ export class WindComputeSystem {
         
         // Create the storage texture for compute shader
         const storageTexture = new StorageTexture(WIND_TEXTURE_SIZE, WIND_TEXTURE_SIZE);
-        storageTexture.type = FloatType;
+        storageTexture.type = HalfFloatType;
         storageTexture.minFilter = NearestFilter;
         storageTexture.magFilter = NearestFilter;
         storageTexture.wrapS = RepeatWrapping;


### PR DESCRIPTION
## Summary

- `WindComputeSystem`'s `StorageTexture` was typed as `FloatType` (`rgba32float`), which is non-filterable in WebGPU
- When Three.js TSL generates WGSL for a `texture()` call on a non-filterable `texture_2d<f32>`, it emits `textureLoad` without the required mip-level argument, causing a WGSL parse error at shader compile time
- Changed to `HalfFloatType` (`rgba16float`), which is filterable — TSL now generates `textureSample` instead, matching the existing pattern in `ground-heightmap.ts` and `fluid_system.ts`

## Test plan

- [ ] Build the project (`npm run build`)
- [ ] Launch dev server (`npm run dev`) and verify no WGSL parse error in browser console
- [ ] Confirm foliage wind sway animation still works correctly
- [ ] Run WASM physics test: `npm run test:wasm`
- [ ] Run smoke test: `npm run test`

https://claude.ai/code/session_01U9igJtvevkaittGHyMuLnn

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9igJtvevkaittGHyMuLnn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted texture precision settings in wind simulation rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/candy_world/pull/816?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->