### PR TITLE
🎨 Palette: [UX improvement] Add juicy overlay animations and focus trapping to Save Menu

### DIFF
--- a/src/ui/save-menu/save-menu-styles.ts
+++ b/src/ui/save-menu/save-menu-styles.ts
@@ -18,12 +18,17 @@ export const MENU_STYLES = `
     align-items: center;
     z-index: 10000;
     font-family: 'Segoe UI', system-ui, sans-serif;
-    animation: fadeIn 0.2s ease;
+    animation: fadeIn 0.3s ease;
 }
 
 @keyframes fadeIn {
     from { opacity: 0; }
     to { opacity: 1; }
+}
+
+@keyframes fadeOut {
+    from { opacity: 1; }
+    to { opacity: 0; }
 }
 
 .candy-save-menu__container {
@@ -36,12 +41,17 @@ export const MENU_STYLES = `
     overflow-y: auto;
     box-shadow: 0 25px 50px rgba(0, 0, 0, 0.5);
     border: 1px solid rgba(255, 255, 255, 0.1);
-    animation: slideUp 0.3s ease;
+    animation: juicyPopIn 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards;
 }
 
-@keyframes slideUp {
-    from { transform: translateY(20px); opacity: 0; }
-    to { transform: translateY(0); opacity: 1; }
+@keyframes juicyPopIn {
+    from { transform: scale(0.95); opacity: 0; }
+    to { transform: scale(1); opacity: 1; }
+}
+
+@keyframes juicyPopOut {
+    from { transform: scale(1); opacity: 1; }
+    to { transform: scale(0.95); opacity: 0; }
 }
 
 .candy-save-menu__header {

--- a/src/ui/save-menu/save-menu.ts
+++ b/src/ui/save-menu/save-menu.ts
@@ -137,7 +137,7 @@ export class SaveMenu {
             if (this.container && this.isOpen()) {
                 this.releaseFocusTrap = trapFocusInside(this.container);
             }
-        }, 200);
+        }, 300);
     }
 
     /**
@@ -147,7 +147,11 @@ export class SaveMenu {
         if (!this.container) return;
 
         // Add exit animation
-        this.container.style.animation = 'slideUp 0.2s ease reverse';
+        this.container.style.animation = 'fadeOut 0.3s ease forwards';
+        const containerInner = this.container.querySelector('.candy-save-menu__container') as HTMLElement;
+        if (containerInner) {
+            containerInner.style.animation = 'juicyPopOut 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards';
+        }
         
         setTimeout(() => {
             if (this.releaseFocusTrap) {
@@ -164,7 +168,7 @@ export class SaveMenu {
             }
 
             this.onCloseCallback?.();
-        }, 200);
+        }, 300);
     }
 
     /**


### PR DESCRIPTION
Visual Change: Replaced generic fade-in/slide-up with new `@keyframes juicyPopIn` and `juicyPopOut` that scale with a cubic-bezier for a slight overshoot/bounce.
"Juice" Factor: The menu feels significantly more snappy and responsive, opening with a premium pop effect and closing gracefully.
Technical: Updated `trapFocusInside` removal timeout in `save-menu.ts` to exactly match the 300ms CSS transition duration, ensuring the element stays correctly focused and visible during the full out-animation without leaking focus or jarring removals.

---
*PR created automatically by Jules for task [11590251127527510514](https://jules.google.com/task/11590251127527510514) started by @ford442*