### PR TITLE
Fix WGSL errors: gl_PointCoord and textureLoad missing mip level

### DIFF
--- a/src/compute/particle_compute.ts
+++ b/src/compute/particle_compute.ts
@@ -31,7 +31,11 @@ import {
     cos,
     sin,
     If,
-    Fn
+    Fn,
+    uv,
+    distance,
+    smoothstep,
+    vec2
 } from 'three/tsl';
 import { StorageInstancedBufferAttribute, PointsNodeMaterial } from 'three/webgpu';
 
@@ -409,13 +413,17 @@ export class ComputeParticleSystem {
 
         material.positionNode = particlePos.xyz;
 
+        // Soft circular disc mask via uv() prevents Three.js from emitting
+        // gl_PointCoord (a GLSL-only built-in) in the generated WGSL shader.
+        const pointCircle = smoothstep(float(0.5), float(0.2), distance(uv(), vec2(0.5, 0.5)));
+
         if (this.type === 'rain') {
             material.sizeNode = float(size).add(this.uBassIntensity.mul(0.5));
             const targetOpacity = float(0.4).add(this.uIntensity.mul(0.6));
-            material.opacityNode = targetOpacity.mul(life);
+            material.opacityNode = targetOpacity.mul(life).mul(pointCircle);
         } else if (this.type === 'mist') {
             const targetOpacity = float(0.3).add(this.uMelodyVolume.mul(0.4));
-            material.opacityNode = targetOpacity.mul(life);
+            material.opacityNode = targetOpacity.mul(life).mul(pointCircle);
         } else {
             material.sizeNode = float(0.2).mul(life); // Shrink as they die
             material.colorNode = vec4(1.0, 0.5, 0.2, life); // Simple fade

--- a/src/foliage/discovery-effect.ts
+++ b/src/foliage/discovery-effect.ts
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { PointsNodeMaterial } from 'three/webgpu';
 import {
-    time, color, positionLocal, vec3, attribute, float,
+    time, color, positionLocal, vec3, vec4, attribute, float,
     mix, sin, cos, positionWorld, abs, step
 } from 'three/tsl';
 
@@ -103,7 +103,7 @@ export function createDiscoveryEffect() {
     // Clamp to 0 if outside active window
     const isActive = step(float(0.0), normalizedAge).mul(step(normalizedAge, float(1.0)));
 
-    material.colorNode = baseColor.mul(opacity).mul(isActive);
+    material.colorNode = vec4(baseColor, opacity.mul(isActive));
 
     const mesh = new THREE.Points(geometry, material);
     mesh.frustumCulled = false; // Always render when triggered

--- a/src/foliage/environment.ts
+++ b/src/foliage/environment.ts
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import { MeshStandardNodeMaterial, PointsNodeMaterial } from 'three/webgpu';
-import { time, vec3, positionLocal, length, sin, cos, color as tslColor, attribute, float, uniform, mix, smoothstep, color, positionWorld, normalWorld, floor } from 'three/tsl';
+import { time, vec3, vec4, positionLocal, length, sin, cos, color as tslColor, attribute, float, uniform, mix, smoothstep, color, positionWorld, normalWorld, floor } from 'three/tsl';
 
 // WGSL-compatible modulo: x - y * floor(x / y)
 // Note: Converts inputs to float first since WGSL floor() only works on floats
@@ -232,6 +232,9 @@ export function createKickDrumGeyser(options: KickDrumGeyserOptions = {}) {
         finalY,
         positionLocal.z.add(jitterZ).mul(uEruptionStrength)
     );
+    // Provide a vec4 colorNode so Three.js doesn't fall back to gl_PointCoord
+    // (a GLSL-only built-in) when generating the WGSL disc-mask for point sprites.
+    plumeMat.colorNode = vec4(tslColor(color), float(0.8));
 
     const plume = new THREE.Points(plumeGeo, plumeMat);
     plume.visible = false;

--- a/src/foliage/simple-flower-batcher.ts
+++ b/src/foliage/simple-flower-batcher.ts
@@ -15,7 +15,7 @@ import {
     uAudioLow,
     uPlayerPosition
 } from './index.ts';
-import { attribute, color as tslColor, positionLocal, vec3, float, mx_noise_float, mix, sin, smoothstep, normalize, length, positionWorld } from 'three/tsl';
+import { attribute, color as tslColor, positionLocal, vec3, float, mx_noise_float, mix, sin, smoothstep, normalize, length, positionWorld, uv, distance, vec2 } from 'three/tsl';
 import { foliageGroup } from '../world/state.ts';
 import { CONFIG } from '../core/config.ts';
 import { uTwilight } from './sky.ts';
@@ -271,10 +271,9 @@ export class SimpleFlowerBatcher {
         const touchPulse = push.mul(0.15);
         pollenMat.sizeNode = float(0.05).add(audioPulse).add(touchPulse);
 
-        // Opacity: Fade out if very far from player? Or always visible?
-        // Let's keep them visible but subtle.
-        // Fade out slightly when pushed to avoid hard edges?
-        pollenMat.opacityNode = float(0.8);
+        // Circular soft-disc mask using uv() to avoid the gl_PointCoord WGSL error.
+        const pollenCircle = smoothstep(float(0.5), float(0.2), distance(uv(), vec2(0.5, 0.5)));
+        pollenMat.opacityNode = float(0.8).mul(pollenCircle);
 
         this.pollenPoints = new THREE.Points(pollenGeo, pollenMat);
         this.pollenPoints.frustumCulled = false; // Always update

--- a/src/particles/gpu_particles.ts
+++ b/src/particles/gpu_particles.ts
@@ -258,7 +258,7 @@ class BubbleStreamSystem implements IParticleSystem {
             color(0xE6E6FA), // Lavender
             iridescence.mul(0.5).add(0.5)
         );
-        material.colorNode = bubbleColor;
+        material.colorNode = vec4(bubbleColor, 1.0);
 
         this.mesh = new THREE.Points(geometry, material);
         this.mesh.userData.type = 'bubbles';
@@ -371,7 +371,7 @@ class PollenCloudSystem implements IParticleSystem {
         const pulse = time.mul(2.0).add(aOffset).sin().mul(0.3).add(0.7);
         material.sizeNode = aSize.mul(pulse);
 
-        material.colorNode = color(pollenColor);
+        material.colorNode = vec4(color(pollenColor), 1.0);
 
         this.mesh = new THREE.Points(geometry, material);
         this.mesh.userData.type = 'pollen';
@@ -479,7 +479,7 @@ class LeafConfettiSystem implements IParticleSystem {
 
         // Color variation
         const colorShift = aOffset.mul(0.1).sin().mul(0.2).add(1.0);
-        material.colorNode = color(leafColor).mul(colorShift);
+        material.colorNode = vec4(color(leafColor).mul(colorShift), 1.0);
 
         this.mesh = new THREE.Points(geometry, material);
         this.mesh.userData.type = 'confetti';

--- a/src/systems/biome-uniforms.ts
+++ b/src/systems/biome-uniforms.ts
@@ -13,7 +13,7 @@ import * as THREE from 'three';
  */
 
 import { uniform, texture, vec2 } from 'three/tsl';
-import { DataTexture, RGBAFormat, FloatType, Color, NearestFilter } from 'three';
+import { DataTexture, RGBAFormat, HalfFloatType, Color, NearestFilter, DataUtils } from 'three';
 import { CONFIG } from '../core/config.ts';
 
 export const BiomeUniforms = {
@@ -112,7 +112,13 @@ export const skyLutData = new Float32Array(128 * 4);
     }
 })();
 
-const _skyLutTex = new DataTexture(skyLutData, 128, 1, RGBAFormat, FloatType);
+// r32float textures are non-filterable in WebGPU — Three.js falls back to
+// textureLoad(...) without the required mip-level argument, causing a WGSL
+// parse error.  HalfFloatType (r16float) IS filterable, so Three.js can use
+// textureSample instead.  The same fix is applied in ground-heightmap.ts.
+const _skyLutHalf = new Uint16Array(128 * 4);
+for (let i = 0; i < 128 * 4; i++) _skyLutHalf[i] = DataUtils.toHalfFloat(skyLutData[i]);
+const _skyLutTex = new DataTexture(_skyLutHalf, 128, 1, RGBAFormat, HalfFloatType);
 _skyLutTex.minFilter = NearestFilter;
 _skyLutTex.magFilter = NearestFilter;
 _skyLutTex.needsUpdate = true;
@@ -147,7 +153,9 @@ export const luminousPlantsLutData = new Float32Array(128 * 4);
     }
 })();
 
-const _luminousPlantsLutTex = new DataTexture(luminousPlantsLutData, 128, 1, RGBAFormat, FloatType);
+const _luminousPlantsLutHalf = new Uint16Array(128 * 4);
+for (let i = 0; i < 128 * 4; i++) _luminousPlantsLutHalf[i] = DataUtils.toHalfFloat(luminousPlantsLutData[i]);
+const _luminousPlantsLutTex = new DataTexture(_luminousPlantsLutHalf, 128, 1, RGBAFormat, HalfFloatType);
 _luminousPlantsLutTex.minFilter = NearestFilter;
 _luminousPlantsLutTex.magFilter = NearestFilter;
 _luminousPlantsLutTex.needsUpdate = true;


### PR DESCRIPTION
## Summary

Two WebGPU shader compilation failures patched across 6 files:

- **`gl_PointCoord` unresolved in WGSL** — Three.js r171's WGSL backend emits the GLSL-only `gl_PointCoord` built-in when a `PointsNodeMaterial` has no `colorNode` providing a full `vec4` (with alpha) and no `opacityNode` referencing `uv()`/`pointUV`. When those conditions aren't met, Three.js falls back to its GLSL disc-mask code verbatim in WGSL, which the WGSL parser rejects.

- **`textureLoad(texture_2d<f32>, vec2<u32>)` missing mip-level argument** — `FloatType` (`r32float`) DataTextures are non-filterable in WebGPU. Three.js falls back to `textureLoad` but omits the required third `level` argument for `texture_2d`. The same root cause and fix pattern were already documented and applied in `ground-heightmap.ts`.

## Changes

| File | Fix |
|------|-----|
| `src/particles/gpu_particles.ts` | Bubble/pollen-cloud/leaf-confetti: `colorNode = vec3` → `vec4(…, 1.0)` |
| `src/foliage/environment.ts` | Geyser plume: add `colorNode = vec4(tslColor(color), 0.8)` (had none) |
| `src/foliage/discovery-effect.ts` | Move fade opacity into alpha channel: `vec4(baseColor, opacity·isActive)` |
| `src/foliage/simple-flower-batcher.ts` | Replace constant `opacityNode = float(0.8)` with `uv()`-based circular mask |
| `src/compute/particle_compute.ts` | Rain/mist `opacityNode` multiplied by `uv()`-based circular mask |
| `src/systems/biome-uniforms.ts` | Sky & luminous-plants LUT textures: `FloatType` → `HalfFloatType` + `DataUtils.toHalfFloat()` conversion |

## Test plan

- [ ] Run `npm run build` — no WGSL parse errors in console
- [ ] Boot smoke test (`npm run test`) — `window.__sceneReady` flag set, no GPU pipeline errors
- [ ] Visually verify particles (rain, mist, pollen, bubbles, confetti, geyser plume, discovery burst) still render correctly
- [ ] Verify sky/moon note-colour LUT still animates (no colour regression)

https://claude.ai/code/session_0197oRWdsC5FtxCshvu45oJF

---
_Generated by [Claude Code](https://claude.ai/code/session_0197oRWdsC5FtxCshvu45oJF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced particle rendering with softer circular fade effects for rain, mist, and pollen particles.
  * Improved visual quality of geyser plumes and discovery effects through optimized color node rendering.

* **Performance**
  * Optimized memory efficiency for sky and plant color data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/candy_world/pull/826?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->