### PR TITLE
fix(particles): remove pointUV to unblock scene startup on WebGPU

### DIFF
--- a/src/particles/compute-particles.ts
+++ b/src/particles/compute-particles.ts
@@ -38,7 +38,7 @@ import {
     Fn, uniform, storage, instanceIndex, vertexIndex, float, vec2, vec3, vec4,
     mix, sin, cos, normalize, color, attribute,
     mx_noise_float, positionLocal, max, length, min, pow, abs,
-    smoothstep, pointUV, uv, pointUV, distance, time, sqrt, dot, cross,
+    smoothstep, uv, distance, time, sqrt, dot, cross,
     cameraPosition
 } from 'three/tsl';
 
@@ -204,7 +204,8 @@ export class ComputeParticleSystem {
             
             case 'pollen':
                 return Fn(() => {
-                    const hueMix = sin(pointUV.x.mul(10.0).add(uTime)).mul(0.5).add(0.5);
+                    // pointUV emits gl_PointCoord which WGSL doesn't support; use seed for variation instead.
+                    const hueMix = sin(seed.mul(10.0).add(uTime)).mul(0.5).add(0.5);
                     const cyan = color(0x00FFFF);
                     const magenta = color(0xFF00FF);
                     return mix(cyan, magenta, hueMix);
@@ -260,10 +261,12 @@ export class ComputeParticleSystem {
     }
     
     private getOpacityNode(): any {
-        return Fn(() => {
-            const distFromCenter = distance(pointUV, vec2(0.5));
-            return smoothstep(0.5, 0.2, distFromCenter);
-        })();
+        // pointUV emits gl_PointCoord which WGSL does not support. WebGPU points are
+        // single-fragment primitives without point-coord, so we fade by life instead of
+        // applying a circular disc mask.
+        const lifeStorage = storage(this.buffers.life, 'float', this.count);
+        const life = lifeStorage.element(vertexIndex);
+        return smoothstep(float(0.0), float(0.5), life).clamp(0.0, 1.0);
     }
     
     private async initWebGPU(): Promise<void> {


### PR DESCRIPTION
## Summary

The scene was failing to start on WebGPU with:

```
Error while parsing WGSL: :46:76 error: unresolved value 'gl_PointCoord'
  DiffuseColor.w = ( DiffuseColor.w * smoothstep( 0.5, 0.2,
    distance( vec2( gl_PointCoord.x, 1.0 - gl_PointCoord.y ), vec2<f32>( 0.5, 0.5 ) ) ) );
GPUPipelineError: [Invalid ShaderModule "fragment"] is invalid due to a previous error.
```

Three.js's `pointUV` TSL node hardcodes `gl_PointCoord` (a GLSL-only builtin) into the WGSL output, which fails to parse and cascades into a `GPUPipelineError` that blocks scene rendering.

`pointUV` was used in two spots in `compute-particles.ts` (used by the falling berry system and friends):
- `getColorNode()` for the `pollen` system — replaced with the per-particle `seed` attribute for hue variation.
- `getOpacityNode()` — replaced the circular disc mask with a life-based fade. WebGPU points are single-fragment primitives without a point-coord, so a true sprite-style disc mask isn't representable on this material path.

There was also a duplicate `pointUV` import (`smoothstep, pointUV, uv, pointUV, …`) which is removed.

## Test plan

- [x] `npm run build` succeeds.
- [x] Smoke test reaches `window.__sceneReady === true` in Chromium with WebGPU enabled.
- [x] Console no longer shows the `unresolved value 'gl_PointCoord'` WGSL parse error or the cascading `GPUPipelineError`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CsD7UpwRTYgMUrgEj81auC)_