### PR TITLE
♿ Aria: [UX improvement] Apply active styling to expanded toggle buttons

### DIFF
--- a/style.css
+++ b/style.css
@@ -347,14 +347,16 @@
 
 /* 🎨 Palette: Pressed State */
 /* Visually differentiates active toggle buttons (e.g., Muted, Night Mode) */
-.toggle-button[aria-pressed="true"] {
+.toggle-button[aria-pressed="true"],
+.toggle-button[aria-expanded="true"] {
     background: #FF4081; /* Higher contrast active color */
     box-shadow: inset 0 2px 5px rgba(0,0,0,0.2);
     border: 2px solid #FFD1DC;
     padding: 8px 18px; /* Offset border to prevent layout shift */
 }
 
-.toggle-button[aria-pressed="true"]:hover {
+.toggle-button[aria-pressed="true"]:hover,
+.toggle-button[aria-expanded="true"]:hover {
     background: #F50057;
 }
 


### PR DESCRIPTION
💡 What: Added CSS styling for `.toggle-button` elements that have `aria-expanded="true"` so that they inherit the same active, pink-background visual styling as `.toggle-button[aria-pressed="true"]`.

🎯 Why: To provide clearer visual feedback to the user. When a menu (like the Jukebox or Accessibility settings) is opened, the button used to open it should visibly remain in an "active" state, making the interface more intuitive and reducing cognitive load.

♿ Accessibility: Relies entirely on the semantic `aria-expanded` state that is already being toggled by the application logic, ensuring visual states are directly tied to screen-reader-announced accessibility states.

---
*PR created automatically by Jules for task [10350404698148886213](https://jules.google.com/task/10350404698148886213) started by @ford442*