### PR TITLE
chore: weekly plan 2026-05-19

### DIFF
--- a/tools/build-optimizer/stats/bundle-analysis.html
+++ b/tools/build-optimizer/stats/bundle-analysis.html
@@ -173,19 +173,19 @@
     <p>Comprehensive bundle visualization and optimization report</p>
     <div class="stats-grid">
       <div class="stat-card">
-        <div class="stat-value">14.96 MB</div>
+        <div class="stat-value">16.71 MB</div>
         <div class="stat-label">Total Size</div>
       </div>
       <div class="stat-card">
-        <div class="stat-value">4.49 MB</div>
+        <div class="stat-value">5.01 MB</div>
         <div class="stat-label">Gzipped</div>
       </div>
       <div class="stat-card">
-        <div class="stat-value">3.74 MB</div>
+        <div class="stat-value">4.18 MB</div>
         <div class="stat-label">Brotli</div>
       </div>
       <div class="stat-card">
-        <div class="stat-value">4</div>
+        <div class="stat-value">8</div>
         <div class="stat-label">Chunks</div>
       </div>
       <div class="stat-card">
@@ -254,6 +254,86 @@
       <div class="dependency-list">
         
           <div class="dependency-item" style="border-color: #b2bec3">
+            <span class="dep-name">./utils-CHkIR9sP.js</span>
+            <span class="dep-size">1.13 MB</span>
+          </div>
+        
+          <div class="dependency-item" style="border-color: #b2bec3">
+            <span class="dep-name">./vendor-36WQIEU1.js</span>
+            <span class="dep-size">1 MB</span>
+          </div>
+        
+          <div class="dependency-item" style="border-color: #b2bec3">
+            <span class="dep-name">./foliage-BOvOkROo.js</span>
+            <span class="dep-size">549.7 KB</span>
+          </div>
+        
+          <div class="dependency-item" style="border-color: #b2bec3">
+            <span class="dep-name">./ui-jIvP09Qj.js</span>
+            <span class="dep-size">468.12 KB</span>
+          </div>
+        
+          <div class="dependency-item" style="border-color: #b2bec3">
+            <span class="dep-name">./world-BuYUkIqU.js</span>
+            <span class="dep-size">463.97 KB</span>
+          </div>
+        
+          <div class="dependency-item" style="border-color: #b2bec3">
+            <span class="dep-name">./gameplay-CrLl3kST.js</span>
+            <span class="dep-size">418.42 KB</span>
+          </div>
+        
+          <div class="dependency-item" style="border-color: #b2bec3">
+            <span class="dep-name">./chunks/foliage-BOvOkROo.js</span>
+            <span class="dep-size">30.94 KB</span>
+          </div>
+        
+          <div class="dependency-item" style="border-color: #b2bec3">
+            <span class="dep-name">./chunks/ui-jIvP09Qj.js</span>
+            <span class="dep-size">30.94 KB</span>
+          </div>
+        
+          <div class="dependency-item" style="border-color: #b2bec3">
+            <span class="dep-name">./chunks/utils-CHkIR9sP.js</span>
+            <span class="dep-size">30.94 KB</span>
+          </div>
+        
+          <div class="dependency-item" style="border-color: #b2bec3">
+            <span class="dep-name">./chunks/world-BuYUkIqU.js</span>
+            <span class="dep-size">30.94 KB</span>
+          </div>
+        
+          <div class="dependency-item" style="border-color: #b2bec3">
+            <span class="dep-name">./chunks/vendor-36WQIEU1.js</span>
+            <span class="dep-size">30.94 KB</span>
+          </div>
+        
+          <div class="dependency-item" style="border-color: #b2bec3">
+            <span class="dep-name">./chunks/audio-Cc_AtAmm.js</span>
+            <span class="dep-size">30.94 KB</span>
+          </div>
+        
+          <div class="dependency-item" style="border-color: #b2bec3">
+            <span class="dep-name">./chunks/weather-DInr9qbu.js</span>
+            <span class="dep-size">30.94 KB</span>
+          </div>
+        
+          <div class="dependency-item" style="border-color: #b2bec3">
+            <span class="dep-name">./chunks/gameplay-CrLl3kST.js</span>
+            <span class="dep-size">30.94 KB</span>
+          </div>
+        
+          <div class="dependency-item" style="border-color: #b2bec3">
+            <span class="dep-name">./chunks/compute-O0n62K7Y.js</span>
+            <span class="dep-size">30.94 KB</span>
+          </div>
+        
+          <div class="dependency-item" style="border-color: #b2bec3">
+            <span class="dep-name">./compute-O0n62K7Y.js</span>
+            <span class="dep-size">29.32 KB</span>
+          </div>
+        
+          <div class="dependency-item" style="border-color: #b2bec3">
             <span class="dep-name">/node_modules/three/build/three.module.js</span>
             <span class="dep-size">4.89 KB</span>
           </div>
@@ -283,39 +363,78 @@
         <div style="margin-bottom: 1.5rem;">
           <div style="display: flex; justify-content: space-between; align-items: center;">
             <h3>main</h3>
-            <span style="color: #4ecdc4; font-weight: bold;">3.27 MB</span>
+            <span style="color: #4ecdc4; font-weight: bold;">79.87 KB</span>
           </div>
           <div style="background: rgba(0,0,0,0.3); height: 8px; border-radius: 4px; margin-top: 0.5rem;">
-            <div style="background: #b2bec3; width: 21.9%; height: 100%; border-radius: 4px;"></div>
+            <div style="background: #b2bec3; width: 0.5%; height: 100%; border-radius: 4px;"></div>
           </div>
           <div style="color: #888; font-size: 0.85rem; margin-top: 0.5rem;">
-            7 files | Gzip: 1005.94 KB | Brotli: 838.28 KB
+            5 files | Gzip: 23.96 KB | Brotli: 19.96 KB
           </div>
         </div>
       
         <div style="margin-bottom: 1.5rem;">
           <div style="display: flex; justify-content: space-between; align-items: center;">
-            <h3>wasm</h3>
-            <span style="color: #4ecdc4; font-weight: bold;">22.17 KB</span>
+            <h3>assets</h3>
+            <span style="color: #4ecdc4; font-weight: bold;">847.44 KB</span>
           </div>
           <div style="background: rgba(0,0,0,0.3); height: 8px; border-radius: 4px; margin-top: 0.5rem;">
-            <div style="background: #4ecdc4; width: 0.1%; height: 100%; border-radius: 4px;"></div>
+            <div style="background: #b2bec3; width: 5.0%; height: 100%; border-radius: 4px;"></div>
           </div>
           <div style="color: #888; font-size: 0.85rem; margin-top: 0.5rem;">
-            1 files | Gzip: 6.65 KB | Brotli: 5.54 KB
+            2 files | Gzip: 254.23 KB | Brotli: 211.86 KB
           </div>
         </div>
       
         <div style="margin-bottom: 1.5rem;">
           <div style="display: flex; justify-content: space-between; align-items: center;">
             <h3>audio</h3>
-            <span style="color: #4ecdc4; font-weight: bold;">11.03 KB</span>
+            <span style="color: #4ecdc4; font-weight: bold;">34.3 KB</span>
           </div>
           <div style="background: rgba(0,0,0,0.3); height: 8px; border-radius: 4px; margin-top: 0.5rem;">
-            <div style="background: #96ceb4; width: 0.1%; height: 100%; border-radius: 4px;"></div>
+            <div style="background: #96ceb4; width: 0.2%; height: 100%; border-radius: 4px;"></div>
           </div>
           <div style="color: #888; font-size: 0.85rem; margin-top: 0.5rem;">
-            1 files | Gzip: 3.31 KB | Brotli: 2.76 KB
+            2 files | Gzip: 10.29 KB | Brotli: 8.57 KB
+          </div>
+        </div>
+      
+        <div style="margin-bottom: 1.5rem;">
+          <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h3>chunks</h3>
+            <span style="color: #4ecdc4; font-weight: bold;">2.07 MB</span>
+          </div>
+          <div style="background: rgba(0,0,0,0.3); height: 8px; border-radius: 4px; margin-top: 0.5rem;">
+            <div style="background: #b2bec3; width: 12.4%; height: 100%; border-radius: 4px;"></div>
+          </div>
+          <div style="color: #888; font-size: 0.85rem; margin-top: 0.5rem;">
+            7 files | Gzip: 636.85 KB | Brotli: 530.71 KB
+          </div>
+        </div>
+      
+        <div style="margin-bottom: 1.5rem;">
+          <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h3>foliage</h3>
+            <span style="color: #4ecdc4; font-weight: bold;">418.42 KB</span>
+          </div>
+          <div style="background: rgba(0,0,0,0.3); height: 8px; border-radius: 4px; margin-top: 0.5rem;">
+            <div style="background: #ffeaa7; width: 2.4%; height: 100%; border-radius: 4px;"></div>
+          </div>
+          <div style="color: #888; font-size: 0.85rem; margin-top: 0.5rem;">
+            1 files | Gzip: 125.53 KB | Brotli: 104.61 KB
+          </div>
+        </div>
+      
+        <div style="margin-bottom: 1.5rem;">
+          <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h3>images</h3>
+            <span style="color: #4ecdc4; font-weight: bold;">1.61 MB</span>
+          </div>
+          <div style="background: rgba(0,0,0,0.3); height: 8px; border-radius: 4px; margin-top: 0.5rem;">
+            <div style="background: #b2bec3; width: 9.6%; height: 100%; border-radius: 4px;"></div>
+          </div>
+          <div style="color: #888; font-size: 0.85rem; margin-top: 0.5rem;">
+            2 files | Gzip: 494.55 KB | Brotli: 412.12 KB
           </div>
         </div>
       
@@ -325,10 +444,23 @@
             <span style="color: #4ecdc4; font-weight: bold;">11.65 MB</span>
           </div>
           <div style="background: rgba(0,0,0,0.3); height: 8px; border-radius: 4px; margin-top: 0.5rem;">
-            <div style="background: #b2bec3; width: 77.9%; height: 100%; border-radius: 4px;"></div>
+            <div style="background: #b2bec3; width: 69.7%; height: 100%; border-radius: 4px;"></div>
           </div>
           <div style="color: #888; font-size: 0.85rem; margin-top: 0.5rem;">
-            4 files | Gzip: 3.49 MB | Brotli: 2.91 MB
+            4 files | Gzip: 3.5 MB | Brotli: 2.91 MB
+          </div>
+        </div>
+      
+        <div style="margin-bottom: 1.5rem;">
+          <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h3>wasm</h3>
+            <span style="color: #4ecdc4; font-weight: bold;">26.78 KB</span>
+          </div>
+          <div style="background: rgba(0,0,0,0.3); height: 8px; border-radius: 4px; margin-top: 0.5rem;">
+            <div style="background: #4ecdc4; width: 0.2%; height: 100%; border-radius: 4px;"></div>
+          </div>
+          <div style="color: #888; font-size: 0.85rem; margin-top: 0.5rem;">
+            1 files | Gzip: 8.03 KB | Brotli: 6.69 KB
           </div>
         </div>
       
@@ -354,7 +486,7 @@
 
   <script>
     // Treemap data
-    const data = [{"name":"main","value":3433603,"category":"other","children":[{"name":".htaccess","value":679,"category":"other","fullPath":".htaccess"},{"name":"bootstrap-loader-BwruBh5B.js","value":2831,"category":"other","fullPath":"bootstrap-loader-BwruBh5B.js"},{"name":"index.html","value":25464,"category":"shaders","fullPath":"index.html"},{"name":"main-BVCDuxDP.js","value":1864902,"category":"shaders","fullPath":"main-BVCDuxDP.js"},{"name":"main-BkyUfddy.css","value":6224,"category":"other","fullPath":"main-BkyUfddy.css"},{"name":"perf_instancing.html","value":1184,"category":"other","fullPath":"perf_instancing.html"},{"name":"splash-XugLlQp2.png","value":1532319,"category":"other","fullPath":"splash-XugLlQp2.png"}]},{"name":"wasm","value":22698,"category":"wasm","children":[{"name":"candy_physics-Ddrkksvv.wasm","value":22698,"category":"wasm","fullPath":"candy_physics-Ddrkksvv.wasm"}]},{"name":"audio","value":11295,"category":"audio","children":[{"name":"audio-processor.js","value":11295,"category":"audio","fullPath":"js/audio-processor.js"}]},{"name":"js","value":12213864,"category":"other","children":[{"name":"emscripten-compile-worker.js","value":1715,"category":"other","fullPath":"js/emscripten-compile-worker.js"},{"name":"libopenmpt.js","value":12206419,"category":"other","fullPath":"js/libopenmpt.js"},{"name":"perf_instancing.js","value":5011,"category":"other","fullPath":"js/perf_instancing.js"},{"name":"worklet-polyfills.js","value":719,"category":"other","fullPath":"js/worklet-polyfills.js"}]}];
+    const data = [{"name":"main","value":81785,"category":"other","children":[{"name":".htaccess","value":679,"category":"other","fullPath":".htaccess"},{"name":"main-BF5S0qyC.css","value":9219,"category":"other","fullPath":"assets/main-BF5S0qyC.css"},{"name":"index.html","value":39017,"category":"other","fullPath":"index.html"},{"name":"main-DbVFPZUs.js","value":31686,"category":"other","fullPath":"main-DbVFPZUs.js"},{"name":"perf_instancing.html","value":1184,"category":"other","fullPath":"perf_instancing.html"}]},{"name":"assets","value":867782,"category":"other","children":[{"name":"map-B63FtkXv.json","value":856252,"category":"other","fullPath":"assets/map-B63FtkXv.json"},{"name":"ui-BA2_WYBH.css","value":11530,"category":"other","fullPath":"assets/ui-BA2_WYBH.css"}]},{"name":"audio","value":35119,"category":"audio","children":[{"name":"audio-Cc_AtAmm.js","value":22749,"category":"audio","fullPath":"chunks/audio-Cc_AtAmm.js"},{"name":"audio-processor.js","value":12370,"category":"audio","fullPath":"js/audio-processor.js"}]},{"name":"chunks","value":2173801,"category":"other","children":[{"name":"compute-O0n62K7Y.js","value":6590,"category":"other","fullPath":"chunks/compute-O0n62K7Y.js"},{"name":"gameplay-CrLl3kST.js","value":16612,"category":"other","fullPath":"chunks/gameplay-CrLl3kST.js"},{"name":"ui-jIvP09Qj.js","value":190324,"category":"other","fullPath":"chunks/ui-jIvP09Qj.js"},{"name":"utils-CHkIR9sP.js","value":50892,"category":"shaders","fullPath":"chunks/utils-CHkIR9sP.js"},{"name":"vendor-36WQIEU1.js","value":1363107,"category":"shaders","fullPath":"chunks/vendor-36WQIEU1.js"},{"name":"weather-DInr9qbu.js","value":30026,"category":"other","fullPath":"chunks/weather-DInr9qbu.js"},{"name":"world-BuYUkIqU.js","value":516250,"category":"other","fullPath":"chunks/world-BuYUkIqU.js"}]},{"name":"foliage","value":428466,"category":"foliage","children":[{"name":"foliage-BOvOkROo.js","value":428466,"category":"foliage","fullPath":"chunks/foliage-BOvOkROo.js"}]},{"name":"images","value":1688065,"category":"other","children":[{"name":"splash-D-9ecu-R.webp","value":155746,"category":"other","fullPath":"images/splash-D-9ecu-R.webp"},{"name":"splash-XugLlQp2.png","value":1532319,"category":"other","fullPath":"images/splash-XugLlQp2.png"}]},{"name":"js","value":12216775,"category":"other","children":[{"name":"emscripten-compile-worker.js","value":1715,"category":"other","fullPath":"js/emscripten-compile-worker.js"},{"name":"libopenmpt.js","value":12206418,"category":"other","fullPath":"js/libopenmpt.js"},{"name":"perf_instancing.js","value":5011,"category":"other","fullPath":"js/perf_instancing.js"},{"name":"worklet-polyfills.js","value":3631,"category":"other","fullPath":"js/worklet-polyfills.js"}]},{"name":"wasm","value":27419,"category":"wasm","children":[{"name":"candy_physics-Bpmoak5a.wasm","value":27419,"category":"wasm","fullPath":"wasm/candy_physics-Bpmoak5a.wasm"}]}];
 
     // Create treemap
     const width = document.getElementById('treemap').clientWidth;

--- a/tools/build-optimizer/stats/compression-report.html
+++ b/tools/build-optimizer/stats/compression-report.html
@@ -1,0 +1,666 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>candy_world Compression Benchmark</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #0a0a0f;
+      color: #e0e0e0;
+      line-height: 1.6;
+    }
+    .header {
+      background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+      padding: 2rem;
+      border-bottom: 1px solid #2a2a3e;
+    }
+    .header h1 {
+      font-size: 2rem;
+      background: linear-gradient(90deg, #4ecdc4, #ff6b6b);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+    .container {
+      max-width: 1400px;
+      margin: 0 auto;
+      padding: 2rem;
+    }
+    .section {
+      background: rgba(255,255,255,0.03);
+      border-radius: 16px;
+      padding: 2rem;
+      margin-bottom: 2rem;
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+    .section h2 {
+      margin-bottom: 1.5rem;
+      color: #fff;
+    }
+    .stats-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 1rem;
+      margin-bottom: 2rem;
+    }
+    .stat-card {
+      background: rgba(255,255,255,0.05);
+      padding: 1.5rem;
+      border-radius: 12px;
+      border: 1px solid rgba(255,255,255,0.1);
+    }
+    .stat-value {
+      font-size: 1.75rem;
+      font-weight: bold;
+    }
+    .stat-label {
+      color: #888;
+      font-size: 0.9rem;
+      margin-top: 0.25rem;
+    }
+    .compression-card {
+      border-left: 4px solid;
+      margin-bottom: 1rem;
+    }
+    .compression-card.none { border-color: #666; }
+    .compression-card.gzip { border-color: #4ecdc4; }
+    .compression-card.brotli { border-color: #ff6b6b; }
+    .compression-card.zstd { border-color: #ffeaa7; }
+    
+    .chart-container {
+      position: relative;
+      height: 400px;
+      margin: 2rem 0;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 1rem;
+    }
+    th, td {
+      padding: 0.75rem;
+      text-align: left;
+      border-bottom: 1px solid rgba(255,255,255,0.1);
+    }
+    th {
+      color: #888;
+      font-weight: 500;
+    }
+    .badge {
+      display: inline-block;
+      padding: 0.25rem 0.75rem;
+      border-radius: 20px;
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+    }
+    .badge-best { background: #00b894; color: #fff; }
+    .badge-good { background: #0984e3; color: #fff; }
+    .badge-ok { background: #fdcb6e; color: #000; }
+    .config-block {
+      background: rgba(0,0,0,0.5);
+      padding: 1.5rem;
+      border-radius: 8px;
+      overflow-x: auto;
+      margin: 1rem 0;
+    }
+    .config-block pre {
+      margin: 0;
+      font-family: 'SF Mono', monospace;
+      font-size: 0.85rem;
+      line-height: 1.5;
+    }
+    .config-tabs {
+      display: flex;
+      gap: 0.5rem;
+      margin-bottom: 1rem;
+    }
+    .config-tab {
+      padding: 0.5rem 1rem;
+      background: rgba(255,255,255,0.1);
+      border: none;
+      border-radius: 6px;
+      color: #fff;
+      cursor: pointer;
+      transition: background 0.2s;
+    }
+    .config-tab:hover, .config-tab.active {
+      background: rgba(255,255,255,0.2);
+    }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <h1>📊 Compression Benchmark Report</h1>
+    <p style="color: #888; margin-top: 0.5rem;">Generated: 5/19/2026, 2:45:03 PM</p>
+  </div>
+
+  <div class="container">
+    <div class="section">
+      <h2>Summary</h2>
+      <div class="stats-grid">
+        
+            <div class="stat-card compression-card none">
+              <div class="stat-value" style="color: #666">19.67 MB</div>
+              <div class="stat-label">NONE</div>
+              
+            </div>
+          
+            <div class="stat-card compression-card gzip">
+              <div class="stat-value" style="color: #4ecdc4">5.33 MB</div>
+              <div class="stat-label">GZIP</div>
+              <div style="color: #00b894; font-size: 0.85rem; margin-top: 0.5rem;">-72.9% savings</div>
+            </div>
+          
+            <div class="stat-card compression-card brotli">
+              <div class="stat-value" style="color: #ff6b6b">4.68 MB</div>
+              <div class="stat-label">BROTLI</div>
+              <div style="color: #00b894; font-size: 0.85rem; margin-top: 0.5rem;">-76.2% savings</div>
+            </div>
+          
+            <div class="stat-card compression-card zstd">
+              <div class="stat-value" style="color: #ffeaa7">0 B</div>
+              <div class="stat-label">ZSTD</div>
+              <div style="color: #00b894; font-size: 0.85rem; margin-top: 0.5rem;">-100.0% savings</div>
+            </div>
+          
+      </div>
+
+      <div class="chart-container">
+        <canvas id="compressionChart"></canvas>
+      </div>
+    </div>
+
+    <div class="section">
+      <h2>⏱️ Estimated Load Times</h2>
+      <div class="stats-grid">
+        
+          <div class="stat-card">
+            <div class="stat-value" style="color: #ff6b6b">51.16s</div>
+            <div class="stat-label">3G</div>
+          </div>
+        
+          <div class="stat-card">
+            <div class="stat-value" style="color: #00b894">0.75s</div>
+            <div class="stat-label">4G</div>
+          </div>
+        
+          <div class="stat-card">
+            <div class="stat-value" style="color: #00b894">0.07s</div>
+            <div class="stat-label">5G</div>
+          </div>
+        
+      </div>
+      <p style="color: #888; margin-top: 1rem;">
+        Based on 4.68 MB total compressed size
+        and simulated connection speeds.
+      </p>
+    </div>
+
+    <div class="section">
+      <h2>💰 Bandwidth Savings</h2>
+      <div class="stat-card">
+        <div class="stat-value" style="color: #00b894;">5.22 TB</div>
+        <div class="stat-label">Annual Bandwidth Savings (1000 visits/day)</div>
+      </div>
+    </div>
+
+    <div class="section">
+      <h2>📁 File Results</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>File</th>
+            <th>Type</th>
+            <th>Original</th>
+            <th>Gzip</th>
+            <th>Brotli</th>
+            <th>Best</th>
+          </tr>
+        </thead>
+        <tbody>
+          
+              <tr>
+                <td>main-BF5S0qyC.css</td>
+                <td><span class="badge badge-ok">CSS</span></td>
+                <td>9 KB</td>
+                <td>2.48 KB (72%)</td>
+                <td>2.15 KB (76%)</td>
+                <td><span class="badge badge-best">BROTLI</span></td>
+              </tr>
+            
+              <tr>
+                <td>map-B63FtkXv.json</td>
+                <td><span class="badge badge-ok">JSON</span></td>
+                <td>836.18 KB</td>
+                <td>167.83 KB (80%)</td>
+                <td>132.72 KB (84%)</td>
+                <td><span class="badge badge-best">BROTLI</span></td>
+              </tr>
+            
+              <tr>
+                <td>ui-BA2_WYBH.css</td>
+                <td><span class="badge badge-ok">CSS</span></td>
+                <td>11.26 KB</td>
+                <td>3.01 KB (73%)</td>
+                <td>2.62 KB (77%)</td>
+                <td><span class="badge badge-best">BROTLI</span></td>
+              </tr>
+            
+              <tr>
+                <td>audio-Cc_AtAmm.js</td>
+                <td><span class="badge badge-ok">JavaScript</span></td>
+                <td>22.22 KB</td>
+                <td>5.83 KB (74%)</td>
+                <td>5.16 KB (77%)</td>
+                <td><span class="badge badge-best">BROTLI</span></td>
+              </tr>
+            
+              <tr>
+                <td>compute-O0n62K7Y.js</td>
+                <td><span class="badge badge-ok">JavaScript</span></td>
+                <td>6.44 KB</td>
+                <td>1.85 KB (71%)</td>
+                <td>1.63 KB (75%)</td>
+                <td><span class="badge badge-best">BROTLI</span></td>
+              </tr>
+            
+              <tr>
+                <td>foliage-BOvOkROo.js</td>
+                <td><span class="badge badge-ok">JavaScript</span></td>
+                <td>418.42 KB</td>
+                <td>105.27 KB (75%)</td>
+                <td>85.15 KB (80%)</td>
+                <td><span class="badge badge-best">BROTLI</span></td>
+              </tr>
+            
+              <tr>
+                <td>gameplay-CrLl3kST.js</td>
+                <td><span class="badge badge-ok">JavaScript</span></td>
+                <td>16.22 KB</td>
+                <td>4.89 KB (70%)</td>
+                <td>4.36 KB (73%)</td>
+                <td><span class="badge badge-best">BROTLI</span></td>
+              </tr>
+            
+              <tr>
+                <td>ui-jIvP09Qj.js</td>
+                <td><span class="badge badge-ok">JavaScript</span></td>
+                <td>185.86 KB</td>
+                <td>38.7 KB (79%)</td>
+                <td>32.29 KB (83%)</td>
+                <td><span class="badge badge-best">BROTLI</span></td>
+              </tr>
+            
+              <tr>
+                <td>utils-CHkIR9sP.js</td>
+                <td><span class="badge badge-ok">JavaScript</span></td>
+                <td>49.7 KB</td>
+                <td>14.01 KB (72%)</td>
+                <td>12.31 KB (75%)</td>
+                <td><span class="badge badge-best">BROTLI</span></td>
+              </tr>
+            
+              <tr>
+                <td>vendor-36WQIEU1.js</td>
+                <td><span class="badge badge-ok">JavaScript</span></td>
+                <td>1.3 MB</td>
+                <td>290.37 KB (78%)</td>
+                <td>227.56 KB (83%)</td>
+                <td><span class="badge badge-best">BROTLI</span></td>
+              </tr>
+            
+              <tr>
+                <td>weather-DInr9qbu.js</td>
+                <td><span class="badge badge-ok">JavaScript</span></td>
+                <td>29.32 KB</td>
+                <td>7.55 KB (74%)</td>
+                <td>6.75 KB (77%)</td>
+                <td><span class="badge badge-best">BROTLI</span></td>
+              </tr>
+            
+              <tr>
+                <td>world-BuYUkIqU.js</td>
+                <td><span class="badge badge-ok">JavaScript</span></td>
+                <td>504.15 KB</td>
+                <td>124.68 KB (75%)</td>
+                <td>102.06 KB (80%)</td>
+                <td><span class="badge badge-best">BROTLI</span></td>
+              </tr>
+            
+              <tr>
+                <td>splash-XugLlQp2.png</td>
+                <td><span class="badge badge-ok">PNG Image</span></td>
+                <td>1.46 MB</td>
+                <td>1.46 MB (-0%)</td>
+                <td>1.46 MB (-0%)</td>
+                <td><span class="badge badge-best">NONE</span></td>
+              </tr>
+            
+              <tr>
+                <td>index.html</td>
+                <td><span class="badge badge-ok">HTML</span></td>
+                <td>38.1 KB</td>
+                <td>8.06 KB (79%)</td>
+                <td>6.85 KB (82%)</td>
+                <td><span class="badge badge-best">BROTLI</span></td>
+              </tr>
+            
+              <tr>
+                <td>audio-processor.js</td>
+                <td><span class="badge badge-ok">JavaScript</span></td>
+                <td>12.08 KB</td>
+                <td>3.45 KB (71%)</td>
+                <td>2.97 KB (75%)</td>
+                <td><span class="badge badge-best">BROTLI</span></td>
+              </tr>
+            
+              <tr>
+                <td>emscripten-compile-worker.js</td>
+                <td><span class="badge badge-ok">JavaScript</span></td>
+                <td>1.67 KB</td>
+                <td>782 B (54%)</td>
+                <td>654 B (62%)</td>
+                <td><span class="badge badge-best">BROTLI</span></td>
+              </tr>
+            
+              <tr>
+                <td>libopenmpt.js</td>
+                <td><span class="badge badge-ok">JavaScript</span></td>
+                <td>11.64 MB</td>
+                <td>1.28 MB (89%)</td>
+                <td>877.55 KB (93%)</td>
+                <td><span class="badge badge-best">BROTLI</span></td>
+              </tr>
+            
+              <tr>
+                <td>perf_instancing.js</td>
+                <td><span class="badge badge-ok">JavaScript</span></td>
+                <td>4.89 KB</td>
+                <td>1.97 KB (60%)</td>
+                <td>1.67 KB (66%)</td>
+                <td><span class="badge badge-best">BROTLI</span></td>
+              </tr>
+            
+              <tr>
+                <td>worklet-polyfills.js</td>
+                <td><span class="badge badge-ok">JavaScript</span></td>
+                <td>3.55 KB</td>
+                <td>1.13 KB (68%)</td>
+                <td>910 B (75%)</td>
+                <td><span class="badge badge-best">BROTLI</span></td>
+              </tr>
+            
+              <tr>
+                <td>main-DbVFPZUs.js</td>
+                <td><span class="badge badge-ok">JavaScript</span></td>
+                <td>30.94 KB</td>
+                <td>8.97 KB (71%)</td>
+                <td>7.93 KB (74%)</td>
+                <td><span class="badge badge-best">BROTLI</span></td>
+              </tr>
+            
+              <tr>
+                <td>perf_instancing.html</td>
+                <td><span class="badge badge-ok">HTML</span></td>
+                <td>1.16 KB</td>
+                <td>652 B (45%)</td>
+                <td>428 B (64%)</td>
+                <td><span class="badge badge-best">BROTLI</span></td>
+              </tr>
+            
+              <tr>
+                <td>candy_physics-Bpmoak5a.wasm</td>
+                <td><span class="badge badge-ok">WASM</span></td>
+                <td>26.78 KB</td>
+                <td>12.81 KB (52%)</td>
+                <td>11.43 KB (57%)</td>
+                <td><span class="badge badge-best">BROTLI</span></td>
+              </tr>
+            
+              <tr>
+                <td>colorcode.json</td>
+                <td><span class="badge badge-ok">JSON</span></td>
+                <td>255 B</td>
+                <td>107 B (58%)</td>
+                <td>86 B (66%)</td>
+                <td><span class="badge badge-best">BROTLI</span></td>
+              </tr>
+            
+              <tr>
+                <td>colorcode.png</td>
+                <td><span class="badge badge-ok">PNG Image</span></td>
+                <td>14.93 KB</td>
+                <td>12.72 KB (15%)</td>
+                <td>12.72 KB (15%)</td>
+                <td><span class="badge badge-best">BROTLI</span></td>
+              </tr>
+            
+              <tr>
+                <td>map.json</td>
+                <td><span class="badge badge-ok">JSON</span></td>
+                <td>836.18 KB</td>
+                <td>167.83 KB (80%)</td>
+                <td>132.72 KB (84%)</td>
+                <td><span class="badge badge-best">BROTLI</span></td>
+              </tr>
+            
+              <tr>
+                <td>map_generated.json</td>
+                <td><span class="badge badge-ok">JSON</span></td>
+                <td>836.18 KB</td>
+                <td>167.83 KB (80%)</td>
+                <td>132.72 KB (84%)</td>
+                <td><span class="badge badge-best">BROTLI</span></td>
+              </tr>
+            
+              <tr>
+                <td>music-bindings.json</td>
+                <td><span class="badge badge-ok">JSON</span></td>
+                <td>996 B</td>
+                <td>368 B (63%)</td>
+                <td>325 B (67%)</td>
+                <td><span class="badge badge-best">BROTLI</span></td>
+              </tr>
+            
+              <tr>
+                <td>splash.png</td>
+                <td><span class="badge badge-ok">PNG Image</span></td>
+                <td>1.46 MB</td>
+                <td>1.46 MB (-0%)</td>
+                <td>1.46 MB (-0%)</td>
+                <td><span class="badge badge-best">NONE</span></td>
+              </tr>
+            
+        </tbody>
+      </table>
+    </div>
+
+    <div class="section">
+      <h2>⚙️ Server Configuration</h2>
+      
+      <div class="config-tabs">
+        <button class="config-tab active" onclick="showConfig('nginx')">Nginx</button>
+        <button class="config-tab" onclick="showConfig('apache')">Apache</button>
+        <button class="config-tab" onclick="showConfig('vercel')">Vercel</button>
+        <button class="config-tab" onclick="showConfig('netlify')">Netlify</button>
+      </div>
+
+      <div id="config-nginx" class="config-content">
+        <div class="config-block"><pre># Nginx Compression Configuration
+# Add to your server block
+
+# Enable gzip
+gzip on;
+gzip_vary on;
+gzip_proxied any;
+gzip_comp_level 6;
+gzip_min_length 1000;
+gzip_types
+    text/plain
+    text/css
+    text/xml
+    text/javascript
+    application/json
+    application/javascript
+    application/xml+rss
+    application/atom+xml
+    image/svg+xml
+    font/woff
+    font/woff2;
+
+# Enable Brotli (requires ngx_brotli module)
+brotli on;
+brotli_comp_level 6;
+brotli_min_length 1000;
+brotli_types
+    text/plain
+    text/css
+    text/xml
+    text/javascript
+    application/json
+    application/javascript
+    application/xml+rss
+    application/atom+xml
+    image/svg+xml
+    font/woff
+    font/woff2;
+</pre></div>
+      </div>
+      <div id="config-apache" class="config-content" style="display: none;">
+        <div class="config-block"><pre># Apache Compression Configuration
+# Add to your .htaccess or virtual host config
+
+# Enable mod_deflate
+&lt;IfModule mod_deflate.c&gt;
+    # Compress HTML, CSS, JavaScript, Text, XML, fonts
+    AddOutputFilterByType DEFLATE application/javascript
+    AddOutputFilterByType DEFLATE application/rss+xml
+    AddOutputFilterByType DEFLATE application/vnd.ms-fontobject
+    AddOutputFilterByType DEFLATE application/x-font
+    AddOutputFilterByType DEFLATE application/x-font-opentype
+    AddOutputFilterByType DEFLATE application/x-font-otf
+    AddOutputFilterByType DEFLATE application/x-font-truetype
+    AddOutputFilterByType DEFLATE application/x-font-ttf
+    AddOutputFilterByType DEFLATE application/x-javascript
+    AddOutputFilterByType DEFLATE application/xhtml+xml
+    AddOutputFilterByType DEFLATE application/xml
+    AddOutputFilterByType DEFLATE font/opentype
+    AddOutputFilterByType DEFLATE font/otf
+    AddOutputFilterByType DEFLATE font/ttf
+    AddOutputFilterByType DEFLATE image/svg+xml
+    AddOutputFilterByType DEFLATE image/x-icon
+    AddOutputFilterByType DEFLATE text/css
+    AddOutputFilterByType DEFLATE text/html
+    AddOutputFilterByType DEFLATE text/javascript
+    AddOutputFilterByType DEFLATE text/plain
+    AddOutputFilterByType DEFLATE text/xml
+    
+    # Remove browser bugs
+    BrowserMatch ^Mozilla/4 gzip-only-text/html
+    BrowserMatch ^Mozilla/4\.0[678] no-gzip
+    BrowserMatch \bMSIE !no-gzip !gzip-only-text/html
+&lt;/IfModule&gt;
+
+# Enable mod_brotli (Apache 2.4.26+)
+&lt;IfModule mod_brotli.c&gt;
+    AddOutputFilterByType BROTLI_COMPRESS text/html text/plain text/xml text/css text/javascript application/javascript application/json
+&lt;/IfModule&gt;
+</pre></div>
+      </div>
+      <div id="config-vercel" class="config-content" style="display: none;">
+        <div class="config-block"><pre>{
+  &quot;headers&quot;: [
+    {
+      &quot;source&quot;: &quot;/(.*)&quot;,
+      &quot;headers&quot;: [
+        {
+          &quot;key&quot;: &quot;Cache-Control&quot;,
+          &quot;value&quot;: &quot;public, max-age=31536000, immutable&quot;
+        }
+      ]
+    }
+  ]
+}
+
+# Note: Vercel automatically handles Brotli and Gzip compression
+# No additional configuration needed
+</pre></div>
+      </div>
+      <div id="config-netlify" class="config-content" style="display: none;">
+        <div class="config-block"><pre># netlify.toml
+
+[build]
+  command = &quot;npm run build&quot;
+  publish = &quot;dist&quot;
+
+[[headers]]
+  for = &quot;/*&quot;
+  [headers.values]
+    X-Frame-Options = &quot;DENY&quot;
+    X-XSS-Protection = &quot;1; mode=block&quot;
+    
+# Netlify automatically compresses assets with Brotli and Gzip
+# For custom compression settings, use build plugins
+</pre></div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    // Compression chart
+    const ctx = document.getElementById('compressionChart').getContext('2d');
+    new Chart(ctx, {
+      type: 'bar',
+      data: {
+        labels: ["NONE","GZIP","BROTLI","ZSTD"],
+        datasets: [{
+          label: 'Total Size',
+          data: [20624146,5589490,4911631,0],
+          backgroundColor: ["#666","#4ecdc4","#ff6b6b","#ffeaa7"],
+          borderRadius: 8
+        }]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: { display: false },
+          title: {
+            display: true,
+            text: 'Compression Algorithm Comparison',
+            color: '#fff'
+          }
+        },
+        scales: {
+          y: {
+            beginAtZero: true,
+            ticks: {
+              color: '#888',
+              callback: function(value) {
+                return (value / 1024 / 1024).toFixed(1) + ' MB';
+              }
+            },
+            grid: { color: 'rgba(255,255,255,0.1)' }
+          },
+          x: {
+            ticks: { color: '#fff' },
+            grid: { display: false }
+          }
+        }
+      }
+    });
+
+    // Tab switching
+    function showConfig(type) {
+      document.querySelectorAll('.config-content').forEach(el => el.style.display = 'none');
+      document.getElementById('config-' + type).style.display = 'block';
+      document.querySelectorAll('.config-tab').forEach(el => el.classList.remove('active'));
+      event.target.classList.add('active');
+    }
+  </script>
+</body>
+</html>

--- a/tools/build-optimizer/stats/compression-report.json
+++ b/tools/build-optimizer/stats/compression-report.json
@@ -1,0 +1,773 @@
+{
+  "timestamp": "2026-05-19T14:45:03.548Z",
+  "files": [
+    {
+      "path": "dist/assets/main-BF5S0qyC.css",
+      "originalSize": 9219,
+      "type": "CSS",
+      "compressions": [
+        {
+          "algorithm": "none",
+          "size": 9219,
+          "ratio": 1,
+          "time": 0
+        },
+        {
+          "algorithm": "gzip",
+          "size": 2541,
+          "ratio": 0.275626423690205,
+          "time": 5.112502000000006
+        },
+        {
+          "algorithm": "brotli",
+          "size": 2202,
+          "ratio": 0.23885453953791083,
+          "time": 21.580593999999962
+        }
+      ],
+      "bestAlgorithm": "brotli",
+      "savingsVsNone": 7017
+    },
+    {
+      "path": "dist/assets/map-B63FtkXv.json",
+      "originalSize": 856252,
+      "type": "JSON",
+      "compressions": [
+        {
+          "algorithm": "none",
+          "size": 856252,
+          "ratio": 1,
+          "time": 0
+        },
+        {
+          "algorithm": "gzip",
+          "size": 171855,
+          "ratio": 0.2007061005404951,
+          "time": 102.85513800000001
+        },
+        {
+          "algorithm": "brotli",
+          "size": 135908,
+          "ratio": 0.15872430078995436,
+          "time": 1507.734743
+        }
+      ],
+      "bestAlgorithm": "brotli",
+      "savingsVsNone": 720344
+    },
+    {
+      "path": "dist/assets/ui-BA2_WYBH.css",
+      "originalSize": 11530,
+      "type": "CSS",
+      "compressions": [
+        {
+          "algorithm": "none",
+          "size": 11530,
+          "ratio": 1,
+          "time": 0
+        },
+        {
+          "algorithm": "gzip",
+          "size": 3083,
+          "ratio": 0.26738941890719864,
+          "time": 5.1497699999999895
+        },
+        {
+          "algorithm": "brotli",
+          "size": 2686,
+          "ratio": 0.23295750216825672,
+          "time": 15.575689000000011
+        }
+      ],
+      "bestAlgorithm": "brotli",
+      "savingsVsNone": 8844
+    },
+    {
+      "path": "dist/chunks/audio-Cc_AtAmm.js",
+      "originalSize": 22749,
+      "type": "JavaScript",
+      "compressions": [
+        {
+          "algorithm": "none",
+          "size": 22749,
+          "ratio": 1,
+          "time": 0
+        },
+        {
+          "algorithm": "gzip",
+          "size": 5975,
+          "ratio": 0.26264890764429205,
+          "time": 5.1827549999998155
+        },
+        {
+          "algorithm": "brotli",
+          "size": 5280,
+          "ratio": 0.23209811420282211,
+          "time": 31.24732999999992
+        }
+      ],
+      "bestAlgorithm": "brotli",
+      "savingsVsNone": 17469
+    },
+    {
+      "path": "dist/chunks/compute-O0n62K7Y.js",
+      "originalSize": 6590,
+      "type": "JavaScript",
+      "compressions": [
+        {
+          "algorithm": "none",
+          "size": 6590,
+          "ratio": 1,
+          "time": 0
+        },
+        {
+          "algorithm": "gzip",
+          "size": 1894,
+          "ratio": 0.2874051593323217,
+          "time": 5.239471999999978
+        },
+        {
+          "algorithm": "brotli",
+          "size": 1665,
+          "ratio": 0.2526555386949924,
+          "time": 10.399817999999868
+        }
+      ],
+      "bestAlgorithm": "brotli",
+      "savingsVsNone": 4925
+    },
+    {
+      "path": "dist/chunks/foliage-BOvOkROo.js",
+      "originalSize": 428466,
+      "type": "JavaScript",
+      "compressions": [
+        {
+          "algorithm": "none",
+          "size": 428466,
+          "ratio": 1,
+          "time": 0
+        },
+        {
+          "algorithm": "gzip",
+          "size": 107793,
+          "ratio": 0.251578888406548,
+          "time": 53.09185600000001
+        },
+        {
+          "algorithm": "brotli",
+          "size": 87191,
+          "ratio": 0.20349572661541407,
+          "time": 785.50171
+        }
+      ],
+      "bestAlgorithm": "brotli",
+      "savingsVsNone": 341275
+    },
+    {
+      "path": "dist/chunks/gameplay-CrLl3kST.js",
+      "originalSize": 16612,
+      "type": "JavaScript",
+      "compressions": [
+        {
+          "algorithm": "none",
+          "size": 16612,
+          "ratio": 1,
+          "time": 0
+        },
+        {
+          "algorithm": "gzip",
+          "size": 5011,
+          "ratio": 0.3016494100650132,
+          "time": 5.078549000000294
+        },
+        {
+          "algorithm": "brotli",
+          "size": 4467,
+          "ratio": 0.26890199855526126,
+          "time": 23.116128000000117
+        }
+      ],
+      "bestAlgorithm": "brotli",
+      "savingsVsNone": 12145
+    },
+    {
+      "path": "dist/chunks/ui-jIvP09Qj.js",
+      "originalSize": 190324,
+      "type": "JavaScript",
+      "compressions": [
+        {
+          "algorithm": "none",
+          "size": 190324,
+          "ratio": 1,
+          "time": 0
+        },
+        {
+          "algorithm": "gzip",
+          "size": 39630,
+          "ratio": 0.2082238708728274,
+          "time": 21.47018799999978
+        },
+        {
+          "algorithm": "brotli",
+          "size": 33069,
+          "ratio": 0.17375107711061138,
+          "time": 285.47984099999985
+        }
+      ],
+      "bestAlgorithm": "brotli",
+      "savingsVsNone": 157255
+    },
+    {
+      "path": "dist/chunks/utils-CHkIR9sP.js",
+      "originalSize": 50892,
+      "type": "JavaScript",
+      "compressions": [
+        {
+          "algorithm": "none",
+          "size": 50892,
+          "ratio": 1,
+          "time": 0
+        },
+        {
+          "algorithm": "gzip",
+          "size": 14343,
+          "ratio": 0.2818321150672011,
+          "time": 11.164823999999953
+        },
+        {
+          "algorithm": "brotli",
+          "size": 12610,
+          "ratio": 0.247779611726794,
+          "time": 71.35054200000013
+        }
+      ],
+      "bestAlgorithm": "brotli",
+      "savingsVsNone": 38282
+    },
+    {
+      "path": "dist/chunks/vendor-36WQIEU1.js",
+      "originalSize": 1363107,
+      "type": "JavaScript",
+      "compressions": [
+        {
+          "algorithm": "none",
+          "size": 1363107,
+          "ratio": 1,
+          "time": 0
+        },
+        {
+          "algorithm": "gzip",
+          "size": 297336,
+          "ratio": 0.21813107848466776,
+          "time": 163.0725309999998
+        },
+        {
+          "algorithm": "brotli",
+          "size": 233024,
+          "ratio": 0.17095062970111663,
+          "time": 2547.0753360000003
+        }
+      ],
+      "bestAlgorithm": "brotli",
+      "savingsVsNone": 1130083
+    },
+    {
+      "path": "dist/chunks/weather-DInr9qbu.js",
+      "originalSize": 30026,
+      "type": "JavaScript",
+      "compressions": [
+        {
+          "algorithm": "none",
+          "size": 30026,
+          "ratio": 1,
+          "time": 0
+        },
+        {
+          "algorithm": "gzip",
+          "size": 7736,
+          "ratio": 0.25764337574102447,
+          "time": 6.310878999999659
+        },
+        {
+          "algorithm": "brotli",
+          "size": 6917,
+          "ratio": 0.23036701525344702,
+          "time": 43.64324899999974
+        }
+      ],
+      "bestAlgorithm": "brotli",
+      "savingsVsNone": 23109
+    },
+    {
+      "path": "dist/chunks/world-BuYUkIqU.js",
+      "originalSize": 516250,
+      "type": "JavaScript",
+      "compressions": [
+        {
+          "algorithm": "none",
+          "size": 516250,
+          "ratio": 1,
+          "time": 0
+        },
+        {
+          "algorithm": "gzip",
+          "size": 127677,
+          "ratio": 0.24731622276029055,
+          "time": 82.14399700000013
+        },
+        {
+          "algorithm": "brotli",
+          "size": 104510,
+          "ratio": 0.20244067796610168,
+          "time": 980.5576230000006
+        }
+      ],
+      "bestAlgorithm": "brotli",
+      "savingsVsNone": 411740
+    },
+    {
+      "path": "dist/images/splash-XugLlQp2.png",
+      "originalSize": 1532319,
+      "type": "PNG Image",
+      "compressions": [
+        {
+          "algorithm": "none",
+          "size": 1532319,
+          "ratio": 1,
+          "time": 0
+        },
+        {
+          "algorithm": "gzip",
+          "size": 1532710,
+          "ratio": 1.000255168799708,
+          "time": 95.38705899999968
+        },
+        {
+          "algorithm": "brotli",
+          "size": 1532327,
+          "ratio": 1.0000052208450068,
+          "time": 1127.4750099999992
+        }
+      ],
+      "bestAlgorithm": "none",
+      "savingsVsNone": 0
+    },
+    {
+      "path": "dist/index.html",
+      "originalSize": 39017,
+      "type": "HTML",
+      "compressions": [
+        {
+          "algorithm": "none",
+          "size": 39017,
+          "ratio": 1,
+          "time": 0
+        },
+        {
+          "algorithm": "gzip",
+          "size": 8254,
+          "ratio": 0.21154881205628315,
+          "time": 8.206570000000283
+        },
+        {
+          "algorithm": "brotli",
+          "size": 7014,
+          "ratio": 0.17976779352589897,
+          "time": 54.08473699999922
+        }
+      ],
+      "bestAlgorithm": "brotli",
+      "savingsVsNone": 32003
+    },
+    {
+      "path": "dist/js/audio-processor.js",
+      "originalSize": 12370,
+      "type": "JavaScript",
+      "compressions": [
+        {
+          "algorithm": "none",
+          "size": 12370,
+          "ratio": 1,
+          "time": 0
+        },
+        {
+          "algorithm": "gzip",
+          "size": 3535,
+          "ratio": 0.28577202910266775,
+          "time": 5.9923520000011194
+        },
+        {
+          "algorithm": "brotli",
+          "size": 3045,
+          "ratio": 0.246160064672595,
+          "time": 24.759436999998798
+        }
+      ],
+      "bestAlgorithm": "brotli",
+      "savingsVsNone": 9325
+    },
+    {
+      "path": "dist/js/emscripten-compile-worker.js",
+      "originalSize": 1715,
+      "type": "JavaScript",
+      "compressions": [
+        {
+          "algorithm": "none",
+          "size": 1715,
+          "ratio": 1,
+          "time": 0
+        },
+        {
+          "algorithm": "gzip",
+          "size": 782,
+          "ratio": 0.45597667638483963,
+          "time": 4.7857329999988
+        },
+        {
+          "algorithm": "brotli",
+          "size": 654,
+          "ratio": 0.3813411078717201,
+          "time": 4.5179559999996854
+        }
+      ],
+      "bestAlgorithm": "brotli",
+      "savingsVsNone": 1061
+    },
+    {
+      "path": "dist/js/libopenmpt.js",
+      "originalSize": 12206418,
+      "type": "JavaScript",
+      "compressions": [
+        {
+          "algorithm": "none",
+          "size": 12206418,
+          "ratio": 1,
+          "time": 0
+        },
+        {
+          "algorithm": "gzip",
+          "size": 1343291,
+          "ratio": 0.11004792724614215,
+          "time": 2583.640942
+        },
+        {
+          "algorithm": "brotli",
+          "size": 898614,
+          "ratio": 0.07361815726775865,
+          "time": 26379.961906000004
+        }
+      ],
+      "bestAlgorithm": "brotli",
+      "savingsVsNone": 11307804
+    },
+    {
+      "path": "dist/js/perf_instancing.js",
+      "originalSize": 5011,
+      "type": "JavaScript",
+      "compressions": [
+        {
+          "algorithm": "none",
+          "size": 5011,
+          "ratio": 1,
+          "time": 0
+        },
+        {
+          "algorithm": "gzip",
+          "size": 2016,
+          "ratio": 0.40231490720415086,
+          "time": 5.4845209999984945
+        },
+        {
+          "algorithm": "brotli",
+          "size": 1707,
+          "ratio": 0.34065056874875277,
+          "time": 8.31713899999886
+        }
+      ],
+      "bestAlgorithm": "brotli",
+      "savingsVsNone": 3304
+    },
+    {
+      "path": "dist/js/worklet-polyfills.js",
+      "originalSize": 3631,
+      "type": "JavaScript",
+      "compressions": [
+        {
+          "algorithm": "none",
+          "size": 3631,
+          "ratio": 1,
+          "time": 0
+        },
+        {
+          "algorithm": "gzip",
+          "size": 1159,
+          "ratio": 0.31919581382539247,
+          "time": 4.634900999997626
+        },
+        {
+          "algorithm": "brotli",
+          "size": 910,
+          "ratio": 0.2506196640044065,
+          "time": 6.615282999999181
+        }
+      ],
+      "bestAlgorithm": "brotli",
+      "savingsVsNone": 2721
+    },
+    {
+      "path": "dist/main-DbVFPZUs.js",
+      "originalSize": 31686,
+      "type": "JavaScript",
+      "compressions": [
+        {
+          "algorithm": "none",
+          "size": 31686,
+          "ratio": 1,
+          "time": 0
+        },
+        {
+          "algorithm": "gzip",
+          "size": 9185,
+          "ratio": 0.2898756548633466,
+          "time": 6.7874540000048
+        },
+        {
+          "algorithm": "brotli",
+          "size": 8123,
+          "ratio": 0.25635927538976205,
+          "time": 42.12557899999956
+        }
+      ],
+      "bestAlgorithm": "brotli",
+      "savingsVsNone": 23563
+    },
+    {
+      "path": "dist/perf_instancing.html",
+      "originalSize": 1184,
+      "type": "HTML",
+      "compressions": [
+        {
+          "algorithm": "none",
+          "size": 1184,
+          "ratio": 1,
+          "time": 0
+        },
+        {
+          "algorithm": "gzip",
+          "size": 652,
+          "ratio": 0.5506756756756757,
+          "time": 4.953518000002077
+        },
+        {
+          "algorithm": "brotli",
+          "size": 428,
+          "ratio": 0.3614864864864865,
+          "time": 3.031970000003639
+        }
+      ],
+      "bestAlgorithm": "brotli",
+      "savingsVsNone": 756
+    },
+    {
+      "path": "dist/wasm/candy_physics-Bpmoak5a.wasm",
+      "originalSize": 27419,
+      "type": "WASM",
+      "compressions": [
+        {
+          "algorithm": "none",
+          "size": 27419,
+          "ratio": 1,
+          "time": 0
+        },
+        {
+          "algorithm": "gzip",
+          "size": 13113,
+          "ratio": 0.4782450125825158,
+          "time": 6.196218000004592
+        },
+        {
+          "algorithm": "brotli",
+          "size": 11705,
+          "ratio": 0.42689375980159744,
+          "time": 46.29993600000307
+        }
+      ],
+      "bestAlgorithm": "brotli",
+      "savingsVsNone": 15714
+    },
+    {
+      "path": "assets/colorcode.json",
+      "originalSize": 255,
+      "type": "JSON",
+      "compressions": [
+        {
+          "algorithm": "none",
+          "size": 255,
+          "ratio": 1,
+          "time": 0
+        },
+        {
+          "algorithm": "gzip",
+          "size": 107,
+          "ratio": 0.4196078431372549,
+          "time": 4.669646000002103
+        },
+        {
+          "algorithm": "brotli",
+          "size": 86,
+          "ratio": 0.33725490196078434,
+          "time": 1.6728539999967325
+        }
+      ],
+      "bestAlgorithm": "brotli",
+      "savingsVsNone": 169
+    },
+    {
+      "path": "assets/colorcode.png",
+      "originalSize": 15285,
+      "type": "PNG Image",
+      "compressions": [
+        {
+          "algorithm": "none",
+          "size": 15285,
+          "ratio": 1,
+          "time": 0
+        },
+        {
+          "algorithm": "gzip",
+          "size": 13024,
+          "ratio": 0.8520771998691528,
+          "time": 4.812147000004188
+        },
+        {
+          "algorithm": "brotli",
+          "size": 13021,
+          "ratio": 0.8518809290153746,
+          "time": 32.76991399999679
+        }
+      ],
+      "bestAlgorithm": "brotli",
+      "savingsVsNone": 2264
+    },
+    {
+      "path": "assets/map.json",
+      "originalSize": 856252,
+      "type": "JSON",
+      "compressions": [
+        {
+          "algorithm": "none",
+          "size": 856252,
+          "ratio": 1,
+          "time": 0
+        },
+        {
+          "algorithm": "gzip",
+          "size": 171855,
+          "ratio": 0.2007061005404951,
+          "time": 100.84367499999644
+        },
+        {
+          "algorithm": "brotli",
+          "size": 135908,
+          "ratio": 0.15872430078995436,
+          "time": 1524.9763900000034
+        }
+      ],
+      "bestAlgorithm": "brotli",
+      "savingsVsNone": 720344
+    },
+    {
+      "path": "assets/map_generated.json",
+      "originalSize": 856252,
+      "type": "JSON",
+      "compressions": [
+        {
+          "algorithm": "none",
+          "size": 856252,
+          "ratio": 1,
+          "time": 0
+        },
+        {
+          "algorithm": "gzip",
+          "size": 171855,
+          "ratio": 0.2007061005404951,
+          "time": 102.40713400000095
+        },
+        {
+          "algorithm": "brotli",
+          "size": 135908,
+          "ratio": 0.15872430078995436,
+          "time": 1589.4310350000014
+        }
+      ],
+      "bestAlgorithm": "brotli",
+      "savingsVsNone": 720344
+    },
+    {
+      "path": "assets/music-bindings.json",
+      "originalSize": 996,
+      "type": "JSON",
+      "compressions": [
+        {
+          "algorithm": "none",
+          "size": 996,
+          "ratio": 1,
+          "time": 0
+        },
+        {
+          "algorithm": "gzip",
+          "size": 368,
+          "ratio": 0.36947791164658633,
+          "time": 5.589277999999467
+        },
+        {
+          "algorithm": "brotli",
+          "size": 325,
+          "ratio": 0.32630522088353414,
+          "time": 2.9181209999951534
+        }
+      ],
+      "bestAlgorithm": "brotli",
+      "savingsVsNone": 671
+    },
+    {
+      "path": "assets/splash.png",
+      "originalSize": 1532319,
+      "type": "PNG Image",
+      "compressions": [
+        {
+          "algorithm": "none",
+          "size": 1532319,
+          "ratio": 1,
+          "time": 0
+        },
+        {
+          "algorithm": "gzip",
+          "size": 1532710,
+          "ratio": 1.000255168799708,
+          "time": 91.3948739999978
+        },
+        {
+          "algorithm": "brotli",
+          "size": 1532327,
+          "ratio": 1.0000052208450068,
+          "time": 1135.5354650000008
+        }
+      ],
+      "bestAlgorithm": "none",
+      "savingsVsNone": 0
+    }
+  ],
+  "summary": {
+    "totalOriginalSize": 20624146,
+    "bestCompressionByType": {},
+    "estimatedLoadTimes": {},
+    "annualBandwidthSavings": 5735073815000
+  },
+  "serverConfigs": {
+    "nginx": "# Nginx Compression Configuration\n# Add to your server block\n\n# Enable gzip\ngzip on;\ngzip_vary on;\ngzip_proxied any;\ngzip_comp_level 6;\ngzip_min_length 1000;\ngzip_types\n    text/plain\n    text/css\n    text/xml\n    text/javascript\n    application/json\n    application/javascript\n    application/xml+rss\n    application/atom+xml\n    image/svg+xml\n    font/woff\n    font/woff2;\n\n# Enable Brotli (requires ngx_brotli module)\nbrotli on;\nbrotli_comp_level 6;\nbrotli_min_length 1000;\nbrotli_types\n    text/plain\n    text/css\n    text/xml\n    text/javascript\n    application/json\n    application/javascript\n    application/xml+rss\n    application/atom+xml\n    image/svg+xml\n    font/woff\n    font/woff2;\n",
+    "apache": "# Apache Compression Configuration\n# Add to your .htaccess or virtual host config\n\n# Enable mod_deflate\n<IfModule mod_deflate.c>\n    # Compress HTML, CSS, JavaScript, Text, XML, fonts\n    AddOutputFilterByType DEFLATE application/javascript\n    AddOutputFilterByType DEFLATE application/rss+xml\n    AddOutputFilterByType DEFLATE application/vnd.ms-fontobject\n    AddOutputFilterByType DEFLATE application/x-font\n    AddOutputFilterByType DEFLATE application/x-font-opentype\n    AddOutputFilterByType DEFLATE application/x-font-otf\n    AddOutputFilterByType DEFLATE application/x-font-truetype\n    AddOutputFilterByType DEFLATE application/x-font-ttf\n    AddOutputFilterByType DEFLATE application/x-javascript\n    AddOutputFilterByType DEFLATE application/xhtml+xml\n    AddOutputFilterByType DEFLATE application/xml\n    AddOutputFilterByType DEFLATE font/opentype\n    AddOutputFilterByType DEFLATE font/otf\n    AddOutputFilterByType DEFLATE font/ttf\n    AddOutputFilterByType DEFLATE image/svg+xml\n    AddOutputFilterByType DEFLATE image/x-icon\n    AddOutputFilterByType DEFLATE text/css\n    AddOutputFilterByType DEFLATE text/html\n    AddOutputFilterByType DEFLATE text/javascript\n    AddOutputFilterByType DEFLATE text/plain\n    AddOutputFilterByType DEFLATE text/xml\n    \n    # Remove browser bugs\n    BrowserMatch ^Mozilla/4 gzip-only-text/html\n    BrowserMatch ^Mozilla/4\\.0[678] no-gzip\n    BrowserMatch \\bMSIE !no-gzip !gzip-only-text/html\n</IfModule>\n\n# Enable mod_brotli (Apache 2.4.26+)\n<IfModule mod_brotli.c>\n    AddOutputFilterByType BROTLI_COMPRESS text/html text/plain text/xml text/css text/javascript application/javascript application/json\n</IfModule>\n",
+    "vercel": "{\n  \"headers\": [\n    {\n      \"source\": \"/(.*)\",\n      \"headers\": [\n        {\n          \"key\": \"Cache-Control\",\n          \"value\": \"public, max-age=31536000, immutable\"\n        }\n      ]\n    }\n  ]\n}\n\n# Note: Vercel automatically handles Brotli and Gzip compression\n# No additional configuration needed\n",
+    "netlify": "# netlify.toml\n\n[build]\n  command = \"npm run build\"\n  publish = \"dist\"\n\n[[headers]]\n  for = \"/*\"\n  [headers.values]\n    X-Frame-Options = \"DENY\"\n    X-XSS-Protection = \"1; mode=block\"\n    \n# Netlify automatically compresses assets with Brotli and Gzip\n# For custom compression settings, use build plugins\n"
+  }
+}

--- a/tools/build-optimizer/stats/configs/apache.htaccess
+++ b/tools/build-optimizer/stats/configs/apache.htaccess
@@ -1,0 +1,38 @@
+# Apache Compression Configuration
+# Add to your .htaccess or virtual host config
+
+# Enable mod_deflate
+<IfModule mod_deflate.c>
+    # Compress HTML, CSS, JavaScript, Text, XML, fonts
+    AddOutputFilterByType DEFLATE application/javascript
+    AddOutputFilterByType DEFLATE application/rss+xml
+    AddOutputFilterByType DEFLATE application/vnd.ms-fontobject
+    AddOutputFilterByType DEFLATE application/x-font
+    AddOutputFilterByType DEFLATE application/x-font-opentype
+    AddOutputFilterByType DEFLATE application/x-font-otf
+    AddOutputFilterByType DEFLATE application/x-font-truetype
+    AddOutputFilterByType DEFLATE application/x-font-ttf
+    AddOutputFilterByType DEFLATE application/x-javascript
+    AddOutputFilterByType DEFLATE application/xhtml+xml
+    AddOutputFilterByType DEFLATE application/xml
+    AddOutputFilterByType DEFLATE font/opentype
+    AddOutputFilterByType DEFLATE font/otf
+    AddOutputFilterByType DEFLATE font/ttf
+    AddOutputFilterByType DEFLATE image/svg+xml
+    AddOutputFilterByType DEFLATE image/x-icon
+    AddOutputFilterByType DEFLATE text/css
+    AddOutputFilterByType DEFLATE text/html
+    AddOutputFilterByType DEFLATE text/javascript
+    AddOutputFilterByType DEFLATE text/plain
+    AddOutputFilterByType DEFLATE text/xml
+    
+    # Remove browser bugs
+    BrowserMatch ^Mozilla/4 gzip-only-text/html
+    BrowserMatch ^Mozilla/4\.0[678] no-gzip
+    BrowserMatch \bMSIE !no-gzip !gzip-only-text/html
+</IfModule>
+
+# Enable mod_brotli (Apache 2.4.26+)
+<IfModule mod_brotli.c>
+    AddOutputFilterByType BROTLI_COMPRESS text/html text/plain text/xml text/css text/javascript application/javascript application/json
+</IfModule>

--- a/tools/build-optimizer/stats/configs/netlify.toml
+++ b/tools/build-optimizer/stats/configs/netlify.toml
@@ -1,0 +1,14 @@
+# netlify.toml
+
+[build]
+  command = "npm run build"
+  publish = "dist"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    X-XSS-Protection = "1; mode=block"
+    
+# Netlify automatically compresses assets with Brotli and Gzip
+# For custom compression settings, use build plugins

--- a/tools/build-optimizer/stats/configs/nginx.conf
+++ b/tools/build-optimizer/stats/configs/nginx.conf
@@ -1,0 +1,38 @@
+# Nginx Compression Configuration
+# Add to your server block
+
+# Enable gzip
+gzip on;
+gzip_vary on;
+gzip_proxied any;
+gzip_comp_level 6;
+gzip_min_length 1000;
+gzip_types
+    text/plain
+    text/css
+    text/xml
+    text/javascript
+    application/json
+    application/javascript
+    application/xml+rss
+    application/atom+xml
+    image/svg+xml
+    font/woff
+    font/woff2;
+
+# Enable Brotli (requires ngx_brotli module)
+brotli on;
+brotli_comp_level 6;
+brotli_min_length 1000;
+brotli_types
+    text/plain
+    text/css
+    text/xml
+    text/javascript
+    application/json
+    application/javascript
+    application/xml+rss
+    application/atom+xml
+    image/svg+xml
+    font/woff
+    font/woff2;

--- a/tools/build-optimizer/stats/configs/vercel.json
+++ b/tools/build-optimizer/stats/configs/vercel.json
@@ -1,0 +1,16 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    }
+  ]
+}
+
+# Note: Vercel automatically handles Brotli and Gzip compression
+# No additional configuration needed

--- a/tools/build-optimizer/stats/tree-shaking-report.json
+++ b/tools/build-optimizer/stats/tree-shaking-report.json
@@ -1,806 +1,1220 @@
 {
-  "totalFiles": 131,
-  "totalExports": 912,
-  "unusedExports": 576,
-  "totalUnusedBytes": 941832,
+  "totalFiles": 226,
+  "totalExports": 1559,
+  "unusedExports": 747,
+  "totalUnusedBytes": 1098547,
   "files": [
     {
-      "path": "foliage/index.ts",
+      "path": "utils/wasm-loader-core.ts",
       "exports": [
         {
-          "name": "./common.ts",
-          "type": "const",
-          "line": 3,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./berries.ts",
-          "type": "const",
-          "line": 4,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./grass.ts",
-          "type": "const",
-          "line": 5,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./mushrooms.ts",
-          "type": "const",
-          "line": 6,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./flowers.ts",
-          "type": "const",
-          "line": 7,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./trees.ts",
-          "type": "const",
-          "line": 8,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./clouds.ts",
-          "type": "const",
-          "line": 9,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./waterfalls.ts",
-          "type": "const",
-          "line": 10,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./cave.ts",
-          "type": "const",
-          "line": 11,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./environment.ts",
-          "type": "const",
-          "line": 12,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./fireflies.ts",
-          "type": "const",
-          "line": 13,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./animation.ts",
-          "type": "const",
-          "line": 14,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./water.ts",
-          "type": "const",
-          "line": 15,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./terrain.ts",
-          "type": "const",
-          "line": 16,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./lake_features.js",
-          "type": "const",
-          "line": 17,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./glitch.ts",
-          "type": "const",
-          "line": 18,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./chromatic.ts",
-          "type": "const",
-          "line": 19,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./strobe.ts",
-          "type": "const",
-          "line": 20,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "createLanternFlower",
-          "type": "const",
-          "line": 23,
-          "isUsed": true,
-          "usedIn": [
-            "systems/weather.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "./sky.ts",
-          "type": "const",
-          "line": 26,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./stars.ts",
-          "type": "const",
-          "line": 27,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./moon.ts",
-          "type": "const",
-          "line": 28,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./celestial-bodies.ts",
-          "type": "const",
-          "line": 29,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./rainbow.ts",
-          "type": "const",
-          "line": 30,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./aurora.ts",
-          "type": "const",
-          "line": 31,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./panning-pads.ts",
-          "type": "const",
-          "line": 32,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./silence-spirits.ts",
-          "type": "const",
-          "line": 33,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./instrument.ts",
-          "type": "const",
-          "line": 34,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./ribbons.ts",
-          "type": "const",
+          "name": "wasmInstance",
+          "type": "let",
           "line": 35,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./mirrors.ts",
-          "type": "const",
-          "line": 36,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./sparkle-trail.ts",
-          "type": "const",
-          "line": 37,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./impacts.ts",
-          "type": "const",
-          "line": 38,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./discovery-effect.ts",
-          "type": "const",
-          "line": 39,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./lotus.ts",
-          "type": "const",
-          "line": 40,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./pollen.ts",
-          "type": "const",
-          "line": 41,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./shield.ts",
-          "type": "const",
-          "line": 42,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "musicReactivitySystem",
-          "type": "const",
-          "line": 45,
           "isUsed": true,
           "usedIn": [
-            "main.ts",
-            "systems/weather.ts"
+            "utils/wasm-animations.ts",
+            "utils/wasm-batch-animation.ts",
+            "utils/wasm-batch-core.ts",
+            "utils/wasm-physics.ts"
           ],
           "size": 0
         },
         {
-          "name": "./musical_flora.ts",
-          "type": "const",
+          "name": "wasmMemory",
+          "type": "let",
+          "line": 36,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/animation.ts",
+            "utils/wasm-batch-core.ts",
+            "utils/wasm-physics.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "positionView",
+          "type": "let",
+          "line": 37,
+          "isUsed": true,
+          "usedIn": [
+            "rendering/materials.ts",
+            "utils/wasm-batch-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "animationView",
+          "type": "let",
+          "line": 38,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-batch-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "outputView",
+          "type": "let",
+          "line": 39,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-batch-animation.ts",
+            "utils/wasm-batch-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "playerStateView",
+          "type": "let",
+          "line": 40,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-physics.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "sharedF32",
+          "type": "let",
+          "line": 43,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "wasmGetGroundHeight",
+          "type": "let",
+          "line": 46,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-physics.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "wasmFreqToHue",
+          "type": "let",
+          "line": 47,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-physics.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "wasmLerp",
+          "type": "let",
           "line": 48,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-physics.ts"
+          ],
+          "size": 0
         },
         {
-          "name": "./arpeggio-batcher.ts",
-          "type": "const",
+          "name": "wasmBatchMushroomSpawnCandidates",
+          "type": "let",
           "line": 49,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-batch-core.ts"
+          ],
+          "size": 0
         },
         {
-          "name": "./portamento-batcher.ts",
-          "type": "const",
+          "name": "wasmUpdateFoliageBatch",
+          "type": "let",
           "line": 50,
           "isUsed": false,
           "usedIn": [],
-          "size": 43
+          "size": 431
         },
         {
-          "name": "./wisteria-cluster.ts",
-          "type": "const",
-          "line": 51,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
+          "name": "wasmInitDynamicFoliageMemory",
+          "type": "let",
+          "line": 53,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-physics.ts"
+          ],
+          "size": 0
         },
         {
-          "name": "./mushroom-batcher.ts",
-          "type": "const",
+          "name": "wasmInitCollisionSystem",
+          "type": "let",
           "line": 54,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-physics.ts"
+          ],
+          "size": 0
         },
         {
-          "name": "./cloud-batcher.ts",
-          "type": "const",
+          "name": "wasmAddCollisionObject",
+          "type": "let",
           "line": 55,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-physics.ts"
+          ],
+          "size": 0
         },
         {
-          "name": "./dandelion-batcher.ts",
-          "type": "const",
+          "name": "wasmResolveGameCollisions",
+          "type": "let",
           "line": 56,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-physics.ts"
+          ],
+          "size": 0
         },
         {
-          "name": "./dandelion-seeds.ts",
-          "type": "const",
+          "name": "wasmCheckPositionValidity",
+          "type": "let",
           "line": 57,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-physics.ts"
+          ],
+          "size": 0
         },
         {
-          "name": "./lantern-batcher.ts",
-          "type": "const",
-          "line": 58,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./simple-flower-batcher.ts",
-          "type": "const",
-          "line": 59,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./glowing-flower-batcher.ts",
-          "type": "const",
+          "name": "wasmSmoothWobble",
+          "type": "let",
           "line": 60,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
+          "isUsed": true,
+          "usedIn": [
+            "foliage/animation.ts"
+          ],
+          "size": 0
         },
         {
-          "name": "./waterfall-batcher.ts",
-          "type": "const",
+          "name": "wasmBatchGrowth",
+          "type": "let",
           "line": 61,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
+          "isUsed": true,
+          "usedIn": [
+            "foliage/animation.ts"
+          ],
+          "size": 0
         },
         {
-          "name": "./tree-batcher.ts",
-          "type": "const",
+          "name": "wasmBatchBloom",
+          "type": "let",
           "line": 62,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/animation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "wasmBatchScaleAnimation",
+          "type": "let",
+          "line": 63,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/animation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "wasmBatchGroundHeight",
+          "type": "let",
+          "line": 66,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-physics.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "wasmDampVelocity",
+          "type": "let",
+          "line": 67,
           "isUsed": false,
           "usedIn": [],
-          "size": 43
+          "size": 431
+        },
+        {
+          "name": "wasmBatchDistanceCalc",
+          "type": "let",
+          "line": 68,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "wasmBatchFrustumTest",
+          "type": "let",
+          "line": 69,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "wasmBatchLODSelect",
+          "type": "let",
+          "line": 70,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "wasmHslToRgb",
+          "type": "let",
+          "line": 73,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-physics.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "wasmHash2D",
+          "type": "let",
+          "line": 74,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-physics.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "wasmValueNoise2D",
+          "type": "let",
+          "line": 75,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-physics.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "wasmFbm2D",
+          "type": "let",
+          "line": 76,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-physics.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "wasmDistSq2D",
+          "type": "let",
+          "line": 77,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-physics.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "wasmDistSq3D",
+          "type": "let",
+          "line": 78,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-physics.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "wasmSmoothstep",
+          "type": "let",
+          "line": 79,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-physics.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "wasmInverseLerp",
+          "type": "let",
+          "line": 80,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-physics.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "wasmBatchHslToRgb",
+          "type": "let",
+          "line": 83,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-batch-animation.ts",
+            "utils/wasm-batch-math.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "wasmBatchSphereCull",
+          "type": "let",
+          "line": 84,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-batch-animation.ts",
+            "utils/wasm-batch-math.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "wasmBatchLerp",
+          "type": "let",
+          "line": 85,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-batch-animation.ts",
+            "utils/wasm-batch-math.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "wasmUpdateParticles",
+          "type": "let",
+          "line": 88,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-batch-particles.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "wasmSpawnBurst",
+          "type": "let",
+          "line": 89,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-batch-particles.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "cppValueNoise2DSimd4",
+          "type": "let",
+          "line": 96,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-batch-math.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "cppFbm2DSimd4",
+          "type": "let",
+          "line": 97,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-batch-math.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "cppBatchGroundHeightSimd",
+          "type": "let",
+          "line": 98,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-batch-math.ts",
+            "utils/wasm-batch-particles.ts",
+            "utils/wasm-physics.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "cppBatchValueNoiseOmp",
+          "type": "let",
+          "line": 99,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-batch-math.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "cppBatchFbmOmp",
+          "type": "let",
+          "line": 100,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-batch-math.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "cppBatchDistSq3DOmp",
+          "type": "let",
+          "line": 101,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-batch-math.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "cppFastSin",
+          "type": "let",
+          "line": 102,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-batch-math.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "cppFastCos",
+          "type": "let",
+          "line": 103,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-batch-math.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "cppFastPow2",
+          "type": "let",
+          "line": 104,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-batch-math.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "cppBatchShiverSimd",
+          "type": "let",
+          "line": 107,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "cppBatchSpringSimd",
+          "type": "let",
+          "line": 108,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "cppBatchFloatSimd",
+          "type": "let",
+          "line": 109,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "cppBatchCloudBobSimd",
+          "type": "let",
+          "line": 110,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "cppBatchVineSwaySimd",
+          "type": "let",
+          "line": 111,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "cppBatchGeyserEruptC",
+          "type": "let",
+          "line": 112,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "cppBatchRetriggerSimd",
+          "type": "let",
+          "line": 113,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "emscriptenInstance",
+          "type": "let",
+          "line": 116,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-batch-animation.ts",
+            "utils/wasm-batch-math.ts",
+            "utils/wasm-batch-particles.ts",
+            "utils/wasm-physics.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "emscriptenMemory",
+          "type": "let",
+          "line": 117,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-batch-animation.ts",
+            "utils/wasm-batch-particles.ts",
+            "utils/wasm-physics.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "POSITION_OFFSET",
+          "type": "const",
+          "line": 124,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-physics.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "ANIMATION_OFFSET",
+          "type": "const",
+          "line": 125,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "OUTPUT_OFFSET",
+          "type": "const",
+          "line": 126,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/animation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "PLAYER_STATE_OFFSET",
+          "type": "const",
+          "line": 127,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "AnimationType",
+          "type": "const",
+          "line": 130,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "AnimationTypeValue",
+          "type": "type",
+          "line": 138,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "WasiStubs",
+          "type": "interface",
+          "line": 147,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "WasmImportObject",
+          "type": "interface",
+          "line": 165,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "EmscriptenModule",
+          "type": "interface",
+          "line": 177,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "ExtendedEmscriptenModule",
+          "type": "interface",
+          "line": 191,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "Positionable",
+          "type": "interface",
+          "line": 241,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "Mushroom",
+          "type": "interface",
+          "line": 252,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "Matrix4Like",
+          "type": "interface",
+          "line": 265,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "Vector3Like",
+          "type": "interface",
+          "line": 270,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "Cave",
+          "type": "interface",
+          "line": 278,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "Cloud",
+          "type": "interface",
+          "line": 289,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "Trampoline",
+          "type": "interface",
+          "line": 303,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "MaterialInfo",
+          "type": "interface",
+          "line": 313,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-batch-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "AnimationData",
+          "type": "interface",
+          "line": 323,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "PositionData",
+          "type": "interface",
+          "line": 333,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "PlayerState",
+          "type": "interface",
+          "line": 343,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-states.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "WasmExportValue",
+          "type": "type",
+          "line": 360,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "WasmExports",
+          "type": "interface",
+          "line": 365,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "initCppFunctions",
+          "type": "function",
+          "line": 570,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "updateWasmProgress",
+          "type": "function",
+          "line": 619,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "loadEmscriptenModule",
+          "type": "function",
+          "line": 634,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "getWasmMemory",
+          "type": "function",
+          "line": 829,
+          "isUsed": true,
+          "usedIn": [
+            "compute/mesh_deformation_wasm.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getEmscriptenMemory",
+          "type": "function",
+          "line": 837,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "getNativeFunc",
+          "type": "function",
+          "line": 846,
+          "isUsed": true,
+          "usedIn": [
+            "compute/mesh_deformation.ts",
+            "compute/mesh_deformation_wasm.ts",
+            "utils/wasm-animations.ts",
+            "utils/wasm-batch-animation.ts",
+            "utils/wasm-physics.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "isWasmReady",
+          "type": "function",
+          "line": 867,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/animation.ts",
+            "systems/weather/weather-ecosystem.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "isEmscriptenReady",
+          "type": "function",
+          "line": 875,
+          "isUsed": true,
+          "usedIn": [
+            "compute/mesh_deformation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getWasmInstance",
+          "type": "function",
+          "line": 883,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/batcher/foliage-batcher-core.ts",
+            "systems/discovery-optimized.ts",
+            "systems/material-batcher.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getEmscriptenInstance",
+          "type": "function",
+          "line": 891,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "InitWasmParallelOptions",
+          "type": "interface",
+          "line": 900,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "initWasm",
+          "type": "function",
+          "line": 906,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "initWasmParallel",
+          "type": "function",
+          "line": 941,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
         }
       ],
-      "imports": [],
+      "imports": [
+        "updateProgress",
+        "parallelWasmLoad",
+        "LOADING_PHASES",
+        "initSharedBuffer",
+        "getSharedBuffer",
+        "isSharedMemoryAvailable",
+        "type ParallelWasmLoadOptions",
+        "checkWasmFileExists",
+        "inspectWasmExports",
+        "patchWasmInstantiateAliases",
+        "showToast",
+        "initCandyPhysics",
+        "default"
+      ],
       "unusedExports": [
         {
-          "name": "./common.ts",
-          "type": "const",
-          "line": 3,
+          "name": "sharedF32",
+          "type": "let",
+          "line": 43,
           "isUsed": false,
           "usedIn": [],
-          "size": 43
+          "size": 431
         },
         {
-          "name": "./berries.ts",
-          "type": "const",
-          "line": 4,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./grass.ts",
-          "type": "const",
-          "line": 5,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./mushrooms.ts",
-          "type": "const",
-          "line": 6,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./flowers.ts",
-          "type": "const",
-          "line": 7,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./trees.ts",
-          "type": "const",
-          "line": 8,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./clouds.ts",
-          "type": "const",
-          "line": 9,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./waterfalls.ts",
-          "type": "const",
-          "line": 10,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./cave.ts",
-          "type": "const",
-          "line": 11,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./environment.ts",
-          "type": "const",
-          "line": 12,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./fireflies.ts",
-          "type": "const",
-          "line": 13,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./animation.ts",
-          "type": "const",
-          "line": 14,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./water.ts",
-          "type": "const",
-          "line": 15,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./terrain.ts",
-          "type": "const",
-          "line": 16,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./lake_features.js",
-          "type": "const",
-          "line": 17,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./glitch.ts",
-          "type": "const",
-          "line": 18,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./chromatic.ts",
-          "type": "const",
-          "line": 19,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./strobe.ts",
-          "type": "const",
-          "line": 20,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./sky.ts",
-          "type": "const",
-          "line": 26,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./stars.ts",
-          "type": "const",
-          "line": 27,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./moon.ts",
-          "type": "const",
-          "line": 28,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./celestial-bodies.ts",
-          "type": "const",
-          "line": 29,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./rainbow.ts",
-          "type": "const",
-          "line": 30,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./aurora.ts",
-          "type": "const",
-          "line": 31,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./panning-pads.ts",
-          "type": "const",
-          "line": 32,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./silence-spirits.ts",
-          "type": "const",
-          "line": 33,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./instrument.ts",
-          "type": "const",
-          "line": 34,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./ribbons.ts",
-          "type": "const",
-          "line": 35,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./mirrors.ts",
-          "type": "const",
-          "line": 36,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./sparkle-trail.ts",
-          "type": "const",
-          "line": 37,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./impacts.ts",
-          "type": "const",
-          "line": 38,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./discovery-effect.ts",
-          "type": "const",
-          "line": 39,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./lotus.ts",
-          "type": "const",
-          "line": 40,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./pollen.ts",
-          "type": "const",
-          "line": 41,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./shield.ts",
-          "type": "const",
-          "line": 42,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./musical_flora.ts",
-          "type": "const",
-          "line": 48,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./arpeggio-batcher.ts",
-          "type": "const",
-          "line": 49,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 43
-        },
-        {
-          "name": "./portamento-batcher.ts",
-          "type": "const",
+          "name": "wasmUpdateFoliageBatch",
+          "type": "let",
           "line": 50,
           "isUsed": false,
           "usedIn": [],
-          "size": 43
+          "size": 431
         },
         {
-          "name": "./wisteria-cluster.ts",
-          "type": "const",
-          "line": 51,
+          "name": "wasmDampVelocity",
+          "type": "let",
+          "line": 67,
           "isUsed": false,
           "usedIn": [],
-          "size": 43
+          "size": 431
         },
         {
-          "name": "./mushroom-batcher.ts",
-          "type": "const",
-          "line": 54,
+          "name": "wasmBatchDistanceCalc",
+          "type": "let",
+          "line": 68,
           "isUsed": false,
           "usedIn": [],
-          "size": 43
+          "size": 431
         },
         {
-          "name": "./cloud-batcher.ts",
-          "type": "const",
-          "line": 55,
+          "name": "wasmBatchFrustumTest",
+          "type": "let",
+          "line": 69,
           "isUsed": false,
           "usedIn": [],
-          "size": 43
+          "size": 431
         },
         {
-          "name": "./dandelion-batcher.ts",
-          "type": "const",
-          "line": 56,
+          "name": "wasmBatchLODSelect",
+          "type": "let",
+          "line": 70,
           "isUsed": false,
           "usedIn": [],
-          "size": 43
+          "size": 431
         },
         {
-          "name": "./dandelion-seeds.ts",
-          "type": "const",
-          "line": 57,
+          "name": "cppBatchShiverSimd",
+          "type": "let",
+          "line": 107,
           "isUsed": false,
           "usedIn": [],
-          "size": 43
+          "size": 431
         },
         {
-          "name": "./lantern-batcher.ts",
-          "type": "const",
-          "line": 58,
+          "name": "cppBatchSpringSimd",
+          "type": "let",
+          "line": 108,
           "isUsed": false,
           "usedIn": [],
-          "size": 43
+          "size": 431
         },
         {
-          "name": "./simple-flower-batcher.ts",
-          "type": "const",
-          "line": 59,
+          "name": "cppBatchFloatSimd",
+          "type": "let",
+          "line": 109,
           "isUsed": false,
           "usedIn": [],
-          "size": 43
+          "size": 431
         },
         {
-          "name": "./glowing-flower-batcher.ts",
-          "type": "const",
-          "line": 60,
+          "name": "cppBatchCloudBobSimd",
+          "type": "let",
+          "line": 110,
           "isUsed": false,
           "usedIn": [],
-          "size": 43
+          "size": 431
         },
         {
-          "name": "./waterfall-batcher.ts",
-          "type": "const",
-          "line": 61,
+          "name": "cppBatchVineSwaySimd",
+          "type": "let",
+          "line": 111,
           "isUsed": false,
           "usedIn": [],
-          "size": 43
+          "size": 431
         },
         {
-          "name": "./tree-batcher.ts",
-          "type": "const",
-          "line": 62,
+          "name": "cppBatchGeyserEruptC",
+          "type": "let",
+          "line": 112,
           "isUsed": false,
           "usedIn": [],
-          "size": 43
+          "size": 431
+        },
+        {
+          "name": "cppBatchRetriggerSimd",
+          "type": "let",
+          "line": 113,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "ANIMATION_OFFSET",
+          "type": "const",
+          "line": 125,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "PLAYER_STATE_OFFSET",
+          "type": "const",
+          "line": 127,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "AnimationType",
+          "type": "const",
+          "line": 130,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "AnimationTypeValue",
+          "type": "type",
+          "line": 138,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "WasiStubs",
+          "type": "interface",
+          "line": 147,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "WasmImportObject",
+          "type": "interface",
+          "line": 165,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "EmscriptenModule",
+          "type": "interface",
+          "line": 177,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "ExtendedEmscriptenModule",
+          "type": "interface",
+          "line": 191,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "Positionable",
+          "type": "interface",
+          "line": 241,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "Mushroom",
+          "type": "interface",
+          "line": 252,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "Matrix4Like",
+          "type": "interface",
+          "line": 265,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "Vector3Like",
+          "type": "interface",
+          "line": 270,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "Cave",
+          "type": "interface",
+          "line": 278,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "Cloud",
+          "type": "interface",
+          "line": 289,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "Trampoline",
+          "type": "interface",
+          "line": 303,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "AnimationData",
+          "type": "interface",
+          "line": 323,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "PositionData",
+          "type": "interface",
+          "line": 333,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "WasmExportValue",
+          "type": "type",
+          "line": 360,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "WasmExports",
+          "type": "interface",
+          "line": 365,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "initCppFunctions",
+          "type": "function",
+          "line": 570,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "updateWasmProgress",
+          "type": "function",
+          "line": 619,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "loadEmscriptenModule",
+          "type": "function",
+          "line": 634,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "getEmscriptenMemory",
+          "type": "function",
+          "line": 837,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "getEmscriptenInstance",
+          "type": "function",
+          "line": 891,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "InitWasmParallelOptions",
+          "type": "interface",
+          "line": 900,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
+        },
+        {
+          "name": "initWasmParallel",
+          "type": "function",
+          "line": 941,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 431
         }
       ],
-      "treeShakingScore": 4
+      "treeShakingScore": 58
     },
     {
       "path": "workers/worker-types.ts",
@@ -1426,9 +1840,11 @@
           "name": "SpawnCandidate",
           "type": "type",
           "line": 3,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 147
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-batch-core.ts"
+          ],
+          "size": 0
         },
         {
           "name": "AnimationType",
@@ -1444,7 +1860,7 @@
           "line": 12,
           "isUsed": true,
           "usedIn": [
-            "main.ts"
+            "core/main.ts"
           ],
           "size": 0
         },
@@ -1454,7 +1870,8 @@
           "line": 13,
           "isUsed": true,
           "usedIn": [
-            "systems/weather.ts"
+            "foliage/animation.ts",
+            "systems/weather/weather-ecosystem.ts"
           ],
           "size": 0
         },
@@ -1474,12 +1891,17 @@
           "line": 16,
           "isUsed": true,
           "usedIn": [
-            "main.ts",
+            "core/deferred-init.ts",
+            "core/game-loop.ts",
+            "core/main.ts",
             "particles/compute-particles.ts",
             "systems/glitch-grenade.ts",
-            "systems/physics.ts",
-            "systems/weather.ts",
-            "world/generation.ts"
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-states.ts",
+            "systems/physics/physics-updates.ts",
+            "systems/weather/weather-ecosystem.ts",
+            "world/generation.ts",
+            "world/ground-heightmap.ts"
           ],
           "size": 0
         },
@@ -1515,8 +1937,7 @@
           "line": 21,
           "isUsed": true,
           "usedIn": [
-            "foliage/musical_flora.ts",
-            "systems/weather.ts"
+            "foliage/musical_flora.ts"
           ],
           "size": 0
         },
@@ -1534,11 +1955,9 @@
           "name": "uploadAnimationData",
           "type": "function",
           "line": 27,
-          "isUsed": true,
-          "usedIn": [
-            "systems/weather.ts"
-          ],
-          "size": 0
+          "isUsed": false,
+          "usedIn": [],
+          "size": 147
         },
         {
           "name": "batchDistanceCull",
@@ -1554,7 +1973,7 @@
           "line": 35,
           "isUsed": true,
           "usedIn": [
-            "systems/weather.ts"
+            "systems/weather/weather-ecosystem.ts"
           ],
           "size": 0
         },
@@ -1564,7 +1983,7 @@
           "line": 39,
           "isUsed": true,
           "usedIn": [
-            "systems/weather.ts"
+            "systems/weather/weather-ecosystem.ts"
           ],
           "size": 0
         },
@@ -1728,14 +2147,6 @@
       ],
       "unusedExports": [
         {
-          "name": "SpawnCandidate",
-          "type": "type",
-          "line": 3,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 147
-        },
-        {
           "name": "AnimationType",
           "type": "const",
           "line": 5,
@@ -1755,6 +2166,14 @@
           "name": "lerpColor",
           "type": "function",
           "line": 19,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 147
+        },
+        {
+          "name": "uploadAnimationData",
+          "type": "function",
+          "line": 27,
           "isUsed": false,
           "usedIn": [],
           "size": 147
@@ -1915,898 +2334,743 @@
       "treeShakingScore": 32
     },
     {
-      "path": "particles/compute-particles.ts",
+      "path": "systems/accessibility.ts",
       "exports": [
         {
-          "name": "ComputeParticleType",
+          "name": "ColorBlindType",
           "type": "type",
-          "line": 52,
+          "line": 19,
           "isUsed": false,
           "usedIn": [],
-          "size": 2118
+          "size": 1276
         },
         {
-          "name": "ComputeParticleConfig",
+          "name": "UIScale",
+          "type": "type",
+          "line": 20,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1276
+        },
+        {
+          "name": "VerbosityLevel",
+          "type": "type",
+          "line": 21,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1276
+        },
+        {
+          "name": "CrosshairStyle",
+          "type": "type",
+          "line": 22,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1276
+        },
+        {
+          "name": "Keybinding",
           "type": "interface",
-          "line": 54,
+          "line": 24,
           "isUsed": false,
           "usedIn": [],
-          "size": 2118
+          "size": 1276
         },
         {
-          "name": "ParticleBuffers",
+          "name": "InputSettings",
           "type": "interface",
-          "line": 71,
+          "line": 32,
           "isUsed": false,
           "usedIn": [],
-          "size": 2118
+          "size": 1276
         },
         {
-          "name": "ParticleAudioData",
+          "name": "VisualSettings",
           "type": "interface",
-          "line": 80,
+          "line": 43,
           "isUsed": false,
           "usedIn": [],
-          "size": 2118
+          "size": 1276
         },
         {
-          "name": "ComputeParticleSystem",
+          "name": "CognitiveSettings",
+          "type": "interface",
+          "line": 59,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1276
+        },
+        {
+          "name": "AuditorySettings",
+          "type": "interface",
+          "line": 70,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1276
+        },
+        {
+          "name": "ScreenReaderSettings",
+          "type": "interface",
+          "line": 83,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1276
+        },
+        {
+          "name": "AccessibilitySettings",
+          "type": "interface",
+          "line": 91,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1276
+        },
+        {
+          "name": "AccessibilityPreset",
+          "type": "interface",
+          "line": 99,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1276
+        },
+        {
+          "name": "defaultSettings",
+          "type": "const",
+          "line": 127,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1276
+        },
+        {
+          "name": "colorBlindMatrices",
+          "type": "const",
+          "line": 189,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1276
+        },
+        {
+          "name": "validateColorMatrices",
+          "type": "function",
+          "line": 227,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1276
+        },
+        {
+          "name": "accessibilityPresets",
+          "type": "const",
+          "line": 241,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1276
+        },
+        {
+          "name": "AccessibilitySystem",
           "type": "class",
+          "line": 395,
+          "isUsed": true,
+          "usedIn": [
+            "ui/accessibility-menu-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getAccessibilitySystem",
+          "type": "function",
+          "line": 937,
+          "isUsed": true,
+          "usedIn": [
+            "ui/accessibility-menu-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "initAccessibilitySystem",
+          "type": "function",
+          "line": 944,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1276
+        },
+        {
+          "name": "applyColorBlindMode",
+          "type": "function",
+          "line": 952,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1276
+        },
+        {
+          "name": "setMotionReduction",
+          "type": "function",
+          "line": 956,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1276
+        },
+        {
+          "name": "announce",
+          "type": "function",
+          "line": 960,
+          "isUsed": true,
+          "usedIn": [
+            "core/input/audio-controls.ts",
+            "core/input/playlist-manager.ts",
+            "ui/accessibility-menu-core.ts",
+            "ui/accessibility-menu-handlers.ts",
+            "ui/save-menu/save-menu.ts",
+            "utils/toast.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getCurrentSettings",
+          "type": "function",
+          "line": 964,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1276
+        },
+        {
+          "name": "AnnouncementPriority",
+          "type": "const",
           "line": 969,
-          "isUsed": true,
-          "usedIn": [
-            "compute/particle_compute.ts",
-            "particles/compute-integration.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "FireflyConfig",
-          "type": "interface",
-          "line": 1379,
           "isUsed": false,
           "usedIn": [],
-          "size": 2118
-        },
-        {
-          "name": "PollenConfig",
-          "type": "interface",
-          "line": 1384,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2118
-        },
-        {
-          "name": "BerryConfig",
-          "type": "interface",
-          "line": 1389,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2118
-        },
-        {
-          "name": "RainConfig",
-          "type": "interface",
-          "line": 1394,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2118
-        },
-        {
-          "name": "SparkConfig",
-          "type": "interface",
-          "line": 1399,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2118
-        },
-        {
-          "name": "createComputeFireflies",
-          "type": "function",
-          "line": 1409,
-          "isUsed": true,
-          "usedIn": [
-            "particles/compute-integration.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "createComputePollen",
-          "type": "function",
-          "line": 1425,
-          "isUsed": true,
-          "usedIn": [
-            "particles/compute-integration.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "createComputeBerries",
-          "type": "function",
-          "line": 1441,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2118
-        },
-        {
-          "name": "createComputeRain",
-          "type": "function",
-          "line": 1457,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2118
-        },
-        {
-          "name": "createComputeSparks",
-          "type": "function",
-          "line": 1473,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2118
-        },
-        {
-          "name": "ComputeSystemCollection",
-          "type": "interface",
-          "line": 1488,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2118
-        },
-        {
-          "name": "initComputeParticleSystems",
-          "type": "function",
-          "line": 1498,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2118
-        },
-        {
-          "name": "addComputeSystem",
-          "type": "function",
-          "line": 1503,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2118
-        },
-        {
-          "name": "removeComputeSystem",
-          "type": "function",
-          "line": 1507,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2118
-        },
-        {
-          "name": "updateAllComputeSystems",
-          "type": "function",
-          "line": 1514,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2118
-        },
-        {
-          "name": "disposeAllComputeSystems",
-          "type": "function",
-          "line": 1527,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2118
-        },
-        {
-          "name": "getActiveComputeSystems",
-          "type": "function",
-          "line": 1536,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2118
-        },
-        {
-          "name": "UPDATE_PARTICLES_WGSL",
-          "type": "const",
-          "line": 1541,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2118
-        },
-        {
-          "name": "RENDER_PARTICLES_WGSL",
-          "type": "const",
-          "line": 1541,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2118
-        },
-        {
-          "name": "FRAGMENT_PARTICLES_WGSL",
-          "type": "const",
-          "line": 1541,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2118
-        },
-        {
-          "name": "default",
-          "type": "function",
-          "line": 1544,
-          "isUsed": true,
-          "usedIn": [
-            "world/generation.ts"
-          ],
-          "size": 0
+          "size": 1276
         }
       ],
-      "imports": [
-        "MeshStandardNodeMaterial",
-        "PointsNodeMaterial",
-        "StorageBufferAttribute",
-        "Fn",
-        "uniform",
-        "storage",
-        "instanceIndex",
-        "vertexIndex",
-        "float",
-        "vec3",
-        "vec4",
-        "mix",
-        "sin",
-        "cos",
-        "normalize",
-        "color",
-        "attribute",
-        "mx_noise_float",
-        "positionLocal",
-        "max",
-        "length",
-        "min",
-        "pow",
-        "abs",
-        "smoothstep",
-        "discard",
-        "uv",
-        "distance",
-        "time",
-        "sqrt",
-        "dot",
-        "cross",
-        "cameraPosition",
-        "uTime",
-        "uAudioLow",
-        "uAudioHigh",
-        "uPlayerPosition",
-        "uWindSpeed",
-        "uWindDirection",
-        "getGroundHeight",
-        "THREE"
-      ],
+      "imports": [],
       "unusedExports": [
         {
-          "name": "ComputeParticleType",
+          "name": "ColorBlindType",
           "type": "type",
-          "line": 52,
+          "line": 19,
           "isUsed": false,
           "usedIn": [],
-          "size": 2118
+          "size": 1276
         },
         {
-          "name": "ComputeParticleConfig",
+          "name": "UIScale",
+          "type": "type",
+          "line": 20,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1276
+        },
+        {
+          "name": "VerbosityLevel",
+          "type": "type",
+          "line": 21,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1276
+        },
+        {
+          "name": "CrosshairStyle",
+          "type": "type",
+          "line": 22,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1276
+        },
+        {
+          "name": "Keybinding",
           "type": "interface",
-          "line": 54,
+          "line": 24,
           "isUsed": false,
           "usedIn": [],
-          "size": 2118
+          "size": 1276
         },
         {
-          "name": "ParticleBuffers",
+          "name": "InputSettings",
           "type": "interface",
-          "line": 71,
+          "line": 32,
           "isUsed": false,
           "usedIn": [],
-          "size": 2118
+          "size": 1276
         },
         {
-          "name": "ParticleAudioData",
+          "name": "VisualSettings",
           "type": "interface",
-          "line": 80,
+          "line": 43,
           "isUsed": false,
           "usedIn": [],
-          "size": 2118
+          "size": 1276
         },
         {
-          "name": "FireflyConfig",
+          "name": "CognitiveSettings",
           "type": "interface",
-          "line": 1379,
+          "line": 59,
           "isUsed": false,
           "usedIn": [],
-          "size": 2118
+          "size": 1276
         },
         {
-          "name": "PollenConfig",
+          "name": "AuditorySettings",
           "type": "interface",
-          "line": 1384,
+          "line": 70,
           "isUsed": false,
           "usedIn": [],
-          "size": 2118
+          "size": 1276
         },
         {
-          "name": "BerryConfig",
+          "name": "ScreenReaderSettings",
           "type": "interface",
-          "line": 1389,
+          "line": 83,
           "isUsed": false,
           "usedIn": [],
-          "size": 2118
+          "size": 1276
         },
         {
-          "name": "RainConfig",
+          "name": "AccessibilitySettings",
           "type": "interface",
-          "line": 1394,
+          "line": 91,
           "isUsed": false,
           "usedIn": [],
-          "size": 2118
+          "size": 1276
         },
         {
-          "name": "SparkConfig",
+          "name": "AccessibilityPreset",
           "type": "interface",
-          "line": 1399,
+          "line": 99,
           "isUsed": false,
           "usedIn": [],
-          "size": 2118
+          "size": 1276
         },
         {
-          "name": "createComputeBerries",
-          "type": "function",
-          "line": 1441,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2118
-        },
-        {
-          "name": "createComputeRain",
-          "type": "function",
-          "line": 1457,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2118
-        },
-        {
-          "name": "createComputeSparks",
-          "type": "function",
-          "line": 1473,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2118
-        },
-        {
-          "name": "ComputeSystemCollection",
-          "type": "interface",
-          "line": 1488,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2118
-        },
-        {
-          "name": "initComputeParticleSystems",
-          "type": "function",
-          "line": 1498,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2118
-        },
-        {
-          "name": "addComputeSystem",
-          "type": "function",
-          "line": 1503,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2118
-        },
-        {
-          "name": "removeComputeSystem",
-          "type": "function",
-          "line": 1507,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2118
-        },
-        {
-          "name": "updateAllComputeSystems",
-          "type": "function",
-          "line": 1514,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2118
-        },
-        {
-          "name": "disposeAllComputeSystems",
-          "type": "function",
-          "line": 1527,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2118
-        },
-        {
-          "name": "getActiveComputeSystems",
-          "type": "function",
-          "line": 1536,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2118
-        },
-        {
-          "name": "UPDATE_PARTICLES_WGSL",
+          "name": "defaultSettings",
           "type": "const",
-          "line": 1541,
+          "line": 127,
           "isUsed": false,
           "usedIn": [],
-          "size": 2118
+          "size": 1276
         },
         {
-          "name": "RENDER_PARTICLES_WGSL",
+          "name": "colorBlindMatrices",
           "type": "const",
-          "line": 1541,
+          "line": 189,
           "isUsed": false,
           "usedIn": [],
-          "size": 2118
+          "size": 1276
         },
         {
-          "name": "FRAGMENT_PARTICLES_WGSL",
-          "type": "const",
-          "line": 1541,
+          "name": "validateColorMatrices",
+          "type": "function",
+          "line": 227,
           "isUsed": false,
           "usedIn": [],
-          "size": 2118
+          "size": 1276
+        },
+        {
+          "name": "accessibilityPresets",
+          "type": "const",
+          "line": 241,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1276
+        },
+        {
+          "name": "initAccessibilitySystem",
+          "type": "function",
+          "line": 944,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1276
+        },
+        {
+          "name": "applyColorBlindMode",
+          "type": "function",
+          "line": 952,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1276
+        },
+        {
+          "name": "setMotionReduction",
+          "type": "function",
+          "line": 956,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1276
+        },
+        {
+          "name": "getCurrentSettings",
+          "type": "function",
+          "line": 964,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1276
+        },
+        {
+          "name": "AnnouncementPriority",
+          "type": "const",
+          "line": 969,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1276
         }
       ],
-      "treeShakingScore": 15
+      "treeShakingScore": 13
     },
     {
-      "path": "systems/asset-streaming.ts",
+      "path": "utils/wasm-animations.ts",
       "exports": [
         {
-          "name": "AssetPriority",
-          "type": "enum",
-          "line": 28,
-          "isUsed": true,
-          "usedIn": [
-            "examples/asset-streaming-usage.ts",
-            "systems/index.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "AssetType",
-          "type": "enum",
-          "line": 37,
+          "name": "WobbleResult",
+          "type": "interface",
+          "line": 27,
           "isUsed": false,
           "usedIn": [],
-          "size": 1799
+          "size": 843
         },
         {
-          "name": "TextureFormat",
-          "type": "enum",
-          "line": 48,
+          "name": "AccordionResult",
+          "type": "interface",
+          "line": 35,
           "isUsed": false,
           "usedIn": [],
-          "size": 1799
+          "size": 843
         },
         {
-          "name": "LoadingState",
-          "type": "enum",
-          "line": 58,
+          "name": "FiberResult",
+          "type": "interface",
+          "line": 43,
           "isUsed": false,
           "usedIn": [],
-          "size": 1799
+          "size": 843
         },
         {
-          "name": "QualityLevel",
-          "type": "enum",
+          "name": "ShiverResult",
+          "type": "interface",
+          "line": 51,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 843
+        },
+        {
+          "name": "SpiralResult",
+          "type": "interface",
+          "line": 59,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 843
+        },
+        {
+          "name": "PrismResult",
+          "type": "interface",
           "line": 68,
-          "isUsed": true,
-          "usedIn": [
-            "examples/asset-streaming-usage.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "MemoryPressure",
-          "type": "enum",
-          "line": 77,
           "isUsed": false,
           "usedIn": [],
-          "size": 1799
+          "size": 843
         },
         {
-          "name": "AssetMetadata",
+          "name": "ArpeggioResult",
+          "type": "interface",
+          "line": 78,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 843
+        },
+        {
+          "name": "ParticleResult",
           "type": "interface",
           "line": 86,
           "isUsed": false,
           "usedIn": [],
-          "size": 1799
+          "size": 843
         },
         {
-          "name": "AssetManifest",
-          "type": "interface",
-          "line": 103,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "LoadedAsset",
-          "type": "interface",
-          "line": 112,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "LoadingProgress",
-          "type": "interface",
-          "line": 126,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "NetworkStats",
-          "type": "interface",
-          "line": 137,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "StreamingConfig",
-          "type": "interface",
-          "line": 147,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "StreamingStats",
-          "type": "interface",
-          "line": 186,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "DEFAULT_STREAMING_CONFIG",
-          "type": "const",
-          "line": 208,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "PRIORITY_DISTANCES",
-          "type": "const",
-          "line": 241,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "QUALITY_FORMAT_PREFERENCES",
-          "type": "const",
-          "line": 250,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "LRUCache",
-          "type": "class",
-          "line": 266,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "NetworkManager",
-          "type": "class",
-          "line": 371,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "ProgressiveTextureLoader",
-          "type": "class",
-          "line": 547,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "AudioStreamingLoader",
-          "type": "class",
-          "line": 612,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "GeometryLODLoader",
-          "type": "class",
-          "line": 674,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "PlaceholderManager",
-          "type": "class",
-          "line": 721,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "AssetStreamer",
-          "type": "class",
-          "line": 833,
-          "isUsed": true,
-          "usedIn": [
-            "examples/asset-streaming-usage.ts",
-            "systems/index.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "createSampleManifest",
+          "name": "calcBounceY",
           "type": "function",
-          "line": 1579,
-          "isUsed": true,
-          "usedIn": [
-            "examples/asset-streaming-usage.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "estimateTextureMemory",
-          "type": "function",
-          "line": 1590,
+          "line": 118,
           "isUsed": false,
           "usedIn": [],
-          "size": 1799
+          "size": 843
         },
         {
-          "name": "estimateGeometryMemory",
+          "name": "calcSwayRotZ",
           "type": "function",
-          "line": 1604,
+          "line": 139,
           "isUsed": false,
           "usedIn": [],
-          "size": 1799
+          "size": 843
         },
         {
-          "name": "default",
+          "name": "calcWobble",
           "type": "function",
-          "line": 1623,
+          "line": 157,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 843
+        },
+        {
+          "name": "calcHopY",
+          "type": "function",
+          "line": 183,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 843
+        },
+        {
+          "name": "calcShiver",
+          "type": "function",
+          "line": 204,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 843
+        },
+        {
+          "name": "calcAccordionStretch",
+          "type": "function",
+          "line": 231,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 843
+        },
+        {
+          "name": "calcFiberWhip",
+          "type": "function",
+          "line": 257,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 843
+        },
+        {
+          "name": "calcSpiralWave",
+          "type": "function",
+          "line": 285,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 843
+        },
+        {
+          "name": "calcPrismRose",
+          "type": "function",
+          "line": 312,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 843
+        },
+        {
+          "name": "calcArpeggioStep",
+          "type": "function",
+          "line": 348,
           "isUsed": true,
           "usedIn": [
-            "world/generation.ts"
+            "foliage/arpeggio.ts"
           ],
           "size": 0
         },
         {
-          "name": "RegionManager",
-          "type": "const",
-          "line": 1624,
-          "isUsed": true,
-          "usedIn": [
-            "examples/asset-streaming-usage.ts",
-            "systems/asset-streaming.ts",
-            "systems/index.ts"
-          ],
-          "size": 0
+          "name": "calcSpeakerPulse",
+          "type": "function",
+          "line": 402,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 843
         },
         {
-          "name": "GridCell",
-          "type": "const",
-          "line": 1624,
-          "isUsed": true,
-          "usedIn": [
-            "systems/asset-streaming.ts"
-          ],
-          "size": 0
+          "name": "calcFloatingParticle",
+          "type": "function",
+          "line": 433,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 843
         },
         {
-          "name": "CellState",
-          "type": "const",
-          "line": 1624,
-          "isUsed": true,
-          "usedIn": [
-            "systems/asset-streaming.ts"
-          ],
-          "size": 0
+          "name": "calcRainDropY",
+          "type": "function",
+          "line": 459,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 843
+        },
+        {
+          "name": "lerpColor",
+          "type": "function",
+          "line": 482,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 843
         }
       ],
       "imports": [
-        "RegionManager",
-        "GridCell",
-        "CellState",
-        "THREE"
+        "wasmInstance",
+        "getNativeFunc",
+        "type WasmExports"
       ],
       "unusedExports": [
         {
-          "name": "AssetType",
-          "type": "enum",
-          "line": 37,
+          "name": "WobbleResult",
+          "type": "interface",
+          "line": 27,
           "isUsed": false,
           "usedIn": [],
-          "size": 1799
+          "size": 843
         },
         {
-          "name": "TextureFormat",
-          "type": "enum",
-          "line": 48,
+          "name": "AccordionResult",
+          "type": "interface",
+          "line": 35,
           "isUsed": false,
           "usedIn": [],
-          "size": 1799
+          "size": 843
         },
         {
-          "name": "LoadingState",
-          "type": "enum",
-          "line": 58,
+          "name": "FiberResult",
+          "type": "interface",
+          "line": 43,
           "isUsed": false,
           "usedIn": [],
-          "size": 1799
+          "size": 843
         },
         {
-          "name": "MemoryPressure",
-          "type": "enum",
-          "line": 77,
+          "name": "ShiverResult",
+          "type": "interface",
+          "line": 51,
           "isUsed": false,
           "usedIn": [],
-          "size": 1799
+          "size": 843
         },
         {
-          "name": "AssetMetadata",
+          "name": "SpiralResult",
+          "type": "interface",
+          "line": 59,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 843
+        },
+        {
+          "name": "PrismResult",
+          "type": "interface",
+          "line": 68,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 843
+        },
+        {
+          "name": "ArpeggioResult",
+          "type": "interface",
+          "line": 78,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 843
+        },
+        {
+          "name": "ParticleResult",
           "type": "interface",
           "line": 86,
           "isUsed": false,
           "usedIn": [],
-          "size": 1799
+          "size": 843
         },
         {
-          "name": "AssetManifest",
-          "type": "interface",
-          "line": 103,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "LoadedAsset",
-          "type": "interface",
-          "line": 112,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "LoadingProgress",
-          "type": "interface",
-          "line": 126,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "NetworkStats",
-          "type": "interface",
-          "line": 137,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "StreamingConfig",
-          "type": "interface",
-          "line": 147,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "StreamingStats",
-          "type": "interface",
-          "line": 186,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "DEFAULT_STREAMING_CONFIG",
-          "type": "const",
-          "line": 208,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "PRIORITY_DISTANCES",
-          "type": "const",
-          "line": 241,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "QUALITY_FORMAT_PREFERENCES",
-          "type": "const",
-          "line": 250,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "LRUCache",
-          "type": "class",
-          "line": 266,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "NetworkManager",
-          "type": "class",
-          "line": 371,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "ProgressiveTextureLoader",
-          "type": "class",
-          "line": 547,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "AudioStreamingLoader",
-          "type": "class",
-          "line": 612,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "GeometryLODLoader",
-          "type": "class",
-          "line": 674,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "PlaceholderManager",
-          "type": "class",
-          "line": 721,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "estimateTextureMemory",
+          "name": "calcBounceY",
           "type": "function",
-          "line": 1590,
+          "line": 118,
           "isUsed": false,
           "usedIn": [],
-          "size": 1799
+          "size": 843
         },
         {
-          "name": "estimateGeometryMemory",
+          "name": "calcSwayRotZ",
           "type": "function",
-          "line": 1604,
+          "line": 139,
           "isUsed": false,
           "usedIn": [],
-          "size": 1799
+          "size": 843
+        },
+        {
+          "name": "calcWobble",
+          "type": "function",
+          "line": 157,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 843
+        },
+        {
+          "name": "calcHopY",
+          "type": "function",
+          "line": 183,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 843
+        },
+        {
+          "name": "calcShiver",
+          "type": "function",
+          "line": 204,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 843
+        },
+        {
+          "name": "calcAccordionStretch",
+          "type": "function",
+          "line": 231,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 843
+        },
+        {
+          "name": "calcFiberWhip",
+          "type": "function",
+          "line": 257,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 843
+        },
+        {
+          "name": "calcSpiralWave",
+          "type": "function",
+          "line": 285,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 843
+        },
+        {
+          "name": "calcPrismRose",
+          "type": "function",
+          "line": 312,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 843
+        },
+        {
+          "name": "calcSpeakerPulse",
+          "type": "function",
+          "line": 402,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 843
+        },
+        {
+          "name": "calcFloatingParticle",
+          "type": "function",
+          "line": 433,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 843
+        },
+        {
+          "name": "calcRainDropY",
+          "type": "function",
+          "line": 459,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 843
+        },
+        {
+          "name": "lerpColor",
+          "type": "function",
+          "line": 482,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 843
         }
       ],
-      "treeShakingScore": 27
+      "treeShakingScore": 5
     },
     {
       "path": "ui/announcer.ts",
@@ -2881,7 +3145,12 @@
           "line": 535,
           "isUsed": true,
           "usedIn": [
-            "ui/accessibility-menu.ts"
+            "core/input/audio-controls.ts",
+            "core/input/playlist-manager.ts",
+            "ui/accessibility-menu-core.ts",
+            "ui/accessibility-menu-handlers.ts",
+            "ui/save-menu/save-menu.ts",
+            "utils/toast.ts"
           ],
           "size": 0
         },
@@ -2987,7 +3256,7 @@
           "line": 587,
           "isUsed": true,
           "usedIn": [
-            "ui/accessibility-menu.ts"
+            "core/input/audio-controls.ts"
           ],
           "size": 0
         }
@@ -3158,349 +3427,6 @@
       "treeShakingScore": 9
     },
     {
-      "path": "systems/analytics.ts",
-      "exports": [
-        {
-          "name": "AnalyticsConfig",
-          "type": "interface",
-          "line": 38,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "EventType",
-          "type": "type",
-          "line": 62,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "AnalyticsEvent",
-          "type": "interface",
-          "line": 77,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "SessionData",
-          "type": "interface",
-          "line": 91,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "FPSHistogram",
-          "type": "interface",
-          "line": 121,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "FrameTimePercentiles",
-          "type": "interface",
-          "line": 133,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "LoadingPhaseTiming",
-          "type": "interface",
-          "line": 143,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "MemorySnapshot",
-          "type": "interface",
-          "line": 153,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "GPUTiming",
-          "type": "interface",
-          "line": 165,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "PerformanceMetrics",
-          "type": "interface",
-          "line": 175,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "AnalyticsExport",
-          "type": "interface",
-          "line": 189,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "ExternalAnalyticsProvider",
-          "type": "interface",
-          "line": 209,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "analytics",
-          "type": "const",
-          "line": 1345,
-          "isUsed": true,
-          "usedIn": [
-            "systems/analytics.ts",
-            "ui/analytics-debug.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "trackEvent",
-          "type": "function",
-          "line": 1356,
-          "isUsed": true,
-          "usedIn": [
-            "systems/analytics.ts",
-            "ui/analytics-debug.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "trackPerformance",
-          "type": "function",
-          "line": 1366,
-          "isUsed": true,
-          "usedIn": [
-            "systems/analytics.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "trackExploration",
-          "type": "function",
-          "line": 1375,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "trackEntityDiscovered",
-          "type": "function",
-          "line": 1388,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "trackAbilityUsed",
-          "type": "function",
-          "line": 1401,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "trackItemCollected",
-          "type": "function",
-          "line": 1410,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "trackUnlockAchieved",
-          "type": "function",
-          "line": 1419,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "trackMilestoneReached",
-          "type": "function",
-          "line": 1428,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "default",
-          "type": "function",
-          "line": 1433,
-          "isUsed": true,
-          "usedIn": [
-            "world/generation.ts"
-          ],
-          "size": 0
-        }
-      ],
-      "imports": [
-        "analytics",
-        "trackEvent",
-        "trackPerformance"
-      ],
-      "unusedExports": [
-        {
-          "name": "AnalyticsConfig",
-          "type": "interface",
-          "line": 38,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "EventType",
-          "type": "type",
-          "line": 62,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "AnalyticsEvent",
-          "type": "interface",
-          "line": 77,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "SessionData",
-          "type": "interface",
-          "line": 91,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "FPSHistogram",
-          "type": "interface",
-          "line": 121,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "FrameTimePercentiles",
-          "type": "interface",
-          "line": 133,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "LoadingPhaseTiming",
-          "type": "interface",
-          "line": 143,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "MemorySnapshot",
-          "type": "interface",
-          "line": 153,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "GPUTiming",
-          "type": "interface",
-          "line": 165,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "PerformanceMetrics",
-          "type": "interface",
-          "line": 175,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "AnalyticsExport",
-          "type": "interface",
-          "line": 189,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "ExternalAnalyticsProvider",
-          "type": "interface",
-          "line": 209,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "trackExploration",
-          "type": "function",
-          "line": 1375,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "trackEntityDiscovered",
-          "type": "function",
-          "line": 1388,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "trackAbilityUsed",
-          "type": "function",
-          "line": 1401,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "trackItemCollected",
-          "type": "function",
-          "line": 1410,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "trackUnlockAchieved",
-          "type": "function",
-          "line": 1419,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        },
-        {
-          "name": "trackMilestoneReached",
-          "type": "function",
-          "line": 1428,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1799
-        }
-      ],
-      "treeShakingScore": 18
-    },
-    {
       "path": "foliage/trees.ts",
       "exports": [
         {
@@ -3509,7 +3435,7 @@
           "line": 11,
           "isUsed": false,
           "usedIn": [],
-          "size": 934
+          "size": 1013
         },
         {
           "name": "ShrubOptions",
@@ -3517,7 +3443,7 @@
           "line": 15,
           "isUsed": false,
           "usedIn": [],
-          "size": 934
+          "size": 1013
         },
         {
           "name": "VineOptions",
@@ -3525,7 +3451,7 @@
           "line": 19,
           "isUsed": false,
           "usedIn": [],
-          "size": 934
+          "size": 1013
         },
         {
           "name": "LeafOptions",
@@ -3533,7 +3459,7 @@
           "line": 24,
           "isUsed": false,
           "usedIn": [],
-          "size": 934
+          "size": 1013
         },
         {
           "name": "BubbleWillowOptions",
@@ -3541,7 +3467,7 @@
           "line": 28,
           "isUsed": false,
           "usedIn": [],
-          "size": 934
+          "size": 1013
         },
         {
           "name": "HelixPlantOptions",
@@ -3549,7 +3475,7 @@
           "line": 32,
           "isUsed": false,
           "usedIn": [],
-          "size": 934
+          "size": 1013
         },
         {
           "name": "BalloonBushOptions",
@@ -3557,7 +3483,7 @@
           "line": 36,
           "isUsed": false,
           "usedIn": [],
-          "size": 934
+          "size": 1013
         },
         {
           "name": "AccordionPalmOptions",
@@ -3565,7 +3491,7 @@
           "line": 40,
           "isUsed": false,
           "usedIn": [],
-          "size": 934
+          "size": 1013
         },
         {
           "name": "FiberOpticWillowOptions",
@@ -3573,7 +3499,7 @@
           "line": 44,
           "isUsed": false,
           "usedIn": [],
-          "size": 934
+          "size": 1013
         },
         {
           "name": "SwingableVineOptions",
@@ -3581,60 +3507,68 @@
           "line": 48,
           "isUsed": false,
           "usedIn": [],
-          "size": 934
+          "size": 1013
         },
         {
-          "name": "InputState",
+          "name": "VineLadderOptions",
           "type": "interface",
           "line": 53,
           "isUsed": false,
           "usedIn": [],
-          "size": 934
+          "size": 1013
         },
         {
-          "name": "PlayerObject",
+          "name": "InputState",
           "type": "interface",
           "line": 58,
           "isUsed": false,
           "usedIn": [],
-          "size": 934
+          "size": 1013
+        },
+        {
+          "name": "PlayerObject",
+          "type": "interface",
+          "line": 63,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1013
         },
         {
           "name": "createFloweringTree",
           "type": "function",
-          "line": 94,
+          "line": 96,
           "isUsed": false,
           "usedIn": [],
-          "size": 934
+          "size": 1013
         },
         {
           "name": "createShrub",
           "type": "function",
-          "line": 166,
+          "line": 169,
           "isUsed": false,
           "usedIn": [],
-          "size": 934
+          "size": 1013
         },
         {
           "name": "createVine",
           "type": "function",
-          "line": 224,
+          "line": 228,
           "isUsed": false,
           "usedIn": [],
-          "size": 934
+          "size": 1013
         },
         {
           "name": "createLeafParticle",
           "type": "function",
-          "line": 242,
+          "line": 259,
           "isUsed": false,
           "usedIn": [],
-          "size": 934
+          "size": 1013
         },
         {
           "name": "createBubbleWillow",
           "type": "function",
-          "line": 255,
+          "line": 272,
           "isUsed": true,
           "usedIn": [
             "world/generation.ts"
@@ -3644,7 +3578,7 @@
         {
           "name": "createHelixPlant",
           "type": "function",
-          "line": 299,
+          "line": 317,
           "isUsed": true,
           "usedIn": [
             "world/generation.ts"
@@ -3654,7 +3588,7 @@
         {
           "name": "createBalloonBush",
           "type": "function",
-          "line": 354,
+          "line": 373,
           "isUsed": true,
           "usedIn": [
             "world/generation.ts"
@@ -3664,15 +3598,15 @@
         {
           "name": "createVineCluster",
           "type": "function",
-          "line": 389,
+          "line": 409,
           "isUsed": false,
           "usedIn": [],
-          "size": 934
+          "size": 1013
         },
         {
           "name": "createAccordionPalm",
           "type": "function",
-          "line": 400,
+          "line": 420,
           "isUsed": true,
           "usedIn": [
             "world/generation.ts"
@@ -3682,7 +3616,7 @@
         {
           "name": "createFiberOpticWillow",
           "type": "function",
-          "line": 447,
+          "line": 467,
           "isUsed": true,
           "usedIn": [
             "world/generation.ts"
@@ -3692,10 +3626,9 @@
         {
           "name": "VineSwing",
           "type": "class",
-          "line": 502,
+          "line": 522,
           "isUsed": true,
           "usedIn": [
-            "systems/physics.ts",
             "world/generation.ts",
             "world/state.ts"
           ],
@@ -3704,7 +3637,17 @@
         {
           "name": "createSwingableVine",
           "type": "function",
-          "line": 623,
+          "line": 643,
+          "isUsed": true,
+          "usedIn": [
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createVineLadder",
+          "type": "function",
+          "line": 696,
           "isUsed": true,
           "usedIn": [
             "world/generation.ts"
@@ -3725,6 +3668,9 @@
         "calculatePlayerPush",
         "createStandardNodeMaterial",
         "createJuicyRimLight",
+        "getCachedProceduralMaterial",
+        "calculateWindSway",
+        "applyPlayerInteraction",
         "tslColor",
         "mix",
         "float",
@@ -3749,7 +3695,7 @@
           "line": 11,
           "isUsed": false,
           "usedIn": [],
-          "size": 934
+          "size": 1013
         },
         {
           "name": "ShrubOptions",
@@ -3757,7 +3703,7 @@
           "line": 15,
           "isUsed": false,
           "usedIn": [],
-          "size": 934
+          "size": 1013
         },
         {
           "name": "VineOptions",
@@ -3765,7 +3711,7 @@
           "line": 19,
           "isUsed": false,
           "usedIn": [],
-          "size": 934
+          "size": 1013
         },
         {
           "name": "LeafOptions",
@@ -3773,7 +3719,7 @@
           "line": 24,
           "isUsed": false,
           "usedIn": [],
-          "size": 934
+          "size": 1013
         },
         {
           "name": "BubbleWillowOptions",
@@ -3781,7 +3727,7 @@
           "line": 28,
           "isUsed": false,
           "usedIn": [],
-          "size": 934
+          "size": 1013
         },
         {
           "name": "HelixPlantOptions",
@@ -3789,7 +3735,7 @@
           "line": 32,
           "isUsed": false,
           "usedIn": [],
-          "size": 934
+          "size": 1013
         },
         {
           "name": "BalloonBushOptions",
@@ -3797,7 +3743,7 @@
           "line": 36,
           "isUsed": false,
           "usedIn": [],
-          "size": 934
+          "size": 1013
         },
         {
           "name": "AccordionPalmOptions",
@@ -3805,7 +3751,7 @@
           "line": 40,
           "isUsed": false,
           "usedIn": [],
-          "size": 934
+          "size": 1013
         },
         {
           "name": "FiberOpticWillowOptions",
@@ -3813,7 +3759,7 @@
           "line": 44,
           "isUsed": false,
           "usedIn": [],
-          "size": 934
+          "size": 1013
         },
         {
           "name": "SwingableVineOptions",
@@ -3821,704 +3767,943 @@
           "line": 48,
           "isUsed": false,
           "usedIn": [],
-          "size": 934
+          "size": 1013
         },
         {
-          "name": "InputState",
+          "name": "VineLadderOptions",
           "type": "interface",
           "line": 53,
           "isUsed": false,
           "usedIn": [],
-          "size": 934
+          "size": 1013
         },
         {
-          "name": "PlayerObject",
+          "name": "InputState",
           "type": "interface",
           "line": 58,
           "isUsed": false,
           "usedIn": [],
-          "size": 934
+          "size": 1013
+        },
+        {
+          "name": "PlayerObject",
+          "type": "interface",
+          "line": 63,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1013
         },
         {
           "name": "createFloweringTree",
           "type": "function",
-          "line": 94,
+          "line": 96,
           "isUsed": false,
           "usedIn": [],
-          "size": 934
+          "size": 1013
         },
         {
           "name": "createShrub",
           "type": "function",
-          "line": 166,
+          "line": 169,
           "isUsed": false,
           "usedIn": [],
-          "size": 934
+          "size": 1013
         },
         {
           "name": "createVine",
           "type": "function",
-          "line": 224,
+          "line": 228,
           "isUsed": false,
           "usedIn": [],
-          "size": 934
+          "size": 1013
         },
         {
           "name": "createLeafParticle",
           "type": "function",
-          "line": 242,
+          "line": 259,
           "isUsed": false,
           "usedIn": [],
-          "size": 934
+          "size": 1013
         },
         {
           "name": "createVineCluster",
           "type": "function",
-          "line": 389,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 934
-        }
-      ],
-      "treeShakingScore": 29
-    },
-    {
-      "path": "rendering/culling-system.ts",
-      "exports": [
-        {
-          "name": "CullingGroup",
-          "type": "enum",
-          "line": 25,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2211
-        },
-        {
-          "name": "EntityType",
-          "type": "enum",
-          "line": 35,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2211
-        },
-        {
-          "name": "LODLevel",
-          "type": "enum",
-          "line": 49,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2211
-        },
-        {
-          "name": "QualityTier",
-          "type": "enum",
-          "line": 57,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2211
-        },
-        {
-          "name": "CullableObject",
-          "type": "interface",
-          "line": 65,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2211
-        },
-        {
-          "name": "CullingConfig",
-          "type": "interface",
-          "line": 83,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2211
-        },
-        {
-          "name": "CullingStats",
-          "type": "interface",
-          "line": 109,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2211
-        },
-        {
-          "name": "DEFAULT_CULL_DISTANCES",
-          "type": "const",
-          "line": 135,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2211
-        },
-        {
-          "name": "LOD_THRESHOLDS",
-          "type": "const",
-          "line": 149,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2211
-        },
-        {
-          "name": "QUALITY_MULTIPLIERS",
-          "type": "const",
-          "line": 157,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2211
-        },
-        {
-          "name": "DEFAULT_CULLING_CONFIG",
-          "type": "const",
-          "line": 165,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2211
-        },
-        {
-          "name": "SpatialHashGrid",
-          "type": "class",
-          "line": 187,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2211
-        },
-        {
-          "name": "OcclusionQueryManager",
-          "type": "class",
-          "line": 321,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2211
-        },
-        {
-          "name": "CullingDebugVisualizer",
-          "type": "class",
           "line": 409,
           "isUsed": false,
           "usedIn": [],
-          "size": 2211
-        },
+          "size": 1013
+        }
+      ],
+      "treeShakingScore": 31
+    },
+    {
+      "path": "utils/wasm-physics.ts",
+      "exports": [
         {
-          "name": "CullingSystem",
-          "type": "class",
-          "line": 599,
+          "name": "PlayerStateResult",
+          "type": "interface",
+          "line": 56,
           "isUsed": false,
           "usedIn": [],
-          "size": 2211
+          "size": 900
         },
         {
-          "name": "createLODMeshes",
+          "name": "dynamicRadiiView",
+          "type": "let",
+          "line": 70,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/arpeggio-batcher.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "initObstacleUploadBridge",
           "type": "function",
-          "line": 1041,
+          "line": 79,
           "isUsed": false,
           "usedIn": [],
-          "size": 2211
+          "size": 900
         },
         {
-          "name": "getDitherValue",
+          "name": "initDynamicFoliageBridge",
           "type": "function",
-          "line": 1129,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2211
+          "line": 98,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-updates.ts"
+          ],
+          "size": 0
         },
         {
-          "name": "default",
+          "name": "uploadCollisionObjects",
           "type": "function",
-          "line": 1139,
+          "line": 115,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-updates.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "resolveGameCollisionsWASM",
+          "type": "function",
+          "line": 298,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "initCollisionSystem",
+          "type": "function",
+          "line": 333,
           "isUsed": true,
           "usedIn": [
             "world/generation.ts"
           ],
           "size": 0
+        },
+        {
+          "name": "addCollisionObject",
+          "type": "function",
+          "line": 349,
+          "isUsed": true,
+          "usedIn": [
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "checkPositionValidity",
+          "type": "function",
+          "line": 362,
+          "isUsed": true,
+          "usedIn": [
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "checkCollision",
+          "type": "function",
+          "line": 377,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 900
+        },
+        {
+          "name": "updatePhysicsCPP",
+          "type": "function",
+          "line": 399,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "initPhysics",
+          "type": "function",
+          "line": 411,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-updates.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "uploadObstaclesBatch",
+          "type": "function",
+          "line": 421,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-updates.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "setPlayerState",
+          "type": "function",
+          "line": 455,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getPlayerState",
+          "type": "function",
+          "line": 465,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "valueNoise2D",
+          "type": "function",
+          "line": 488,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 900
+        },
+        {
+          "name": "fbm",
+          "type": "function",
+          "line": 502,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 900
+        },
+        {
+          "name": "fastInvSqrt",
+          "type": "function",
+          "line": 519,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 900
+        },
+        {
+          "name": "fastDistance",
+          "type": "function",
+          "line": 535,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 900
+        },
+        {
+          "name": "hash",
+          "type": "function",
+          "line": 548,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 900
+        },
+        {
+          "name": "getGroundHeightBatch",
+          "type": "function",
+          "line": 571,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 900
+        },
+        {
+          "name": "getGroundHeight",
+          "type": "function",
+          "line": 624,
+          "isUsed": true,
+          "usedIn": [
+            "core/deferred-init.ts",
+            "core/game-loop.ts",
+            "core/main.ts",
+            "particles/compute-particles.ts",
+            "systems/glitch-grenade.ts",
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-states.ts",
+            "systems/physics/physics-updates.ts",
+            "systems/weather/weather-ecosystem.ts",
+            "world/generation.ts",
+            "world/ground-heightmap.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "batchGroundHeight",
+          "type": "function",
+          "line": 637,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 900
+        },
+        {
+          "name": "freqToHue",
+          "type": "function",
+          "line": 699,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/animation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "lerp",
+          "type": "function",
+          "line": 713,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 900
+        },
+        {
+          "name": "hslToRgb",
+          "type": "function",
+          "line": 740,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 900
+        },
+        {
+          "name": "hash2D",
+          "type": "function",
+          "line": 774,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 900
+        },
+        {
+          "name": "ascValueNoise2D",
+          "type": "function",
+          "line": 787,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 900
+        },
+        {
+          "name": "fbm2D",
+          "type": "function",
+          "line": 813,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 900
+        },
+        {
+          "name": "distSq2D",
+          "type": "function",
+          "line": 839,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 900
+        },
+        {
+          "name": "distSq3D",
+          "type": "function",
+          "line": 856,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 900
+        },
+        {
+          "name": "smoothstep",
+          "type": "function",
+          "line": 869,
+          "isUsed": true,
+          "usedIn": [
+            "compute/particle_compute.ts",
+            "foliage/arpeggio-batcher.ts",
+            "foliage/aurora.ts",
+            "foliage/cave.ts",
+            "foliage/cloud-batcher.ts",
+            "foliage/dandelion-seeds.ts",
+            "foliage/environment.ts",
+            "foliage/flowers.ts",
+            "foliage/fluid_fog.ts",
+            "foliage/foliage-materials.ts",
+            "foliage/glowing-flower-batcher.ts",
+            "foliage/grass.ts",
+            "foliage/impacts.ts",
+            "foliage/instrument.ts",
+            "foliage/lantern-batcher.ts",
+            "foliage/lotus.ts",
+            "foliage/material-core.ts",
+            "foliage/moon.ts",
+            "foliage/mushroom-batcher.ts",
+            "foliage/musical_flora.ts",
+            "foliage/panning-pads.ts",
+            "foliage/pollen.ts",
+            "foliage/post-processing.ts",
+            "foliage/rainbow.ts",
+            "foliage/ribbons.ts",
+            "foliage/silence-spirits.ts",
+            "foliage/simple-flower-batcher.ts",
+            "foliage/sky.ts",
+            "foliage/sparkle-trail.ts",
+            "foliage/stars.ts",
+            "foliage/terrain.ts",
+            "foliage/tree-batcher.ts",
+            "foliage/water.ts",
+            "foliage/waterfall-batcher.ts",
+            "foliage/wisteria-cluster.ts",
+            "gameplay/chord-strike.ts",
+            "gameplay/jitter-mines.ts",
+            "gameplay/rainbow-blaster.ts",
+            "particles/compute-particles.ts",
+            "particles/cpu-particle-system.ts",
+            "systems/glitch-grenade.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "inverseLerp",
+          "type": "function",
+          "line": 882,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 900
         }
       ],
       "imports": [
+        "cppBatchGroundHeightSimd",
+        "wasmInstance",
+        "wasmMemory",
+        "wasmInitDynamicFoliageMemory",
+        "wasmInitCollisionSystem",
+        "wasmAddCollisionObject",
+        "wasmResolveGameCollisions",
+        "wasmCheckPositionValidity",
+        "emscriptenInstance",
+        "emscriptenMemory",
+        "playerStateView",
+        "wasmGetGroundHeight",
+        "wasmBatchGroundHeight",
+        "wasmFreqToHue",
+        "wasmLerp",
+        "getNativeFunc",
+        "POSITION_OFFSET",
+        "type WasmExports",
+        "type Cave",
+        "type Mushroom",
+        "type Cloud",
+        "type Trampoline",
+        "type PlayerState",
+        "wasmHslToRgb",
+        "wasmHash2D",
+        "wasmValueNoise2D",
+        "wasmFbm2D",
+        "wasmDistSq2D",
+        "wasmDistSq3D",
+        "wasmSmoothstep",
+        "wasmInverseLerp",
         "THREE"
       ],
       "unusedExports": [
         {
-          "name": "CullingGroup",
-          "type": "enum",
-          "line": 25,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2211
-        },
-        {
-          "name": "EntityType",
-          "type": "enum",
-          "line": 35,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2211
-        },
-        {
-          "name": "LODLevel",
-          "type": "enum",
-          "line": 49,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2211
-        },
-        {
-          "name": "QualityTier",
-          "type": "enum",
-          "line": 57,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2211
-        },
-        {
-          "name": "CullableObject",
+          "name": "PlayerStateResult",
           "type": "interface",
-          "line": 65,
+          "line": 56,
           "isUsed": false,
           "usedIn": [],
-          "size": 2211
+          "size": 900
         },
         {
-          "name": "CullingConfig",
-          "type": "interface",
-          "line": 83,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2211
-        },
-        {
-          "name": "CullingStats",
-          "type": "interface",
-          "line": 109,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2211
-        },
-        {
-          "name": "DEFAULT_CULL_DISTANCES",
-          "type": "const",
-          "line": 135,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2211
-        },
-        {
-          "name": "LOD_THRESHOLDS",
-          "type": "const",
-          "line": 149,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2211
-        },
-        {
-          "name": "QUALITY_MULTIPLIERS",
-          "type": "const",
-          "line": 157,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2211
-        },
-        {
-          "name": "DEFAULT_CULLING_CONFIG",
-          "type": "const",
-          "line": 165,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2211
-        },
-        {
-          "name": "SpatialHashGrid",
-          "type": "class",
-          "line": 187,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2211
-        },
-        {
-          "name": "OcclusionQueryManager",
-          "type": "class",
-          "line": 321,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2211
-        },
-        {
-          "name": "CullingDebugVisualizer",
-          "type": "class",
-          "line": 409,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2211
-        },
-        {
-          "name": "CullingSystem",
-          "type": "class",
-          "line": 599,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2211
-        },
-        {
-          "name": "createLODMeshes",
+          "name": "initObstacleUploadBridge",
           "type": "function",
-          "line": 1041,
+          "line": 79,
           "isUsed": false,
           "usedIn": [],
-          "size": 2211
+          "size": 900
         },
         {
-          "name": "getDitherValue",
+          "name": "checkCollision",
           "type": "function",
-          "line": 1129,
+          "line": 377,
           "isUsed": false,
           "usedIn": [],
-          "size": 2211
+          "size": 900
+        },
+        {
+          "name": "valueNoise2D",
+          "type": "function",
+          "line": 488,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 900
+        },
+        {
+          "name": "fbm",
+          "type": "function",
+          "line": 502,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 900
+        },
+        {
+          "name": "fastInvSqrt",
+          "type": "function",
+          "line": 519,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 900
+        },
+        {
+          "name": "fastDistance",
+          "type": "function",
+          "line": 535,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 900
+        },
+        {
+          "name": "hash",
+          "type": "function",
+          "line": 548,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 900
+        },
+        {
+          "name": "getGroundHeightBatch",
+          "type": "function",
+          "line": 571,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 900
+        },
+        {
+          "name": "batchGroundHeight",
+          "type": "function",
+          "line": 637,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 900
+        },
+        {
+          "name": "lerp",
+          "type": "function",
+          "line": 713,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 900
+        },
+        {
+          "name": "hslToRgb",
+          "type": "function",
+          "line": 740,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 900
+        },
+        {
+          "name": "hash2D",
+          "type": "function",
+          "line": 774,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 900
+        },
+        {
+          "name": "ascValueNoise2D",
+          "type": "function",
+          "line": 787,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 900
+        },
+        {
+          "name": "fbm2D",
+          "type": "function",
+          "line": 813,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 900
+        },
+        {
+          "name": "distSq2D",
+          "type": "function",
+          "line": 839,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 900
+        },
+        {
+          "name": "distSq3D",
+          "type": "function",
+          "line": 856,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 900
+        },
+        {
+          "name": "inverseLerp",
+          "type": "function",
+          "line": 882,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 900
         }
       ],
-      "treeShakingScore": 6
+      "treeShakingScore": 45
     },
     {
-      "path": "systems/accessibility.ts",
+      "path": "utils/wasm-batch-animation.ts",
       "exports": [
         {
-          "name": "ColorBlindType",
-          "type": "type",
-          "line": 19,
+          "name": "batchAnimationCalc",
+          "type": "function",
+          "line": 39,
           "isUsed": true,
           "usedIn": [
-            "ui/accessibility-menu.ts"
+            "foliage/musical_flora.ts"
           ],
           "size": 0
         },
         {
-          "name": "UIScale",
-          "type": "type",
-          "line": 20,
-          "isUsed": true,
-          "usedIn": [
-            "ui/accessibility-menu.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "VerbosityLevel",
-          "type": "type",
-          "line": 21,
-          "isUsed": true,
-          "usedIn": [
-            "ui/accessibility-menu.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "CrosshairStyle",
-          "type": "type",
-          "line": 22,
-          "isUsed": true,
-          "usedIn": [
-            "ui/accessibility-menu.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "Keybinding",
-          "type": "interface",
-          "line": 24,
+          "name": "batchShiver_c",
+          "type": "function",
+          "line": 58,
           "isUsed": false,
           "usedIn": [],
-          "size": 1276
+          "size": 669
         },
         {
-          "name": "InputSettings",
-          "type": "interface",
-          "line": 32,
+          "name": "batchSpring_c",
+          "type": "function",
+          "line": 71,
           "isUsed": false,
           "usedIn": [],
-          "size": 1276
+          "size": 669
         },
         {
-          "name": "VisualSettings",
-          "type": "interface",
-          "line": 43,
+          "name": "batchFloat_c",
+          "type": "function",
+          "line": 84,
           "isUsed": false,
           "usedIn": [],
-          "size": 1276
+          "size": 669
         },
         {
-          "name": "CognitiveSettings",
-          "type": "interface",
-          "line": 59,
+          "name": "batchCloudBob_c",
+          "type": "function",
+          "line": 97,
           "isUsed": false,
           "usedIn": [],
-          "size": 1276
+          "size": 669
         },
         {
-          "name": "AuditorySettings",
-          "type": "interface",
-          "line": 70,
+          "name": "deformWave_c",
+          "type": "function",
+          "line": 114,
           "isUsed": false,
           "usedIn": [],
-          "size": 1276
+          "size": 669
         },
         {
-          "name": "ScreenReaderSettings",
-          "type": "interface",
-          "line": 83,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1276
-        },
-        {
-          "name": "AccessibilitySettings",
-          "type": "interface",
-          "line": 91,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1276
-        },
-        {
-          "name": "AccessibilityPreset",
-          "type": "interface",
-          "line": 99,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1276
-        },
-        {
-          "name": "defaultSettings",
-          "type": "const",
+          "name": "deformJiggle_c",
+          "type": "function",
           "line": 127,
           "isUsed": false,
           "usedIn": [],
-          "size": 1276
+          "size": 669
         },
         {
-          "name": "colorBlindMatrices",
-          "type": "const",
-          "line": 189,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1276
-        },
-        {
-          "name": "validateColorMatrices",
+          "name": "deformWobble_c",
           "type": "function",
-          "line": 227,
+          "line": 140,
           "isUsed": false,
           "usedIn": [],
-          "size": 1276
+          "size": 669
         },
         {
-          "name": "accessibilityPresets",
-          "type": "const",
-          "line": 241,
+          "name": "batchUpdateLODMatrices_c",
+          "type": "function",
+          "line": 162,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 669
+        },
+        {
+          "name": "batchScaleMatrices_c",
+          "type": "function",
+          "line": 186,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 669
+        },
+        {
+          "name": "batchFadeColors_c",
+          "type": "function",
+          "line": 197,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 669
+        },
+        {
+          "name": "batchFrustumCull_c",
+          "type": "function",
+          "line": 213,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 669
+        },
+        {
+          "name": "batchDistanceCullIndexed_c",
+          "type": "function",
+          "line": 229,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 669
+        },
+        {
+          "name": "fluidInit",
+          "type": "function",
+          "line": 251,
           "isUsed": true,
           "usedIn": [
-            "ui/accessibility-menu.ts"
+            "systems/fluid_system.ts"
           ],
           "size": 0
         },
         {
-          "name": "AccessibilitySystem",
-          "type": "class",
-          "line": 395,
+          "name": "fluidStep",
+          "type": "function",
+          "line": 262,
           "isUsed": true,
           "usedIn": [
-            "ui/accessibility-menu.ts"
+            "systems/fluid_system.ts"
           ],
           "size": 0
         },
         {
-          "name": "getAccessibilitySystem",
+          "name": "fluidAddDensity",
           "type": "function",
-          "line": 937,
+          "line": 273,
           "isUsed": true,
           "usedIn": [
-            "ui/accessibility-menu.ts"
+            "systems/fluid_system.ts"
           ],
           "size": 0
         },
         {
-          "name": "initAccessibilitySystem",
+          "name": "fluidAddVelocity",
           "type": "function",
-          "line": 944,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1276
-        },
-        {
-          "name": "applyColorBlindMode",
-          "type": "function",
-          "line": 952,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1276
-        },
-        {
-          "name": "setMotionReduction",
-          "type": "function",
-          "line": 956,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1276
-        },
-        {
-          "name": "announce",
-          "type": "function",
-          "line": 960,
+          "line": 285,
           "isUsed": true,
           "usedIn": [
-            "ui/accessibility-menu.ts"
+            "systems/fluid_system.ts"
           ],
           "size": 0
         },
         {
-          "name": "getCurrentSettings",
+          "name": "getFluidDensityView",
           "type": "function",
-          "line": 964,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1276
+          "line": 295,
+          "isUsed": true,
+          "usedIn": [
+            "systems/fluid_system.ts"
+          ],
+          "size": 0
         },
         {
-          "name": "AnnouncementPriority",
-          "type": "const",
-          "line": 969,
+          "name": "updateParticlesWASM",
+          "type": "function",
+          "line": 316,
           "isUsed": false,
           "usedIn": [],
-          "size": 1276
+          "size": 669
+        },
+        {
+          "name": "batchHslToRgb",
+          "type": "function",
+          "line": 359,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 669
+        },
+        {
+          "name": "batchSphereCull",
+          "type": "function",
+          "line": 412,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 669
+        },
+        {
+          "name": "batchLerp",
+          "type": "function",
+          "line": 447,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 669
         }
       ],
-      "imports": [],
+      "imports": [
+        "wasmInstance",
+        "emscriptenInstance",
+        "emscriptenMemory",
+        "outputView",
+        "wasmBatchHslToRgb",
+        "wasmBatchSphereCull",
+        "wasmBatchLerp",
+        "getNativeFunc",
+        "type WasmExports"
+      ],
       "unusedExports": [
         {
-          "name": "Keybinding",
-          "type": "interface",
-          "line": 24,
+          "name": "batchShiver_c",
+          "type": "function",
+          "line": 58,
           "isUsed": false,
           "usedIn": [],
-          "size": 1276
+          "size": 669
         },
         {
-          "name": "InputSettings",
-          "type": "interface",
-          "line": 32,
+          "name": "batchSpring_c",
+          "type": "function",
+          "line": 71,
           "isUsed": false,
           "usedIn": [],
-          "size": 1276
+          "size": 669
         },
         {
-          "name": "VisualSettings",
-          "type": "interface",
-          "line": 43,
+          "name": "batchFloat_c",
+          "type": "function",
+          "line": 84,
           "isUsed": false,
           "usedIn": [],
-          "size": 1276
+          "size": 669
         },
         {
-          "name": "CognitiveSettings",
-          "type": "interface",
-          "line": 59,
+          "name": "batchCloudBob_c",
+          "type": "function",
+          "line": 97,
           "isUsed": false,
           "usedIn": [],
-          "size": 1276
+          "size": 669
         },
         {
-          "name": "AuditorySettings",
-          "type": "interface",
-          "line": 70,
+          "name": "deformWave_c",
+          "type": "function",
+          "line": 114,
           "isUsed": false,
           "usedIn": [],
-          "size": 1276
+          "size": 669
         },
         {
-          "name": "ScreenReaderSettings",
-          "type": "interface",
-          "line": 83,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1276
-        },
-        {
-          "name": "AccessibilitySettings",
-          "type": "interface",
-          "line": 91,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1276
-        },
-        {
-          "name": "AccessibilityPreset",
-          "type": "interface",
-          "line": 99,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1276
-        },
-        {
-          "name": "defaultSettings",
-          "type": "const",
+          "name": "deformJiggle_c",
+          "type": "function",
           "line": 127,
           "isUsed": false,
           "usedIn": [],
-          "size": 1276
+          "size": 669
         },
         {
-          "name": "colorBlindMatrices",
-          "type": "const",
-          "line": 189,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1276
-        },
-        {
-          "name": "validateColorMatrices",
+          "name": "deformWobble_c",
           "type": "function",
-          "line": 227,
+          "line": 140,
           "isUsed": false,
           "usedIn": [],
-          "size": 1276
+          "size": 669
         },
         {
-          "name": "initAccessibilitySystem",
+          "name": "batchUpdateLODMatrices_c",
           "type": "function",
-          "line": 944,
+          "line": 162,
           "isUsed": false,
           "usedIn": [],
-          "size": 1276
+          "size": 669
         },
         {
-          "name": "applyColorBlindMode",
+          "name": "batchScaleMatrices_c",
           "type": "function",
-          "line": 952,
+          "line": 186,
           "isUsed": false,
           "usedIn": [],
-          "size": 1276
+          "size": 669
         },
         {
-          "name": "setMotionReduction",
+          "name": "batchFadeColors_c",
           "type": "function",
-          "line": 956,
+          "line": 197,
           "isUsed": false,
           "usedIn": [],
-          "size": 1276
+          "size": 669
         },
         {
-          "name": "getCurrentSettings",
+          "name": "batchFrustumCull_c",
           "type": "function",
-          "line": 964,
+          "line": 213,
           "isUsed": false,
           "usedIn": [],
-          "size": 1276
+          "size": 669
         },
         {
-          "name": "AnnouncementPriority",
-          "type": "const",
-          "line": 969,
+          "name": "batchDistanceCullIndexed_c",
+          "type": "function",
+          "line": 229,
           "isUsed": false,
           "usedIn": [],
-          "size": 1276
+          "size": 669
+        },
+        {
+          "name": "updateParticlesWASM",
+          "type": "function",
+          "line": 316,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 669
+        },
+        {
+          "name": "batchHslToRgb",
+          "type": "function",
+          "line": 359,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 669
+        },
+        {
+          "name": "batchSphereCull",
+          "type": "function",
+          "line": 412,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 669
+        },
+        {
+          "name": "batchLerp",
+          "type": "function",
+          "line": 447,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 669
         }
       ],
-      "treeShakingScore": 33
+      "treeShakingScore": 27
     },
     {
       "path": "particles/compute-integration.ts",
@@ -4529,7 +4714,7 @@
           "line": 28,
           "isUsed": false,
           "usedIn": [],
-          "size": 868
+          "size": 891
         },
         {
           "name": "getAllParticleMetrics",
@@ -4537,7 +4722,7 @@
           "line": 32,
           "isUsed": false,
           "usedIn": [],
-          "size": 868
+          "size": 891
         },
         {
           "name": "IntegratedFireflyOptions",
@@ -4545,109 +4730,172 @@
           "line": 40,
           "isUsed": false,
           "usedIn": [],
-          "size": 868
+          "size": 891
         },
         {
           "name": "createIntegratedFireflies",
           "type": "function",
           "line": 50,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 868
+          "isUsed": true,
+          "usedIn": [
+            "world/generation.ts"
+          ],
+          "size": 0
         },
         {
           "name": "IntegratedPollenOptions",
           "type": "interface",
-          "line": 102,
+          "line": 103,
           "isUsed": false,
           "usedIn": [],
-          "size": 868
+          "size": 891
         },
         {
           "name": "createIntegratedPollen",
           "type": "function",
-          "line": 113,
+          "line": 114,
+          "isUsed": true,
+          "usedIn": [
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "IntegratedSparksOptions",
+          "type": "interface",
+          "line": 164,
           "isUsed": false,
           "usedIn": [],
-          "size": 868
+          "size": 891
+        },
+        {
+          "name": "IntegratedBerriesOptions",
+          "type": "interface",
+          "line": 171,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 891
+        },
+        {
+          "name": "IntegratedRainOptions",
+          "type": "interface",
+          "line": 178,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 891
+        },
+        {
+          "name": "createIntegratedSparks",
+          "type": "function",
+          "line": 189,
+          "isUsed": true,
+          "usedIn": [
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createIntegratedBerries",
+          "type": "function",
+          "line": 247,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 891
+        },
+        {
+          "name": "createIntegratedRain",
+          "type": "function",
+          "line": 298,
+          "isUsed": true,
+          "usedIn": [
+            "systems/weather/weather-effects.ts"
+          ],
+          "size": 0
         },
         {
           "name": "registerIntegratedSystem",
           "type": "function",
-          "line": 175,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 868
+          "line": 356,
+          "isUsed": true,
+          "usedIn": [
+            "world/generation.ts"
+          ],
+          "size": 0
         },
         {
           "name": "updateAllIntegratedSystems",
           "type": "function",
-          "line": 201,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 868
+          "line": 382,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts"
+          ],
+          "size": 0
         },
         {
           "name": "disposeIntegratedSystem",
           "type": "function",
-          "line": 212,
+          "line": 393,
           "isUsed": false,
           "usedIn": [],
-          "size": 868
+          "size": 891
         },
         {
           "name": "disposeAllIntegratedSystems",
           "type": "function",
-          "line": 223,
+          "line": 404,
           "isUsed": false,
           "usedIn": [],
-          "size": 868
+          "size": 891
         },
         {
           "name": "queueDeferredSystem",
           "type": "function",
-          "line": 243,
+          "line": 424,
           "isUsed": false,
           "usedIn": [],
-          "size": 868
+          "size": 891
         },
         {
           "name": "loadDeferredSystems",
           "type": "function",
-          "line": 248,
+          "line": 429,
           "isUsed": false,
           "usedIn": [],
-          "size": 868
+          "size": 891
         },
         {
           "name": "BenchmarkResult",
           "type": "interface",
-          "line": 299,
+          "line": 488,
           "isUsed": false,
           "usedIn": [],
-          "size": 868
+          "size": 891
         },
         {
           "name": "benchmarkParticleSystem",
           "type": "function",
-          "line": 310,
+          "line": 499,
           "isUsed": false,
           "usedIn": [],
-          "size": 868
+          "size": 891
         },
         {
           "name": "printBenchmarkResults",
           "type": "function",
-          "line": 395,
+          "line": 588,
           "isUsed": false,
           "usedIn": [],
-          "size": 868
+          "size": 891
         }
       ],
       "imports": [
         "ComputeParticleSystem",
         "createComputeFireflies",
         "createComputePollen",
+        "createComputeSparks",
+        "createComputeBerries",
+        "createComputeRain",
         "createLegacyFireflies",
         "createLegacyPollen",
         "THREE"
@@ -4659,7 +4907,7 @@
           "line": 28,
           "isUsed": false,
           "usedIn": [],
-          "size": 868
+          "size": 891
         },
         {
           "name": "getAllParticleMetrics",
@@ -4667,7 +4915,7 @@
           "line": 32,
           "isUsed": false,
           "usedIn": [],
-          "size": 868
+          "size": 891
         },
         {
           "name": "IntegratedFireflyOptions",
@@ -4675,349 +4923,106 @@
           "line": 40,
           "isUsed": false,
           "usedIn": [],
-          "size": 868
-        },
-        {
-          "name": "createIntegratedFireflies",
-          "type": "function",
-          "line": 50,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 868
+          "size": 891
         },
         {
           "name": "IntegratedPollenOptions",
           "type": "interface",
-          "line": 102,
+          "line": 103,
           "isUsed": false,
           "usedIn": [],
-          "size": 868
+          "size": 891
         },
         {
-          "name": "createIntegratedPollen",
-          "type": "function",
-          "line": 113,
+          "name": "IntegratedSparksOptions",
+          "type": "interface",
+          "line": 164,
           "isUsed": false,
           "usedIn": [],
-          "size": 868
+          "size": 891
         },
         {
-          "name": "registerIntegratedSystem",
-          "type": "function",
-          "line": 175,
+          "name": "IntegratedBerriesOptions",
+          "type": "interface",
+          "line": 171,
           "isUsed": false,
           "usedIn": [],
-          "size": 868
+          "size": 891
         },
         {
-          "name": "updateAllIntegratedSystems",
-          "type": "function",
-          "line": 201,
+          "name": "IntegratedRainOptions",
+          "type": "interface",
+          "line": 178,
           "isUsed": false,
           "usedIn": [],
-          "size": 868
+          "size": 891
+        },
+        {
+          "name": "createIntegratedBerries",
+          "type": "function",
+          "line": 247,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 891
         },
         {
           "name": "disposeIntegratedSystem",
           "type": "function",
-          "line": 212,
+          "line": 393,
           "isUsed": false,
           "usedIn": [],
-          "size": 868
+          "size": 891
         },
         {
           "name": "disposeAllIntegratedSystems",
           "type": "function",
-          "line": 223,
+          "line": 404,
           "isUsed": false,
           "usedIn": [],
-          "size": 868
+          "size": 891
         },
         {
           "name": "queueDeferredSystem",
           "type": "function",
-          "line": 243,
+          "line": 424,
           "isUsed": false,
           "usedIn": [],
-          "size": 868
+          "size": 891
         },
         {
           "name": "loadDeferredSystems",
           "type": "function",
-          "line": 248,
+          "line": 429,
           "isUsed": false,
           "usedIn": [],
-          "size": 868
+          "size": 891
         },
         {
           "name": "BenchmarkResult",
           "type": "interface",
-          "line": 299,
+          "line": 488,
           "isUsed": false,
           "usedIn": [],
-          "size": 868
+          "size": 891
         },
         {
           "name": "benchmarkParticleSystem",
           "type": "function",
-          "line": 310,
+          "line": 499,
           "isUsed": false,
           "usedIn": [],
-          "size": 868
+          "size": 891
         },
         {
           "name": "printBenchmarkResults",
           "type": "function",
-          "line": 395,
+          "line": 588,
           "isUsed": false,
           "usedIn": [],
-          "size": 868
+          "size": 891
         }
       ],
-      "treeShakingScore": 0
-    },
-    {
-      "path": "ui/loading-screen.ts",
-      "exports": [
-        {
-          "name": "LoadingPhase",
-          "type": "interface",
-          "line": 20,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1775
-        },
-        {
-          "name": "LoadingProgress",
-          "type": "interface",
-          "line": 30,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1775
-        },
-        {
-          "name": "LoadingScreenOptions",
-          "type": "interface",
-          "line": 40,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1775
-        },
-        {
-          "name": "DEFAULT_LOADING_PHASES",
-          "type": "const",
-          "line": 52,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1775
-        },
-        {
-          "name": "LoadingScreen",
-          "type": "class",
-          "line": 116,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1775
-        },
-        {
-          "name": "initLoadingScreen",
-          "type": "function",
-          "line": 701,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1775
-        },
-        {
-          "name": "getLoadingScreen",
-          "type": "function",
-          "line": 715,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1775
-        },
-        {
-          "name": "showLoadingScreen",
-          "type": "function",
-          "line": 722,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1775
-        },
-        {
-          "name": "hideLoadingScreen",
-          "type": "function",
-          "line": 732,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1775
-        },
-        {
-          "name": "updateProgress",
-          "type": "function",
-          "line": 739,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1775
-        },
-        {
-          "name": "setLoadingStatus",
-          "type": "function",
-          "line": 756,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1775
-        },
-        {
-          "name": "completePhase",
-          "type": "function",
-          "line": 767,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1775
-        },
-        {
-          "name": "setLoadingDebug",
-          "type": "function",
-          "line": 774,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1775
-        },
-        {
-          "name": "installLegacyAPI",
-          "type": "function",
-          "line": 789,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1775
-        },
-        {
-          "name": "default",
-          "type": "function",
-          "line": 808,
-          "isUsed": true,
-          "usedIn": [
-            "world/generation.ts"
-          ],
-          "size": 0
-        }
-      ],
-      "imports": [],
-      "unusedExports": [
-        {
-          "name": "LoadingPhase",
-          "type": "interface",
-          "line": 20,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1775
-        },
-        {
-          "name": "LoadingProgress",
-          "type": "interface",
-          "line": 30,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1775
-        },
-        {
-          "name": "LoadingScreenOptions",
-          "type": "interface",
-          "line": 40,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1775
-        },
-        {
-          "name": "DEFAULT_LOADING_PHASES",
-          "type": "const",
-          "line": 52,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1775
-        },
-        {
-          "name": "LoadingScreen",
-          "type": "class",
-          "line": 116,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1775
-        },
-        {
-          "name": "initLoadingScreen",
-          "type": "function",
-          "line": 701,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1775
-        },
-        {
-          "name": "getLoadingScreen",
-          "type": "function",
-          "line": 715,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1775
-        },
-        {
-          "name": "showLoadingScreen",
-          "type": "function",
-          "line": 722,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1775
-        },
-        {
-          "name": "hideLoadingScreen",
-          "type": "function",
-          "line": 732,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1775
-        },
-        {
-          "name": "updateProgress",
-          "type": "function",
-          "line": 739,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1775
-        },
-        {
-          "name": "setLoadingStatus",
-          "type": "function",
-          "line": 756,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1775
-        },
-        {
-          "name": "completePhase",
-          "type": "function",
-          "line": 767,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1775
-        },
-        {
-          "name": "setLoadingDebug",
-          "type": "function",
-          "line": 774,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1775
-        },
-        {
-          "name": "installLegacyAPI",
-          "type": "function",
-          "line": 789,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1775
-        }
-      ],
-      "treeShakingScore": 7
+      "treeShakingScore": 29
     },
     {
       "path": "systems/region-manager.ts",
@@ -5028,7 +5033,7 @@
           "line": 25,
           "isUsed": true,
           "usedIn": [
-            "systems/asset-streaming.ts"
+            "systems/asset-streaming/asset-streaming-core.ts"
           ],
           "size": 0
         },
@@ -5038,7 +5043,7 @@
           "line": 34,
           "isUsed": true,
           "usedIn": [
-            "systems/asset-streaming.ts"
+            "systems/asset-streaming/asset-streaming-core.ts"
           ],
           "size": 0
         },
@@ -5048,7 +5053,7 @@
           "line": 49,
           "isUsed": false,
           "usedIn": [],
-          "size": 1797
+          "size": 1844
         },
         {
           "name": "CellWithBounds",
@@ -5056,7 +5061,7 @@
           "line": 59,
           "isUsed": false,
           "usedIn": [],
-          "size": 1797
+          "size": 1844
         },
         {
           "name": "RegionConfig",
@@ -5064,7 +5069,7 @@
           "line": 64,
           "isUsed": false,
           "usedIn": [],
-          "size": 1797
+          "size": 1844
         },
         {
           "name": "RegionStats",
@@ -5072,7 +5077,7 @@
           "line": 75,
           "isUsed": false,
           "usedIn": [],
-          "size": 1797
+          "size": 1844
         },
         {
           "name": "LODTransition",
@@ -5080,7 +5085,7 @@
           "line": 88,
           "isUsed": false,
           "usedIn": [],
-          "size": 1797
+          "size": 1844
         },
         {
           "name": "SpatialQueryResult",
@@ -5088,7 +5093,7 @@
           "line": 96,
           "isUsed": false,
           "usedIn": [],
-          "size": 1797
+          "size": 1844
         },
         {
           "name": "DEFAULT_REGION_CONFIG",
@@ -5096,7 +5101,7 @@
           "line": 106,
           "isUsed": false,
           "usedIn": [],
-          "size": 1797
+          "size": 1844
         },
         {
           "name": "getCellKey",
@@ -5104,48 +5109,56 @@
           "line": 121,
           "isUsed": false,
           "usedIn": [],
-          "size": 1797
+          "size": 1844
         },
         {
           "name": "parseCellKey",
           "type": "function",
-          "line": 126,
+          "line": 132,
           "isUsed": false,
           "usedIn": [],
-          "size": 1797
+          "size": 1844
         },
         {
           "name": "worldToCell",
           "type": "function",
-          "line": 132,
+          "line": 140,
           "isUsed": false,
           "usedIn": [],
-          "size": 1797
+          "size": 1844
         },
         {
           "name": "cellToBounds",
           "type": "function",
-          "line": 144,
+          "line": 152,
           "isUsed": false,
           "usedIn": [],
-          "size": 1797
+          "size": 1844
         },
         {
           "name": "distanceToCell",
           "type": "function",
-          "line": 165,
+          "line": 173,
           "isUsed": false,
           "usedIn": [],
-          "size": 1797
+          "size": 1844
+        },
+        {
+          "name": "distanceToCellSq",
+          "type": "function",
+          "line": 184,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1844
         },
         {
           "name": "RegionManager",
           "type": "class",
-          "line": 191,
+          "line": 210,
           "isUsed": true,
           "usedIn": [
             "examples/asset-streaming-usage.ts",
-            "systems/asset-streaming.ts",
+            "systems/asset-streaming/asset-streaming-core.ts",
             "systems/index.ts"
           ],
           "size": 0
@@ -5153,17 +5166,20 @@
         {
           "name": "CellLoader",
           "type": "class",
-          "line": 910,
+          "line": 974,
           "isUsed": false,
           "usedIn": [],
-          "size": 1797
+          "size": 1844
         },
         {
           "name": "default",
           "type": "function",
-          "line": 995,
+          "line": 1064,
           "isUsed": true,
           "usedIn": [
+            "core/init.ts",
+            "systems/music-reactivity.ts",
+            "utils/wasm-loader-core.ts",
             "world/generation.ts"
           ],
           "size": 0
@@ -5177,7 +5193,7 @@
           "line": 49,
           "isUsed": false,
           "usedIn": [],
-          "size": 1797
+          "size": 1844
         },
         {
           "name": "CellWithBounds",
@@ -5185,7 +5201,7 @@
           "line": 59,
           "isUsed": false,
           "usedIn": [],
-          "size": 1797
+          "size": 1844
         },
         {
           "name": "RegionConfig",
@@ -5193,7 +5209,7 @@
           "line": 64,
           "isUsed": false,
           "usedIn": [],
-          "size": 1797
+          "size": 1844
         },
         {
           "name": "RegionStats",
@@ -5201,7 +5217,7 @@
           "line": 75,
           "isUsed": false,
           "usedIn": [],
-          "size": 1797
+          "size": 1844
         },
         {
           "name": "LODTransition",
@@ -5209,7 +5225,7 @@
           "line": 88,
           "isUsed": false,
           "usedIn": [],
-          "size": 1797
+          "size": 1844
         },
         {
           "name": "SpatialQueryResult",
@@ -5217,7 +5233,7 @@
           "line": 96,
           "isUsed": false,
           "usedIn": [],
-          "size": 1797
+          "size": 1844
         },
         {
           "name": "DEFAULT_REGION_CONFIG",
@@ -5225,7 +5241,7 @@
           "line": 106,
           "isUsed": false,
           "usedIn": [],
-          "size": 1797
+          "size": 1844
         },
         {
           "name": "getCellKey",
@@ -5233,50 +5249,58 @@
           "line": 121,
           "isUsed": false,
           "usedIn": [],
-          "size": 1797
+          "size": 1844
         },
         {
           "name": "parseCellKey",
           "type": "function",
-          "line": 126,
+          "line": 132,
           "isUsed": false,
           "usedIn": [],
-          "size": 1797
+          "size": 1844
         },
         {
           "name": "worldToCell",
           "type": "function",
-          "line": 132,
+          "line": 140,
           "isUsed": false,
           "usedIn": [],
-          "size": 1797
+          "size": 1844
         },
         {
           "name": "cellToBounds",
           "type": "function",
-          "line": 144,
+          "line": 152,
           "isUsed": false,
           "usedIn": [],
-          "size": 1797
+          "size": 1844
         },
         {
           "name": "distanceToCell",
           "type": "function",
-          "line": 165,
+          "line": 173,
           "isUsed": false,
           "usedIn": [],
-          "size": 1797
+          "size": 1844
+        },
+        {
+          "name": "distanceToCellSq",
+          "type": "function",
+          "line": 184,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1844
         },
         {
           "name": "CellLoader",
           "type": "class",
-          "line": 910,
+          "line": 974,
           "isUsed": false,
           "usedIn": [],
-          "size": 1797
+          "size": 1844
         }
       ],
-      "treeShakingScore": 24
+      "treeShakingScore": 22
     },
     {
       "path": "systems/weather.core.ts",
@@ -5287,9 +5311,11 @@
           "line": 12,
           "isUsed": true,
           "usedIn": [
-            "main.ts",
-            "systems/weather-utils.ts",
-            "systems/weather.ts"
+            "core/game-loop.ts",
+            "systems/weather/weather-atmosphere.ts",
+            "systems/weather/weather-effects.ts",
+            "systems/weather/weather.ts",
+            "systems/weather-utils.ts"
           ],
           "size": 0
         },
@@ -5510,879 +5536,842 @@
       "treeShakingScore": 7
     },
     {
-      "path": "foliage/common.ts",
+      "path": "systems/discovery-persistence.ts",
       "exports": [
         {
-          "name": "sharedGeometries",
-          "type": "const",
-          "line": 28,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/arpeggio-batcher.ts",
-            "foliage/fireflies.ts",
-            "foliage/flower-batcher.ts",
-            "foliage/flowers.ts",
-            "foliage/glowing-flower-batcher.ts",
-            "foliage/instrument.ts",
-            "foliage/lantern-batcher.ts",
-            "foliage/lotus.ts",
-            "foliage/mushroom-batcher.ts",
-            "foliage/mushrooms.ts",
-            "foliage/panning-pads.ts",
-            "foliage/silence-spirits.ts",
-            "foliage/simple-flower-batcher.ts",
-            "foliage/tree-batcher.ts",
-            "foliage/trees.ts",
-            "foliage/waterfall-batcher.ts",
-            "systems/glitch-grenade.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "eyeGeo",
-          "type": "const",
-          "line": 50,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 874
-        },
-        {
-          "name": "pupilGeo",
-          "type": "const",
-          "line": 51,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 874
-        },
-        {
-          "name": "_scratchVec1",
-          "type": "const",
-          "line": 54,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 874
-        },
-        {
-          "name": "_scratchVec2",
-          "type": "const",
-          "line": 55,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 874
-        },
-        {
-          "name": "_scratchVec3",
-          "type": "const",
-          "line": 56,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 874
-        },
-        {
-          "name": "reactiveObjects",
-          "type": "const",
-          "line": 59,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 874
-        },
-        {
-          "name": "reactiveMaterials",
-          "type": "const",
-          "line": 61,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/animation.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "_foliageReactiveColor",
-          "type": "const",
-          "line": 62,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/animation.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "uWindSpeed",
-          "type": "const",
-          "line": 63,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/cloud-batcher.ts",
-            "foliage/dandelion-seeds.ts",
-            "foliage/glowing-flower-batcher.ts",
-            "foliage/grass.ts",
-            "foliage/lod.ts",
-            "foliage/pollen.ts",
-            "foliage/tree-batcher.ts",
-            "foliage/trees.ts",
-            "main.ts",
-            "particles/compute-particles.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "uWindDirection",
-          "type": "const",
-          "line": 64,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/cloud-batcher.ts",
-            "foliage/dandelion-seeds.ts",
-            "foliage/glowing-flower-batcher.ts",
-            "foliage/grass.ts",
-            "foliage/pollen.ts",
-            "main.ts",
-            "particles/compute-particles.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "uTime",
-          "type": "const",
-          "line": 65,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/arpeggio-batcher.ts",
-            "foliage/berries.ts",
-            "foliage/celestial-bodies.ts",
-            "foliage/cloud-batcher.ts",
-            "foliage/dandelion-batcher.ts",
-            "foliage/dandelion-seeds.ts",
-            "foliage/environment.ts",
-            "foliage/fireflies.ts",
-            "foliage/flower-batcher.ts",
-            "foliage/flowers.ts",
-            "foliage/glowing-flower-batcher.ts",
-            "foliage/impacts.ts",
-            "foliage/lantern-batcher.ts",
-            "foliage/lod.ts",
-            "foliage/lotus.ts",
-            "foliage/mirrors.ts",
-            "foliage/mushroom-batcher.ts",
-            "foliage/musical_flora.ts",
-            "foliage/panning-pads.ts",
-            "foliage/pollen.ts",
-            "foliage/shield.ts",
-            "foliage/silence-spirits.ts",
-            "foliage/simple-flower-batcher.ts",
-            "foliage/sparkle-trail.ts",
-            "foliage/tree-batcher.ts",
-            "foliage/waterfall-batcher.ts",
-            "foliage/wisteria-cluster.ts",
-            "gameplay/jitter-mines.ts",
-            "gameplay/rainbow-blaster.ts",
-            "main.ts",
-            "particles/compute-particles.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "uGlitchIntensity",
-          "type": "const",
-          "line": 66,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/arpeggio-batcher.ts",
-            "foliage/lotus.ts",
-            "foliage/musical_flora.ts",
-            "foliage/tree-batcher.ts",
-            "gameplay/jitter-mines.ts",
-            "main.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "uGlitchExplosionCenter",
-          "type": "const",
-          "line": 67,
-          "isUsed": true,
-          "usedIn": [
-            "systems/glitch-grenade.ts",
-            "systems/physics.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "uGlitchExplosionRadius",
-          "type": "const",
-          "line": 68,
-          "isUsed": true,
-          "usedIn": [
-            "systems/glitch-grenade.ts",
-            "systems/physics.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "uAudioLow",
-          "type": "const",
-          "line": 69,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/aurora.ts",
-            "foliage/berries.ts",
-            "foliage/cave.ts",
-            "foliage/celestial-bodies.ts",
-            "foliage/cloud-batcher.ts",
-            "foliage/dandelion-batcher.ts",
-            "foliage/environment.ts",
-            "foliage/fireflies.ts",
-            "foliage/flowers.ts",
-            "foliage/glowing-flower-batcher.ts",
-            "foliage/grass.ts",
-            "foliage/lantern-batcher.ts",
-            "foliage/lod.ts",
-            "foliage/lotus.ts",
-            "foliage/mushroom-batcher.ts",
-            "foliage/musical_flora.ts",
-            "foliage/pollen.ts",
-            "foliage/shield.ts",
-            "foliage/simple-flower-batcher.ts",
-            "foliage/sparkle-trail.ts",
-            "foliage/stars.ts",
-            "foliage/terrain.ts",
-            "foliage/tree-batcher.ts",
-            "foliage/trees.ts",
-            "foliage/water.ts",
-            "foliage/waterfall-batcher.ts",
-            "main.ts",
-            "particles/compute-particles.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "uAudioHigh",
-          "type": "const",
-          "line": 70,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/arpeggio-batcher.ts",
-            "foliage/aurora.ts",
-            "foliage/celestial-bodies.ts",
-            "foliage/cloud-batcher.ts",
-            "foliage/dandelion-batcher.ts",
-            "foliage/dandelion-seeds.ts",
-            "foliage/environment.ts",
-            "foliage/fireflies.ts",
-            "foliage/flower-batcher.ts",
-            "foliage/flowers.ts",
-            "foliage/glowing-flower-batcher.ts",
-            "foliage/grass.ts",
-            "foliage/impacts.ts",
-            "foliage/lantern-batcher.ts",
-            "foliage/lod.ts",
-            "foliage/mirrors.ts",
-            "foliage/mushroom-batcher.ts",
-            "foliage/pollen.ts",
-            "foliage/simple-flower-batcher.ts",
-            "foliage/sparkle-trail.ts",
-            "foliage/stars.ts",
-            "foliage/terrain.ts",
-            "foliage/tree-batcher.ts",
-            "foliage/water.ts",
-            "foliage/waterfall-batcher.ts",
-            "foliage/wisteria-cluster.ts",
-            "gameplay/harpoon-line.ts",
-            "gameplay/rainbow-blaster.ts",
-            "main.ts",
-            "particles/compute-particles.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "uPlayerPosition",
-          "type": "const",
-          "line": 73,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/arpeggio-batcher.ts",
-            "foliage/fireflies.ts",
-            "foliage/grass.ts",
-            "foliage/mushroom-batcher.ts",
-            "foliage/panning-pads.ts",
-            "foliage/pollen.ts",
-            "foliage/silence-spirits.ts",
-            "foliage/simple-flower-batcher.ts",
-            "foliage/terrain.ts",
-            "main.ts",
-            "particles/compute-particles.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "median",
-          "type": "function",
-          "line": 78,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/animation.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "generateNoiseTexture",
-          "type": "function",
-          "line": 85,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 874
-        },
-        {
-          "name": "getCachedProceduralMaterial",
-          "type": "function",
-          "line": 104,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 874
-        },
-        {
-          "name": "triplanarNoise",
-          "type": "const",
-          "line": 122,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/cave.ts",
-            "foliage/cloud-batcher.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "perturbNormal",
-          "type": "const",
-          "line": 140,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/cave.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "createRimLight",
-          "type": "const",
-          "line": 165,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/cave.ts",
-            "foliage/lantern-batcher.ts",
-            "foliage/mirrors.ts",
-            "foliage/mushroom-batcher.ts",
-            "foliage/terrain.ts",
-            "foliage/water.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "createJuicyRimLight",
-          "type": "const",
-          "line": 180,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/arpeggio-batcher.ts",
-            "foliage/cloud-batcher.ts",
-            "foliage/environment.ts",
-            "foliage/fireflies.ts",
-            "foliage/flower-batcher.ts",
-            "foliage/flowers.ts",
-            "foliage/glowing-flower-batcher.ts",
-            "foliage/lantern-batcher.ts",
-            "foliage/mushroom-batcher.ts",
-            "foliage/simple-flower-batcher.ts",
-            "foliage/tree-batcher.ts",
-            "foliage/trees.ts",
-            "foliage/waterfall-batcher.ts",
-            "gameplay/harpoon-line.ts",
-            "gameplay/rainbow-blaster.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "createSugarSparkle",
-          "type": "const",
-          "line": 205,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/dandelion-batcher.ts",
-            "foliage/dandelion-seeds.ts",
-            "foliage/mushroom-batcher.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "addRimLight",
-          "type": "const",
-          "line": 238,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 874
-        },
-        {
-          "name": "colorFromNote",
-          "type": "const",
-          "line": 247,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/mushroom-batcher.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "calculatePlayerPush",
-          "type": "const",
-          "line": 262,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/portamento-batcher.ts",
-            "foliage/trees.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "applyPlayerInteraction",
-          "type": "const",
-          "line": 286,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/arpeggio-batcher.ts",
-            "foliage/dandelion-batcher.ts",
-            "foliage/flower-batcher.ts",
-            "foliage/flowers.ts",
-            "foliage/glowing-flower-batcher.ts",
-            "foliage/lantern-batcher.ts",
-            "foliage/lod.ts",
-            "foliage/simple-flower-batcher.ts",
-            "foliage/tree-batcher.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "calculateWindSway",
-          "type": "const",
-          "line": 319,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/arpeggio-batcher.ts",
-            "foliage/dandelion-batcher.ts",
-            "foliage/flower-batcher.ts",
-            "foliage/flowers.ts",
-            "foliage/glowing-flower-batcher.ts",
-            "foliage/lantern-batcher.ts",
-            "foliage/lod.ts",
-            "foliage/portamento-batcher.ts",
-            "foliage/simple-flower-batcher.ts",
-            "foliage/tree-batcher.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "calculateWindSwayLegacy",
-          "type": "const",
-          "line": 362,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 874
-        },
-        {
-          "name": "windComputeSystem",
-          "type": "const",
-          "line": 382,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/common.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "calculateFlowerBloom",
-          "type": "const",
-          "line": 384,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/flower-batcher.ts",
-            "foliage/flowers.ts",
-            "foliage/simple-flower-batcher.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "UnifiedMaterialOptions",
+          "name": "PersistedDiscovery",
           "type": "interface",
-          "line": 400,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/panning-pads.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "createUnifiedMaterial",
-          "type": "function",
-          "line": 436,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/instrument.ts",
-            "foliage/lantern-batcher.ts",
-            "foliage/panning-pads.ts",
-            "foliage/portamento-batcher.ts",
-            "foliage/ribbons.ts",
-            "foliage/shield.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "CandyPresets",
-          "type": "const",
-          "line": 675,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/berries.ts",
-            "foliage/celestial-bodies.ts",
-            "foliage/environment.ts",
-            "foliage/flower-batcher.ts",
-            "foliage/lod.ts",
-            "foliage/moon.ts",
-            "foliage/musical_flora.ts",
-            "foliage/panning-pads.ts",
-            "foliage/simple-flower-batcher.ts",
-            "foliage/terrain.ts",
-            "foliage/tree-batcher.ts",
-            "foliage/water.ts",
-            "foliage/waterfall-batcher.ts",
-            "foliage/waterfalls.ts",
-            "foliage/wisteria-cluster.ts",
-            "gameplay/harpoon-line.ts",
-            "rendering/shader-warmup.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "createClayMaterial",
-          "type": "function",
-          "line": 757,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/flowers.ts",
-            "foliage/grass.ts",
-            "foliage/lotus.ts",
-            "foliage/musical_flora.ts",
-            "foliage/simple-flower-batcher.ts",
-            "foliage/trees.ts",
-            "gameplay/jitter-mines.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "createCandyMaterial",
-          "type": "function",
-          "line": 761,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/arpeggio-batcher.ts",
-            "foliage/musical_flora.ts",
-            "gameplay/rainbow-blaster.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "createTexturedClay",
-          "type": "function",
-          "line": 765,
+          "line": 18,
           "isUsed": false,
           "usedIn": [],
-          "size": 874
+          "size": 1742
         },
         {
-          "name": "createSugaredMaterial",
-          "type": "function",
-          "line": 774,
+          "name": "DiscoveryExport",
+          "type": "interface",
+          "line": 39,
           "isUsed": false,
           "usedIn": [],
-          "size": 874
+          "size": 1742
         },
         {
-          "name": "createGradientMaterial",
-          "type": "function",
-          "line": 787,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/trees.ts"
-          ],
-          "size": 0
+          "name": "ImportResult",
+          "type": "interface",
+          "line": 62,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1742
         },
         {
-          "name": "createStandardNodeMaterial",
-          "type": "function",
-          "line": 829,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/arpeggio-batcher.ts",
-            "foliage/dandelion-batcher.ts",
-            "foliage/flower-batcher.ts",
-            "foliage/flowers.ts",
-            "foliage/glowing-flower-batcher.ts",
-            "foliage/lantern-batcher.ts",
-            "foliage/panning-pads.ts",
-            "foliage/tree-batcher.ts",
-            "foliage/trees.ts"
-          ],
-          "size": 0
+          "name": "DiscoveryStats",
+          "type": "interface",
+          "line": 72,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1742
         },
         {
-          "name": "createTransparentNodeMaterial",
-          "type": "function",
-          "line": 849,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/flowers.ts"
-          ],
-          "size": 0
+          "name": "DiscoveryPersistence",
+          "type": "class",
+          "line": 95,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1742
         },
         {
-          "name": "foliageMaterials",
+          "name": "discoveryPersistence",
           "type": "const",
-          "line": 858,
+          "line": 670,
           "isUsed": true,
           "usedIn": [
-            "foliage/flower-batcher.ts",
-            "foliage/flowers.ts",
-            "foliage/glowing-flower-batcher.ts",
-            "foliage/lantern-batcher.ts",
-            "foliage/mushroom-batcher.ts",
-            "foliage/simple-flower-batcher.ts",
-            "foliage/trees.ts",
-            "foliage/waterfall-batcher.ts",
-            "rendering/shader-warmup.ts"
+            "systems/discovery-optimized.ts",
+            "systems/discovery.ts"
           ],
           "size": 0
         },
         {
-          "name": "registerReactiveMaterial",
+          "name": "exportDiscoveries",
           "type": "function",
-          "line": 984,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/arpeggio-batcher.ts",
-            "foliage/environment.ts",
-            "foliage/flowers.ts",
-            "foliage/lotus.ts",
-            "foliage/musical_flora.ts",
-            "foliage/panning-pads.ts",
-            "foliage/portamento-batcher.ts",
-            "foliage/silence-spirits.ts",
-            "foliage/trees.ts",
-            "foliage/waterfall-batcher.ts",
-            "foliage/waterfalls.ts"
-          ],
-          "size": 0
+          "line": 676,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1742
         },
         {
-          "name": "pickAnimation",
+          "name": "importDiscoveries",
           "type": "function",
-          "line": 985,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/flowers.ts",
-            "foliage/trees.ts"
-          ],
-          "size": 0
+          "line": 685,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1742
         },
         {
-          "name": "attachReactivity",
+          "name": "clearLocalDiscoveries",
           "type": "function",
-          "line": 987,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/celestial-bodies.ts",
-            "foliage/environment.ts",
-            "foliage/flowers.ts",
-            "foliage/instrument.ts",
-            "foliage/lotus.ts",
-            "foliage/mirrors.ts",
-            "foliage/moon.ts",
-            "foliage/musical_flora.ts",
-            "foliage/panning-pads.ts",
-            "foliage/silence-spirits.ts",
-            "foliage/trees.ts",
-            "foliage/waterfalls.ts",
-            "foliage/wisteria-cluster.ts"
-          ],
-          "size": 0
+          "line": 692,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1742
         },
         {
-          "name": "cleanupReactivity",
+          "name": "getDiscoveryStats",
           "type": "function",
-          "line": 997,
-          "isUsed": true,
-          "usedIn": [
-            "systems/weather.ts"
-          ],
-          "size": 0
+          "line": 699,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1742
         },
         {
-          "name": "validateFoliageMaterials",
+          "name": "isPersistenceAvailable",
           "type": "function",
-          "line": 1002,
-          "isUsed": true,
-          "usedIn": [
-            "world/generation.ts"
-          ],
-          "size": 0
+          "line": 706,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1742
         },
         {
-          "name": "validateNodeGeometries",
+          "name": "getDiscoveryIds",
           "type": "function",
-          "line": 1015,
-          "isUsed": true,
-          "usedIn": [
-            "main.ts"
-          ],
-          "size": 0
+          "line": 718,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1742
+        },
+        {
+          "name": "isDiscovered",
+          "type": "function",
+          "line": 726,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1742
         }
       ],
       "imports": [
-        "MeshStandardNodeMaterial",
-        "color",
-        "float",
-        "uv",
-        "mix",
-        "vec3",
-        "vec2",
-        "Fn",
-        "uniform",
-        "dot",
-        "max",
-        "min",
-        "mx_noise_float",
-        "positionLocal",
-        "positionWorld",
-        "normalWorld",
-        "normalLocal",
-        "cameraPosition",
-        "sin",
-        "pow",
-        "abs",
-        "normalize",
-        "smoothstep",
-        "exp",
-        "texture",
-        "Node",
-        "applyGlitch",
-        "FoliageMaterial",
-        "windComputeSystem",
-        "getWindTextureData",
-        "geometryRegistry",
-        "CommonGeometries",
-        "getSphereGeometry",
-        "getCylinderGeometry",
-        "getConeGeometry",
-        "getCapsuleGeometry",
-        "getPlaneGeometry",
-        "getTorusGeometry",
+        "DISCOVERY_MAP",
+        "type DiscoveryItem"
+      ],
+      "unusedExports": [
+        {
+          "name": "PersistedDiscovery",
+          "type": "interface",
+          "line": 18,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1742
+        },
+        {
+          "name": "DiscoveryExport",
+          "type": "interface",
+          "line": 39,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1742
+        },
+        {
+          "name": "ImportResult",
+          "type": "interface",
+          "line": 62,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1742
+        },
+        {
+          "name": "DiscoveryStats",
+          "type": "interface",
+          "line": 72,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1742
+        },
+        {
+          "name": "DiscoveryPersistence",
+          "type": "class",
+          "line": 95,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1742
+        },
+        {
+          "name": "exportDiscoveries",
+          "type": "function",
+          "line": 676,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1742
+        },
+        {
+          "name": "importDiscoveries",
+          "type": "function",
+          "line": 685,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1742
+        },
+        {
+          "name": "clearLocalDiscoveries",
+          "type": "function",
+          "line": 692,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1742
+        },
+        {
+          "name": "getDiscoveryStats",
+          "type": "function",
+          "line": 699,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1742
+        },
+        {
+          "name": "isPersistenceAvailable",
+          "type": "function",
+          "line": 706,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1742
+        },
+        {
+          "name": "getDiscoveryIds",
+          "type": "function",
+          "line": 718,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1742
+        },
+        {
+          "name": "isDiscovered",
+          "type": "function",
+          "line": 726,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1742
+        }
+      ],
+      "treeShakingScore": 8
+    },
+    {
+      "path": "utils/wasm-batch-math.ts",
+      "exports": [
+        {
+          "name": "batchHslToRgb",
+          "type": "function",
+          "line": 80,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1267
+        },
+        {
+          "name": "batchSphereCull",
+          "type": "function",
+          "line": 132,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1267
+        },
+        {
+          "name": "batchLerp",
+          "type": "function",
+          "line": 167,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1267
+        },
+        {
+          "name": "batchValueNoiseSimd4",
+          "type": "function",
+          "line": 195,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1267
+        },
+        {
+          "name": "batchFbmSimd4",
+          "type": "function",
+          "line": 234,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1267
+        },
+        {
+          "name": "batchGroundHeightSimd",
+          "type": "function",
+          "line": 271,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1267
+        },
+        {
+          "name": "batchValueNoiseOmp",
+          "type": "function",
+          "line": 313,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1267
+        },
+        {
+          "name": "batchFbmOmp",
+          "type": "function",
+          "line": 352,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1267
+        },
+        {
+          "name": "batchDistSq3DOmp",
+          "type": "function",
+          "line": 394,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1267
+        },
+        {
+          "name": "fastSin",
+          "type": "function",
+          "line": 448,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1267
+        },
+        {
+          "name": "fastCos",
+          "type": "function",
+          "line": 460,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1267
+        },
+        {
+          "name": "fastPow2",
+          "type": "function",
+          "line": 472,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1267
+        }
+      ],
+      "imports": [
+        "emscriptenInstance",
+        "cppValueNoise2DSimd4",
+        "cppFbm2DSimd4",
+        "cppBatchGroundHeightSimd",
+        "cppBatchValueNoiseOmp",
+        "cppBatchFbmOmp",
+        "cppBatchDistSq3DOmp",
+        "cppFastSin",
+        "cppFastCos",
+        "cppFastPow2",
+        "wasmBatchHslToRgb",
+        "wasmBatchSphereCull",
+        "wasmBatchLerp"
+      ],
+      "unusedExports": [
+        {
+          "name": "batchHslToRgb",
+          "type": "function",
+          "line": 80,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1267
+        },
+        {
+          "name": "batchSphereCull",
+          "type": "function",
+          "line": 132,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1267
+        },
+        {
+          "name": "batchLerp",
+          "type": "function",
+          "line": 167,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1267
+        },
+        {
+          "name": "batchValueNoiseSimd4",
+          "type": "function",
+          "line": 195,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1267
+        },
+        {
+          "name": "batchFbmSimd4",
+          "type": "function",
+          "line": 234,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1267
+        },
+        {
+          "name": "batchGroundHeightSimd",
+          "type": "function",
+          "line": 271,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1267
+        },
+        {
+          "name": "batchValueNoiseOmp",
+          "type": "function",
+          "line": 313,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1267
+        },
+        {
+          "name": "batchFbmOmp",
+          "type": "function",
+          "line": 352,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1267
+        },
+        {
+          "name": "batchDistSq3DOmp",
+          "type": "function",
+          "line": 394,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1267
+        },
+        {
+          "name": "fastSin",
+          "type": "function",
+          "line": 448,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1267
+        },
+        {
+          "name": "fastCos",
+          "type": "function",
+          "line": 460,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1267
+        },
+        {
+          "name": "fastPow2",
+          "type": "function",
+          "line": 472,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1267
+        }
+      ],
+      "treeShakingScore": 0
+    },
+    {
+      "path": "compute/gpu-foliage-animator.ts",
+      "exports": [
+        {
+          "name": "FoliageInstanceData",
+          "type": "interface",
+          "line": 29,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2569
+        },
+        {
+          "name": "FoliageAudioState",
+          "type": "interface",
+          "line": 47,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2569
+        },
+        {
+          "name": "AnimationType",
+          "type": "enum",
+          "line": 62,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2569
+        },
+        {
+          "name": "FoliageAnimationOutput",
+          "type": "interface",
+          "line": 81,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2569
+        },
+        {
+          "name": "FOLIAGE_ANIMATION_WGSL",
+          "type": "const",
+          "line": 117,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2569
+        },
+        {
+          "name": "GPUFoliageAnimator",
+          "type": "class",
+          "line": 361,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2569
+        },
+        {
+          "name": "updateInstancedMeshFromAnimator",
+          "type": "function",
+          "line": 687,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2569
+        },
+        {
+          "name": "createGPUFoliageAnimator",
+          "type": "function",
+          "line": 740,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2569
+        },
+        {
+          "name": "createFoliageInstanceData",
+          "type": "function",
+          "line": 758,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2569
+        },
+        {
+          "name": "FoliageAnimatorCapabilities",
+          "type": "interface",
+          "line": 794,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2569
+        },
+        {
+          "name": "detectFoliageCapabilities",
+          "type": "function",
+          "line": 803,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2569
+        }
+      ],
+      "imports": [
+        "GPUComputeLibrary",
         "THREE"
       ],
       "unusedExports": [
         {
-          "name": "eyeGeo",
-          "type": "const",
-          "line": 50,
+          "name": "FoliageInstanceData",
+          "type": "interface",
+          "line": 29,
           "isUsed": false,
           "usedIn": [],
-          "size": 874
+          "size": 2569
         },
         {
-          "name": "pupilGeo",
-          "type": "const",
-          "line": 51,
+          "name": "FoliageAudioState",
+          "type": "interface",
+          "line": 47,
           "isUsed": false,
           "usedIn": [],
-          "size": 874
+          "size": 2569
         },
         {
-          "name": "_scratchVec1",
-          "type": "const",
-          "line": 54,
+          "name": "AnimationType",
+          "type": "enum",
+          "line": 62,
           "isUsed": false,
           "usedIn": [],
-          "size": 874
+          "size": 2569
         },
         {
-          "name": "_scratchVec2",
-          "type": "const",
-          "line": 55,
+          "name": "FoliageAnimationOutput",
+          "type": "interface",
+          "line": 81,
           "isUsed": false,
           "usedIn": [],
-          "size": 874
+          "size": 2569
         },
         {
-          "name": "_scratchVec3",
+          "name": "FOLIAGE_ANIMATION_WGSL",
           "type": "const",
-          "line": 56,
+          "line": 117,
           "isUsed": false,
           "usedIn": [],
-          "size": 874
+          "size": 2569
         },
         {
-          "name": "reactiveObjects",
-          "type": "const",
-          "line": 59,
+          "name": "GPUFoliageAnimator",
+          "type": "class",
+          "line": 361,
           "isUsed": false,
           "usedIn": [],
-          "size": 874
+          "size": 2569
         },
         {
-          "name": "generateNoiseTexture",
+          "name": "updateInstancedMeshFromAnimator",
           "type": "function",
-          "line": 85,
+          "line": 687,
           "isUsed": false,
           "usedIn": [],
-          "size": 874
+          "size": 2569
         },
         {
-          "name": "getCachedProceduralMaterial",
+          "name": "createGPUFoliageAnimator",
           "type": "function",
-          "line": 104,
+          "line": 740,
           "isUsed": false,
           "usedIn": [],
-          "size": 874
+          "size": 2569
         },
         {
-          "name": "addRimLight",
-          "type": "const",
-          "line": 238,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 874
-        },
-        {
-          "name": "calculateWindSwayLegacy",
-          "type": "const",
-          "line": 362,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 874
-        },
-        {
-          "name": "createTexturedClay",
+          "name": "createFoliageInstanceData",
           "type": "function",
-          "line": 765,
+          "line": 758,
           "isUsed": false,
           "usedIn": [],
-          "size": 874
+          "size": 2569
         },
         {
-          "name": "createSugaredMaterial",
-          "type": "function",
-          "line": 774,
+          "name": "FoliageAnimatorCapabilities",
+          "type": "interface",
+          "line": 794,
           "isUsed": false,
           "usedIn": [],
-          "size": 874
+          "size": 2569
+        },
+        {
+          "name": "detectFoliageCapabilities",
+          "type": "function",
+          "line": 803,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2569
         }
       ],
-      "treeShakingScore": 76
+      "treeShakingScore": 0
+    },
+    {
+      "path": "foliage/animation-nodes.ts",
+      "exports": [
+        {
+          "name": "ANIMATION_TYPES",
+          "type": "const",
+          "line": 6,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/portamento-batcher.ts",
+            "foliage/tree-batcher.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "gentleSwayNode",
+          "type": "const",
+          "line": 26,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 436
+        },
+        {
+          "name": "bounceNode",
+          "type": "const",
+          "line": 34,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 436
+        },
+        {
+          "name": "shiverNode",
+          "type": "const",
+          "line": 41,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 436
+        },
+        {
+          "name": "springNode",
+          "type": "const",
+          "line": 49,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 436
+        },
+        {
+          "name": "vineSwayNode",
+          "type": "const",
+          "line": 57,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 436
+        },
+        {
+          "name": "hopNode",
+          "type": "const",
+          "line": 65,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 436
+        },
+        {
+          "name": "wobbleNode",
+          "type": "const",
+          "line": 72,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 436
+        },
+        {
+          "name": "accordionNode",
+          "type": "const",
+          "line": 79,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 436
+        },
+        {
+          "name": "spiralWaveNode",
+          "type": "const",
+          "line": 86,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 436
+        },
+        {
+          "name": "fiberWhipNode",
+          "type": "const",
+          "line": 94,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 436
+        },
+        {
+          "name": "applyInstanceAnimation",
+          "type": "const",
+          "line": 105,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/portamento-batcher.ts",
+            "foliage/tree-batcher.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "applyInstanceNormalAnimation",
+          "type": "const",
+          "line": 130,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 436
+        }
+      ],
+      "imports": [
+        "positionLocal",
+        "time",
+        "float",
+        "sin",
+        "cos",
+        "vec3",
+        "attribute",
+        "select",
+        "positionWorld",
+        "normalLocal",
+        "uAudioLow",
+        "uAudioHigh"
+      ],
+      "unusedExports": [
+        {
+          "name": "gentleSwayNode",
+          "type": "const",
+          "line": 26,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 436
+        },
+        {
+          "name": "bounceNode",
+          "type": "const",
+          "line": 34,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 436
+        },
+        {
+          "name": "shiverNode",
+          "type": "const",
+          "line": 41,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 436
+        },
+        {
+          "name": "springNode",
+          "type": "const",
+          "line": 49,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 436
+        },
+        {
+          "name": "vineSwayNode",
+          "type": "const",
+          "line": 57,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 436
+        },
+        {
+          "name": "hopNode",
+          "type": "const",
+          "line": 65,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 436
+        },
+        {
+          "name": "wobbleNode",
+          "type": "const",
+          "line": 72,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 436
+        },
+        {
+          "name": "accordionNode",
+          "type": "const",
+          "line": 79,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 436
+        },
+        {
+          "name": "spiralWaveNode",
+          "type": "const",
+          "line": 86,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 436
+        },
+        {
+          "name": "fiberWhipNode",
+          "type": "const",
+          "line": 94,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 436
+        },
+        {
+          "name": "applyInstanceNormalAnimation",
+          "type": "const",
+          "line": 130,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 436
+        }
+      ],
+      "treeShakingScore": 15
     },
     {
       "path": "particles/particle_config.ts",
@@ -6457,9 +6446,12 @@
           "name": "ComputeParticleConfig",
           "type": "interface",
           "line": 114,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 442
+          "isUsed": true,
+          "usedIn": [
+            "particles/compute-particles.ts",
+            "particles/cpu-particle-system.ts"
+          ],
+          "size": 0
         },
         {
           "name": "ParticleAudioState",
@@ -6555,14 +6547,6 @@
           "size": 442
         },
         {
-          "name": "ComputeParticleConfig",
-          "type": "interface",
-          "line": 114,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 442
-        },
-        {
           "name": "ParticleAudioState",
           "type": "interface",
           "line": 130,
@@ -6595,419 +6579,7 @@
           "size": 442
         }
       ],
-      "treeShakingScore": 8
-    },
-    {
-      "path": "systems/discovery-persistence.ts",
-      "exports": [
-        {
-          "name": "PersistedDiscovery",
-          "type": "interface",
-          "line": 18,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1716
-        },
-        {
-          "name": "DiscoveryExport",
-          "type": "interface",
-          "line": 39,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1716
-        },
-        {
-          "name": "ImportResult",
-          "type": "interface",
-          "line": 62,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1716
-        },
-        {
-          "name": "DiscoveryStats",
-          "type": "interface",
-          "line": 72,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1716
-        },
-        {
-          "name": "DiscoveryPersistence",
-          "type": "class",
-          "line": 95,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1716
-        },
-        {
-          "name": "discoveryPersistence",
-          "type": "const",
-          "line": 656,
-          "isUsed": true,
-          "usedIn": [
-            "systems/discovery-optimized.ts",
-            "systems/discovery.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "exportDiscoveries",
-          "type": "function",
-          "line": 662,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1716
-        },
-        {
-          "name": "importDiscoveries",
-          "type": "function",
-          "line": 671,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1716
-        },
-        {
-          "name": "clearLocalDiscoveries",
-          "type": "function",
-          "line": 678,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1716
-        },
-        {
-          "name": "getDiscoveryStats",
-          "type": "function",
-          "line": 685,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1716
-        },
-        {
-          "name": "isPersistenceAvailable",
-          "type": "function",
-          "line": 692,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1716
-        },
-        {
-          "name": "getDiscoveryIds",
-          "type": "function",
-          "line": 704,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1716
-        },
-        {
-          "name": "isDiscovered",
-          "type": "function",
-          "line": 712,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1716
-        }
-      ],
-      "imports": [
-        "DISCOVERY_MAP",
-        "type DiscoveryItem"
-      ],
-      "unusedExports": [
-        {
-          "name": "PersistedDiscovery",
-          "type": "interface",
-          "line": 18,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1716
-        },
-        {
-          "name": "DiscoveryExport",
-          "type": "interface",
-          "line": 39,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1716
-        },
-        {
-          "name": "ImportResult",
-          "type": "interface",
-          "line": 62,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1716
-        },
-        {
-          "name": "DiscoveryStats",
-          "type": "interface",
-          "line": 72,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1716
-        },
-        {
-          "name": "DiscoveryPersistence",
-          "type": "class",
-          "line": 95,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1716
-        },
-        {
-          "name": "exportDiscoveries",
-          "type": "function",
-          "line": 662,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1716
-        },
-        {
-          "name": "importDiscoveries",
-          "type": "function",
-          "line": 671,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1716
-        },
-        {
-          "name": "clearLocalDiscoveries",
-          "type": "function",
-          "line": 678,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1716
-        },
-        {
-          "name": "getDiscoveryStats",
-          "type": "function",
-          "line": 685,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1716
-        },
-        {
-          "name": "isPersistenceAvailable",
-          "type": "function",
-          "line": 692,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1716
-        },
-        {
-          "name": "getDiscoveryIds",
-          "type": "function",
-          "line": 704,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1716
-        },
-        {
-          "name": "isDiscovered",
-          "type": "function",
-          "line": 712,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1716
-        }
-      ],
-      "treeShakingScore": 8
-    },
-    {
-      "path": "rendering/material_types.ts",
-      "exports": [
-        {
-          "name": "MaterialType",
-          "type": "const",
-          "line": 12,
-          "isUsed": true,
-          "usedIn": [
-            "rendering/materials.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "MaterialTypeValue",
-          "type": "type",
-          "line": 24,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 329
-        },
-        {
-          "name": "CandyMaterialConfig",
-          "type": "interface",
-          "line": 29,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 329
-        },
-        {
-          "name": "GlowingMaterialConfig",
-          "type": "interface",
-          "line": 47,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 329
-        },
-        {
-          "name": "PetalMaterialConfig",
-          "type": "interface",
-          "line": 59,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 329
-        },
-        {
-          "name": "AudioReactiveMaterialConfig",
-          "type": "interface",
-          "line": 69,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 329
-        },
-        {
-          "name": "GroundMaterialConfig",
-          "type": "interface",
-          "line": 81,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 329
-        },
-        {
-          "name": "AudioState",
-          "type": "interface",
-          "line": 89,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 329
-        },
-        {
-          "name": "IAudioReactiveMaterial",
-          "type": "interface",
-          "line": 103,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 329
-        },
-        {
-          "name": "CandyMaterial",
-          "type": "interface",
-          "line": 111,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 329
-        },
-        {
-          "name": "AudioUniforms",
-          "type": "interface",
-          "line": 131,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 329
-        },
-        {
-          "name": "MaterialCreateResult",
-          "type": "type",
-          "line": 141,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 329
-        }
-      ],
-      "imports": [
-        "THREE"
-      ],
-      "unusedExports": [
-        {
-          "name": "MaterialTypeValue",
-          "type": "type",
-          "line": 24,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 329
-        },
-        {
-          "name": "CandyMaterialConfig",
-          "type": "interface",
-          "line": 29,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 329
-        },
-        {
-          "name": "GlowingMaterialConfig",
-          "type": "interface",
-          "line": 47,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 329
-        },
-        {
-          "name": "PetalMaterialConfig",
-          "type": "interface",
-          "line": 59,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 329
-        },
-        {
-          "name": "AudioReactiveMaterialConfig",
-          "type": "interface",
-          "line": 69,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 329
-        },
-        {
-          "name": "GroundMaterialConfig",
-          "type": "interface",
-          "line": 81,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 329
-        },
-        {
-          "name": "AudioState",
-          "type": "interface",
-          "line": 89,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 329
-        },
-        {
-          "name": "IAudioReactiveMaterial",
-          "type": "interface",
-          "line": 103,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 329
-        },
-        {
-          "name": "CandyMaterial",
-          "type": "interface",
-          "line": 111,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 329
-        },
-        {
-          "name": "AudioUniforms",
-          "type": "interface",
-          "line": 131,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 329
-        },
-        {
-          "name": "MaterialCreateResult",
-          "type": "type",
-          "line": 141,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 329
-        }
-      ],
-      "treeShakingScore": 8
+      "treeShakingScore": 15
     },
     {
       "path": "rendering/materials.ts",
@@ -7454,6 +7026,312 @@
       "treeShakingScore": 15
     },
     {
+      "path": "systems/analytics/types.ts",
+      "exports": [
+        {
+          "name": "AnalyticsConfig",
+          "type": "interface",
+          "line": 14,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 393
+        },
+        {
+          "name": "EventType",
+          "type": "type",
+          "line": 38,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 393
+        },
+        {
+          "name": "AnalyticsEvent",
+          "type": "interface",
+          "line": 53,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 393
+        },
+        {
+          "name": "SessionData",
+          "type": "interface",
+          "line": 67,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 393
+        },
+        {
+          "name": "FPSHistogram",
+          "type": "interface",
+          "line": 97,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 393
+        },
+        {
+          "name": "FrameTimePercentiles",
+          "type": "interface",
+          "line": 109,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 393
+        },
+        {
+          "name": "LoadingPhaseTiming",
+          "type": "interface",
+          "line": 119,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 393
+        },
+        {
+          "name": "MemorySnapshot",
+          "type": "interface",
+          "line": 129,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 393
+        },
+        {
+          "name": "GPUTiming",
+          "type": "interface",
+          "line": 141,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 393
+        },
+        {
+          "name": "PerformanceMetrics",
+          "type": "interface",
+          "line": 151,
+          "isUsed": true,
+          "usedIn": [
+            "systems/performance-budget/performance-budget-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "AnalyticsExport",
+          "type": "interface",
+          "line": 165,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 393
+        },
+        {
+          "name": "ExternalAnalyticsProvider",
+          "type": "interface",
+          "line": 185,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 393
+        },
+        {
+          "name": "DEFAULT_CONFIG",
+          "type": "const",
+          "line": 199,
+          "isUsed": true,
+          "usedIn": [
+            "systems/analytics/core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "STORAGE_KEYS",
+          "type": "const",
+          "line": 211,
+          "isUsed": true,
+          "usedIn": [
+            "systems/analytics/core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "ANALYTICS_VERSION",
+          "type": "const",
+          "line": 218,
+          "isUsed": true,
+          "usedIn": [
+            "systems/analytics/core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "generateSessionId",
+          "type": "function",
+          "line": 228,
+          "isUsed": true,
+          "usedIn": [
+            "systems/analytics/core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getTimestamp",
+          "type": "function",
+          "line": 244,
+          "isUsed": true,
+          "usedIn": [
+            "systems/analytics/core.ts",
+            "systems/analytics/performance.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "safeLocalStorage",
+          "type": "function",
+          "line": 251,
+          "isUsed": true,
+          "usedIn": [
+            "systems/analytics/core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "loadConfig",
+          "type": "function",
+          "line": 267,
+          "isUsed": true,
+          "usedIn": [
+            "systems/analytics/core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "saveConfig",
+          "type": "function",
+          "line": 285,
+          "isUsed": true,
+          "usedIn": [
+            "systems/analytics/core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "loadQueuedEvents",
+          "type": "function",
+          "line": 299,
+          "isUsed": true,
+          "usedIn": [
+            "systems/analytics/core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "saveQueuedEvents",
+          "type": "function",
+          "line": 317,
+          "isUsed": true,
+          "usedIn": [
+            "systems/analytics/core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "shouldSample",
+          "type": "function",
+          "line": 334,
+          "isUsed": true,
+          "usedIn": [
+            "systems/analytics/core.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [],
+      "unusedExports": [
+        {
+          "name": "AnalyticsConfig",
+          "type": "interface",
+          "line": 14,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 393
+        },
+        {
+          "name": "EventType",
+          "type": "type",
+          "line": 38,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 393
+        },
+        {
+          "name": "AnalyticsEvent",
+          "type": "interface",
+          "line": 53,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 393
+        },
+        {
+          "name": "SessionData",
+          "type": "interface",
+          "line": 67,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 393
+        },
+        {
+          "name": "FPSHistogram",
+          "type": "interface",
+          "line": 97,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 393
+        },
+        {
+          "name": "FrameTimePercentiles",
+          "type": "interface",
+          "line": 109,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 393
+        },
+        {
+          "name": "LoadingPhaseTiming",
+          "type": "interface",
+          "line": 119,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 393
+        },
+        {
+          "name": "MemorySnapshot",
+          "type": "interface",
+          "line": 129,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 393
+        },
+        {
+          "name": "GPUTiming",
+          "type": "interface",
+          "line": 141,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 393
+        },
+        {
+          "name": "AnalyticsExport",
+          "type": "interface",
+          "line": 165,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 393
+        },
+        {
+          "name": "ExternalAnalyticsProvider",
+          "type": "interface",
+          "line": 185,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 393
+        }
+      ],
+      "treeShakingScore": 52
+    },
+    {
       "path": "systems/music-reactivity.core.ts",
       "exports": [
         {
@@ -7462,7 +7340,7 @@
           "line": 10,
           "isUsed": false,
           "usedIn": [],
-          "size": 682
+          "size": 707
         },
         {
           "name": "LightLevelCheck",
@@ -7470,7 +7348,7 @@
           "line": 17,
           "isUsed": false,
           "usedIn": [],
-          "size": 682
+          "size": 707
         },
         {
           "name": "ChannelMapping",
@@ -7478,71 +7356,71 @@
           "line": 22,
           "isUsed": false,
           "usedIn": [],
-          "size": 682
+          "size": 707
         },
         {
           "name": "calculateLightFactor",
           "type": "function",
-          "line": 42,
+          "line": 45,
           "isUsed": false,
           "usedIn": [],
-          "size": 682
+          "size": 707
         },
         {
           "name": "calculateChannelIndex",
           "type": "function",
-          "line": 72,
+          "line": 75,
           "isUsed": false,
           "usedIn": [],
-          "size": 682
+          "size": 707
         },
         {
           "name": "isObjectVisible",
           "type": "function",
-          "line": 113,
+          "line": 116,
           "isUsed": false,
           "usedIn": [],
-          "size": 682
+          "size": 707
         },
         {
           "name": "resolveNoteName",
           "type": "function",
-          "line": 144,
+          "line": 147,
           "isUsed": false,
           "usedIn": [],
-          "size": 682
+          "size": 707
         },
         {
           "name": "getNoteColorTyped",
           "type": "function",
-          "line": 172,
+          "line": 176,
           "isUsed": false,
           "usedIn": [],
-          "size": 682
+          "size": 707
         },
         {
           "name": "calculateSplitIndex",
           "type": "function",
-          "line": 217,
+          "line": 223,
           "isUsed": false,
           "usedIn": [],
-          "size": 682
+          "size": 707
         },
         {
           "name": "shouldCheckTimeBudget",
           "type": "function",
-          "line": 225,
+          "line": 231,
           "isUsed": false,
           "usedIn": [],
-          "size": 682
+          "size": 707
         },
         {
           "name": "calculateNextStartIndex",
           "type": "function",
-          "line": 236,
+          "line": 242,
           "isUsed": false,
           "usedIn": [],
-          "size": 682
+          "size": 707
         }
       ],
       "imports": [
@@ -7555,7 +7433,7 @@
           "line": 10,
           "isUsed": false,
           "usedIn": [],
-          "size": 682
+          "size": 707
         },
         {
           "name": "LightLevelCheck",
@@ -7563,7 +7441,7 @@
           "line": 17,
           "isUsed": false,
           "usedIn": [],
-          "size": 682
+          "size": 707
         },
         {
           "name": "ChannelMapping",
@@ -7571,277 +7449,1222 @@
           "line": 22,
           "isUsed": false,
           "usedIn": [],
-          "size": 682
+          "size": 707
         },
         {
           "name": "calculateLightFactor",
           "type": "function",
-          "line": 42,
+          "line": 45,
           "isUsed": false,
           "usedIn": [],
-          "size": 682
+          "size": 707
         },
         {
           "name": "calculateChannelIndex",
           "type": "function",
-          "line": 72,
+          "line": 75,
           "isUsed": false,
           "usedIn": [],
-          "size": 682
+          "size": 707
         },
         {
           "name": "isObjectVisible",
           "type": "function",
-          "line": 113,
+          "line": 116,
           "isUsed": false,
           "usedIn": [],
-          "size": 682
+          "size": 707
         },
         {
           "name": "resolveNoteName",
           "type": "function",
-          "line": 144,
+          "line": 147,
           "isUsed": false,
           "usedIn": [],
-          "size": 682
+          "size": 707
         },
         {
           "name": "getNoteColorTyped",
           "type": "function",
-          "line": 172,
+          "line": 176,
           "isUsed": false,
           "usedIn": [],
-          "size": 682
+          "size": 707
         },
         {
           "name": "calculateSplitIndex",
           "type": "function",
-          "line": 217,
+          "line": 223,
           "isUsed": false,
           "usedIn": [],
-          "size": 682
+          "size": 707
         },
         {
           "name": "shouldCheckTimeBudget",
           "type": "function",
-          "line": 225,
+          "line": 231,
           "isUsed": false,
           "usedIn": [],
-          "size": 682
+          "size": 707
         },
         {
           "name": "calculateNextStartIndex",
           "type": "function",
-          "line": 236,
+          "line": 242,
           "isUsed": false,
           "usedIn": [],
-          "size": 682
+          "size": 707
         }
       ],
       "treeShakingScore": 0
     },
     {
-      "path": "systems/performance-budget.ts",
+      "path": "rendering/material_types.ts",
       "exports": [
         {
-          "name": "BudgetMode",
-          "type": "enum",
-          "line": 42,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 3137
+          "name": "MaterialType",
+          "type": "const",
+          "line": 12,
+          "isUsed": true,
+          "usedIn": [
+            "rendering/materials.ts"
+          ],
+          "size": 0
         },
         {
-          "name": "BudgetType",
+          "name": "MaterialTypeValue",
           "type": "type",
-          "line": 54,
+          "line": 24,
           "isUsed": false,
           "usedIn": [],
-          "size": 3137
+          "size": 329
         },
         {
-          "name": "BudgetConfig",
+          "name": "CandyMaterialConfig",
           "type": "interface",
-          "line": 62,
+          "line": 29,
           "isUsed": false,
           "usedIn": [],
-          "size": 3137
+          "size": 329
         },
         {
-          "name": "InstanceBudget",
+          "name": "GlowingMaterialConfig",
           "type": "interface",
-          "line": 74,
+          "line": 47,
           "isUsed": false,
           "usedIn": [],
-          "size": 3137
+          "size": 329
         },
         {
-          "name": "PerformanceBudgetConfig",
+          "name": "PetalMaterialConfig",
+          "type": "interface",
+          "line": 59,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 329
+        },
+        {
+          "name": "AudioReactiveMaterialConfig",
+          "type": "interface",
+          "line": 69,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 329
+        },
+        {
+          "name": "GroundMaterialConfig",
           "type": "interface",
           "line": 81,
           "isUsed": false,
           "usedIn": [],
-          "size": 3137
+          "size": 329
         },
         {
-          "name": "PerformanceMetrics",
+          "name": "AudioState",
           "type": "interface",
-          "line": 99,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 3137
-        },
-        {
-          "name": "BudgetViolation",
-          "type": "interface",
-          "line": 109,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 3137
-        },
-        {
-          "name": "AdaptiveSettings",
-          "type": "interface",
-          "line": 120,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 3137
-        },
-        {
-          "name": "DebugOverlayOptions",
-          "type": "interface",
-          "line": 136,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 3137
-        },
-        {
-          "name": "PERFORMANCE_BUDGETS",
-          "type": "const",
-          "line": 149,
+          "line": 89,
           "isUsed": true,
           "usedIn": [
-            "systems/performance-budget.ts"
+            "systems/physics/physics-abilities.ts",
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-states.ts",
+            "systems/physics/physics-updates.ts"
           ],
           "size": 0
         },
         {
-          "name": "PerformanceBudget",
-          "type": "class",
+          "name": "IAudioReactiveMaterial",
+          "type": "interface",
+          "line": 103,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 329
+        },
+        {
+          "name": "CandyMaterial",
+          "type": "interface",
+          "line": 111,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 329
+        },
+        {
+          "name": "AudioUniforms",
+          "type": "interface",
+          "line": 131,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 329
+        },
+        {
+          "name": "MaterialCreateResult",
+          "type": "type",
+          "line": 141,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 329
+        }
+      ],
+      "imports": [
+        "THREE"
+      ],
+      "unusedExports": [
+        {
+          "name": "MaterialTypeValue",
+          "type": "type",
+          "line": 24,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 329
+        },
+        {
+          "name": "CandyMaterialConfig",
+          "type": "interface",
+          "line": 29,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 329
+        },
+        {
+          "name": "GlowingMaterialConfig",
+          "type": "interface",
+          "line": 47,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 329
+        },
+        {
+          "name": "PetalMaterialConfig",
+          "type": "interface",
+          "line": 59,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 329
+        },
+        {
+          "name": "AudioReactiveMaterialConfig",
+          "type": "interface",
+          "line": 69,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 329
+        },
+        {
+          "name": "GroundMaterialConfig",
+          "type": "interface",
+          "line": 81,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 329
+        },
+        {
+          "name": "IAudioReactiveMaterial",
+          "type": "interface",
+          "line": 103,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 329
+        },
+        {
+          "name": "CandyMaterial",
+          "type": "interface",
+          "line": 111,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 329
+        },
+        {
+          "name": "AudioUniforms",
+          "type": "interface",
+          "line": 131,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 329
+        },
+        {
+          "name": "MaterialCreateResult",
+          "type": "type",
+          "line": 141,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 329
+        }
+      ],
+      "treeShakingScore": 17
+    },
+    {
+      "path": "utils/bootstrap-loader.ts",
+      "exports": [
+        {
+          "name": "startBootstrap",
+          "type": "function",
+          "line": 52,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 893
+        },
+        {
+          "name": "getBootstrapProgress",
+          "type": "function",
+          "line": 81,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 893
+        },
+        {
+          "name": "isBootstrapComplete",
+          "type": "function",
+          "line": 104,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 893
+        },
+        {
+          "name": "ProgressCallback",
+          "type": "type",
+          "line": 132,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 893
+        },
+        {
+          "name": "CompletionCallback",
+          "type": "type",
+          "line": 137,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 893
+        },
+        {
+          "name": "CleanupFunction",
+          "type": "type",
+          "line": 142,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 893
+        },
+        {
+          "name": "pollBootstrapProgress",
+          "type": "function",
+          "line": 152,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 893
+        },
+        {
+          "name": "resetBootstrap",
+          "type": "function",
+          "line": 211,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 893
+        },
+        {
+          "name": "getBootstrapHeight",
+          "type": "function",
+          "line": 237,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 893
+        },
+        {
+          "name": "integrateWithLoadingUI",
+          "type": "function",
+          "line": 270,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 893
+        }
+      ],
+      "imports": [],
+      "unusedExports": [
+        {
+          "name": "startBootstrap",
+          "type": "function",
+          "line": 52,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 893
+        },
+        {
+          "name": "getBootstrapProgress",
+          "type": "function",
+          "line": 81,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 893
+        },
+        {
+          "name": "isBootstrapComplete",
+          "type": "function",
+          "line": 104,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 893
+        },
+        {
+          "name": "ProgressCallback",
+          "type": "type",
+          "line": 132,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 893
+        },
+        {
+          "name": "CompletionCallback",
+          "type": "type",
+          "line": 137,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 893
+        },
+        {
+          "name": "CleanupFunction",
+          "type": "type",
+          "line": 142,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 893
+        },
+        {
+          "name": "pollBootstrapProgress",
+          "type": "function",
+          "line": 152,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 893
+        },
+        {
+          "name": "resetBootstrap",
+          "type": "function",
+          "line": 211,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 893
+        },
+        {
+          "name": "getBootstrapHeight",
+          "type": "function",
+          "line": 237,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 893
+        },
+        {
+          "name": "integrateWithLoadingUI",
+          "type": "function",
+          "line": 270,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 893
+        }
+      ],
+      "treeShakingScore": 0
+    },
+    {
+      "path": "foliage/material-core.ts",
+      "exports": [
+        {
+          "name": "sharedGeometries",
+          "type": "const",
+          "line": 22,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/arpeggio-batcher.ts",
+            "foliage/fireflies.ts",
+            "foliage/flower-batcher.ts",
+            "foliage/flowers.ts",
+            "foliage/glowing-flower-batcher.ts",
+            "foliage/instrument.ts",
+            "foliage/lantern-batcher.ts",
+            "foliage/lotus.ts",
+            "foliage/mushroom-batcher.ts",
+            "foliage/mushrooms.ts",
+            "foliage/panning-pads.ts",
+            "foliage/silence-spirits.ts",
+            "foliage/simple-flower-batcher.ts",
+            "foliage/tree-batcher.ts",
+            "foliage/trees.ts",
+            "foliage/waterfall-batcher.ts",
+            "systems/glitch-grenade.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "eyeGeo",
+          "type": "const",
+          "line": 44,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 753
+        },
+        {
+          "name": "pupilGeo",
+          "type": "const",
+          "line": 45,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 753
+        },
+        {
+          "name": "_scratchVec1",
+          "type": "const",
+          "line": 48,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/foliage-reactivity.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "_scratchVec2",
+          "type": "const",
+          "line": 49,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 753
+        },
+        {
+          "name": "_scratchVec3",
+          "type": "const",
+          "line": 50,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 753
+        },
+        {
+          "name": "uWindSpeed",
+          "type": "const",
+          "line": 53,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts",
+            "foliage/cloud-batcher.ts",
+            "foliage/dandelion-seeds.ts",
+            "foliage/foliage-materials.ts",
+            "foliage/glowing-flower-batcher.ts",
+            "foliage/grass.ts",
+            "foliage/lod.ts",
+            "foliage/pollen.ts",
+            "foliage/tree-batcher.ts",
+            "foliage/trees.ts",
+            "particles/compute-particles.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "uWindDirection",
+          "type": "const",
+          "line": 54,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts",
+            "foliage/cloud-batcher.ts",
+            "foliage/dandelion-seeds.ts",
+            "foliage/foliage-materials.ts",
+            "foliage/glowing-flower-batcher.ts",
+            "foliage/grass.ts",
+            "foliage/pollen.ts",
+            "particles/compute-particles.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "uTime",
+          "type": "const",
+          "line": 55,
+          "isUsed": true,
+          "usedIn": [
+            "core/deferred-init.ts",
+            "core/game-loop.ts",
+            "foliage/arpeggio-batcher.ts",
+            "foliage/aurora.ts",
+            "foliage/berries.ts",
+            "foliage/celestial-bodies.ts",
+            "foliage/cloud-batcher.ts",
+            "foliage/dandelion-batcher.ts",
+            "foliage/dandelion-seeds.ts",
+            "foliage/environment.ts",
+            "foliage/fireflies.ts",
+            "foliage/flower-batcher.ts",
+            "foliage/flowers.ts",
+            "foliage/fluid_fog.ts",
+            "foliage/foliage-materials.ts",
+            "foliage/glowing-flower-batcher.ts",
+            "foliage/impacts.ts",
+            "foliage/lantern-batcher.ts",
+            "foliage/lod.ts",
+            "foliage/lotus.ts",
+            "foliage/luminous-plant-batcher.ts",
+            "foliage/mirrors.ts",
+            "foliage/moon.ts",
+            "foliage/mushroom-batcher.ts",
+            "foliage/musical_flora.ts",
+            "foliage/panning-pads.ts",
+            "foliage/pollen.ts",
+            "foliage/portamento-batcher.ts",
+            "foliage/shield.ts",
+            "foliage/silence-spirits.ts",
+            "foliage/simple-flower-batcher.ts",
+            "foliage/sky.ts",
+            "foliage/sparkle-trail.ts",
+            "foliage/tree-batcher.ts",
+            "foliage/waterfall-batcher.ts",
+            "foliage/waterfalls.ts",
+            "foliage/wisteria-cluster.ts",
+            "gameplay/chord-strike.ts",
+            "gameplay/harpoon-line.ts",
+            "gameplay/jitter-mines.ts",
+            "gameplay/rainbow-blaster.ts",
+            "particles/compute-particles.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "uGlitchIntensity",
+          "type": "const",
+          "line": 56,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts",
+            "foliage/arpeggio-batcher.ts",
+            "foliage/lotus.ts",
+            "foliage/musical_flora.ts",
+            "foliage/tree-batcher.ts",
+            "gameplay/jitter-mines.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "uGlitchExplosionCenter",
+          "type": "const",
+          "line": 57,
+          "isUsed": true,
+          "usedIn": [
+            "systems/glitch-grenade.ts",
+            "systems/physics/physics-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "uGlitchExplosionRadius",
+          "type": "const",
+          "line": 58,
+          "isUsed": true,
+          "usedIn": [
+            "systems/glitch-grenade.ts",
+            "systems/physics/physics-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "uAudioLow",
+          "type": "const",
+          "line": 59,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts",
+            "foliage/animation-nodes.ts",
+            "foliage/aurora.ts",
+            "foliage/berries.ts",
+            "foliage/cave.ts",
+            "foliage/celestial-bodies.ts",
+            "foliage/cloud-batcher.ts",
+            "foliage/dandelion-batcher.ts",
+            "foliage/environment.ts",
+            "foliage/fireflies.ts",
+            "foliage/flower-batcher.ts",
+            "foliage/flowers.ts",
+            "foliage/foliage-materials.ts",
+            "foliage/glowing-flower-batcher.ts",
+            "foliage/grass.ts",
+            "foliage/impacts.ts",
+            "foliage/lantern-batcher.ts",
+            "foliage/lod.ts",
+            "foliage/lotus.ts",
+            "foliage/moon.ts",
+            "foliage/mushroom-batcher.ts",
+            "foliage/musical_flora.ts",
+            "foliage/pollen.ts",
+            "foliage/portamento-batcher.ts",
+            "foliage/shield.ts",
+            "foliage/simple-flower-batcher.ts",
+            "foliage/sky.ts",
+            "foliage/sparkle-trail.ts",
+            "foliage/stars.ts",
+            "foliage/terrain.ts",
+            "foliage/tree-batcher.ts",
+            "foliage/trees.ts",
+            "foliage/water.ts",
+            "foliage/waterfall-batcher.ts",
+            "foliage/wisteria-cluster.ts",
+            "gameplay/chord-strike.ts",
+            "gameplay/jitter-mines.ts",
+            "particles/compute-particles.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "uAudioHigh",
+          "type": "const",
+          "line": 60,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts",
+            "foliage/animation-nodes.ts",
+            "foliage/arpeggio-batcher.ts",
+            "foliage/aurora.ts",
+            "foliage/celestial-bodies.ts",
+            "foliage/cloud-batcher.ts",
+            "foliage/dandelion-batcher.ts",
+            "foliage/dandelion-seeds.ts",
+            "foliage/environment.ts",
+            "foliage/fireflies.ts",
+            "foliage/flower-batcher.ts",
+            "foliage/flowers.ts",
+            "foliage/glowing-flower-batcher.ts",
+            "foliage/grass.ts",
+            "foliage/impacts.ts",
+            "foliage/lantern-batcher.ts",
+            "foliage/lod.ts",
+            "foliage/mirrors.ts",
+            "foliage/moon.ts",
+            "foliage/mushroom-batcher.ts",
+            "foliage/pollen.ts",
+            "foliage/portamento-batcher.ts",
+            "foliage/simple-flower-batcher.ts",
+            "foliage/sky.ts",
+            "foliage/sparkle-trail.ts",
+            "foliage/stars.ts",
+            "foliage/terrain.ts",
+            "foliage/tree-batcher.ts",
+            "foliage/water.ts",
+            "foliage/waterfall-batcher.ts",
+            "foliage/waterfalls.ts",
+            "foliage/wisteria-cluster.ts",
+            "gameplay/chord-strike.ts",
+            "gameplay/harpoon-line.ts",
+            "gameplay/rainbow-blaster.ts",
+            "particles/compute-particles.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "uPlayerPosition",
+          "type": "const",
+          "line": 63,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts",
+            "foliage/arpeggio-batcher.ts",
+            "foliage/cloud-batcher.ts",
+            "foliage/fireflies.ts",
+            "foliage/grass.ts",
+            "foliage/mushroom-batcher.ts",
+            "foliage/panning-pads.ts",
+            "foliage/pollen.ts",
+            "foliage/silence-spirits.ts",
+            "foliage/simple-flower-batcher.ts",
+            "foliage/terrain.ts",
+            "particles/compute-particles.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getCachedProceduralMaterial",
+          "type": "function",
+          "line": 73,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/dandelion-batcher.ts",
+            "foliage/flower-batcher.ts",
+            "foliage/flowers.ts",
+            "foliage/trees.ts",
+            "foliage/wisteria-cluster.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "median",
+          "type": "function",
+          "line": 88,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/animation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "generateNoiseTexture",
+          "type": "function",
+          "line": 95,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 753
+        },
+        {
+          "name": "triplanarNoise",
+          "type": "const",
+          "line": 112,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/cave.ts",
+            "foliage/cloud-batcher.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "perturbNormal",
+          "type": "const",
+          "line": 130,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/cave.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createRimLight",
+          "type": "const",
+          "line": 155,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/cave.ts",
+            "foliage/lantern-batcher.ts",
+            "foliage/mirrors.ts",
+            "foliage/mushroom-batcher.ts",
+            "foliage/terrain.ts",
+            "foliage/water.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createJuicyRimLight",
+          "type": "const",
+          "line": 170,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/arpeggio-batcher.ts",
+            "foliage/aurora.ts",
+            "foliage/cloud-batcher.ts",
+            "foliage/dandelion-batcher.ts",
+            "foliage/environment.ts",
+            "foliage/fireflies.ts",
+            "foliage/flower-batcher.ts",
+            "foliage/flowers.ts",
+            "foliage/foliage-materials.ts",
+            "foliage/glowing-flower-batcher.ts",
+            "foliage/lantern-batcher.ts",
+            "foliage/luminous-plant-batcher.ts",
+            "foliage/moon.ts",
+            "foliage/mushroom-batcher.ts",
+            "foliage/portamento-batcher.ts",
+            "foliage/simple-flower-batcher.ts",
+            "foliage/tree-batcher.ts",
+            "foliage/trees.ts",
+            "foliage/water.ts",
+            "foliage/waterfall-batcher.ts",
+            "foliage/waterfalls.ts",
+            "foliage/wisteria-cluster.ts",
+            "gameplay/chord-strike.ts",
+            "gameplay/harpoon-line.ts",
+            "gameplay/rainbow-blaster.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createSugarSparkle",
+          "type": "const",
           "line": 195,
           "isUsed": true,
           "usedIn": [
-            "systems/performance-budget.ts"
+            "foliage/dandelion-batcher.ts",
+            "foliage/dandelion-seeds.ts",
+            "foliage/environment.ts",
+            "foliage/mushroom-batcher.ts",
+            "foliage/tree-batcher.ts"
           ],
           "size": 0
         },
         {
-          "name": "performanceBudget",
+          "name": "addRimLight",
           "type": "const",
-          "line": 1356,
+          "line": 228,
           "isUsed": false,
           "usedIn": [],
-          "size": 3137
+          "size": 753
         },
         {
-          "name": "default",
-          "type": "function",
-          "line": 1359,
+          "name": "colorFromNote",
+          "type": "const",
+          "line": 237,
           "isUsed": true,
           "usedIn": [
-            "world/generation.ts"
+            "foliage/mushroom-batcher.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "calculatePlayerPush",
+          "type": "const",
+          "line": 250,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/portamento-batcher.ts",
+            "foliage/trees.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "applyPlayerInteraction",
+          "type": "const",
+          "line": 274,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/arpeggio-batcher.ts",
+            "foliage/dandelion-batcher.ts",
+            "foliage/flower-batcher.ts",
+            "foliage/flowers.ts",
+            "foliage/foliage-materials.ts",
+            "foliage/glowing-flower-batcher.ts",
+            "foliage/lantern-batcher.ts",
+            "foliage/lod.ts",
+            "foliage/mushroom-batcher.ts",
+            "foliage/simple-flower-batcher.ts",
+            "foliage/tree-batcher.ts",
+            "foliage/trees.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "calculateWindSway",
+          "type": "const",
+          "line": 286,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/arpeggio-batcher.ts",
+            "foliage/dandelion-batcher.ts",
+            "foliage/flower-batcher.ts",
+            "foliage/flowers.ts",
+            "foliage/foliage-materials.ts",
+            "foliage/glowing-flower-batcher.ts",
+            "foliage/lantern-batcher.ts",
+            "foliage/lod.ts",
+            "foliage/luminous-plant-batcher.ts",
+            "foliage/portamento-batcher.ts",
+            "foliage/simple-flower-batcher.ts",
+            "foliage/tree-batcher.ts",
+            "foliage/trees.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "calculateWindSwayLegacy",
+          "type": "const",
+          "line": 332,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 753
+        },
+        {
+          "name": "getWindTextureData",
+          "type": "const",
+          "line": 352,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/material-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "windComputeSystem",
+          "type": "const",
+          "line": 352,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "calculateFlowerBloom",
+          "type": "const",
+          "line": 354,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/flower-batcher.ts",
+            "foliage/flowers.ts",
+            "foliage/foliage-materials.ts",
+            "foliage/simple-flower-batcher.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "UnifiedMaterialOptions",
+          "type": "interface",
+          "line": 376,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/panning-pads.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createUnifiedMaterial",
+          "type": "function",
+          "line": 412,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/foliage-materials.ts",
+            "foliage/instrument.ts",
+            "foliage/lantern-batcher.ts",
+            "foliage/panning-pads.ts",
+            "foliage/portamento-batcher.ts",
+            "foliage/ribbons.ts",
+            "foliage/shield.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "CandyPresets",
+          "type": "const",
+          "line": 651,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/aurora.ts",
+            "foliage/berries.ts",
+            "foliage/celestial-bodies.ts",
+            "foliage/environment.ts",
+            "foliage/flower-batcher.ts",
+            "foliage/foliage-materials.ts",
+            "foliage/lake_features.ts",
+            "foliage/lod.ts",
+            "foliage/moon.ts",
+            "foliage/musical_flora.ts",
+            "foliage/panning-pads.ts",
+            "foliage/simple-flower-batcher.ts",
+            "foliage/terrain.ts",
+            "foliage/tree-batcher.ts",
+            "foliage/water.ts",
+            "foliage/waterfall-batcher.ts",
+            "foliage/waterfalls.ts",
+            "foliage/wisteria-cluster.ts",
+            "rendering/shader-warmup.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createClayMaterial",
+          "type": "function",
+          "line": 733,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/flowers.ts",
+            "foliage/grass.ts",
+            "foliage/lotus.ts",
+            "foliage/musical_flora.ts",
+            "foliage/simple-flower-batcher.ts",
+            "foliage/trees.ts",
+            "gameplay/jitter-mines.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createCandyMaterial",
+          "type": "function",
+          "line": 737,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/arpeggio-batcher.ts",
+            "foliage/musical_flora.ts",
+            "gameplay/rainbow-blaster.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createTexturedClay",
+          "type": "function",
+          "line": 741,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 753
+        },
+        {
+          "name": "createSugaredMaterial",
+          "type": "function",
+          "line": 750,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 753
+        },
+        {
+          "name": "createGradientMaterial",
+          "type": "function",
+          "line": 763,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/trees.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createStandardNodeMaterial",
+          "type": "function",
+          "line": 805,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/arpeggio-batcher.ts",
+            "foliage/dandelion-batcher.ts",
+            "foliage/flower-batcher.ts",
+            "foliage/flowers.ts",
+            "foliage/foliage-materials.ts",
+            "foliage/glowing-flower-batcher.ts",
+            "foliage/lantern-batcher.ts",
+            "foliage/luminous-plant-batcher.ts",
+            "foliage/panning-pads.ts",
+            "foliage/tree-batcher.ts",
+            "foliage/trees.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createTransparentNodeMaterial",
+          "type": "function",
+          "line": 825,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/flowers.ts"
           ],
           "size": 0
         }
       ],
       "imports": [
-        "PerformanceBudget",
-        "PERFORMANCE_BUDGETS",
+        "MeshStandardNodeMaterial",
+        "color",
+        "float",
+        "uv",
+        "mix",
+        "vec3",
+        "vec2",
+        "Fn",
+        "uniform",
+        "dot",
+        "max",
+        "min",
+        "mx_noise_float",
+        "positionLocal",
+        "positionWorld",
+        "normalWorld",
+        "normalLocal",
+        "cameraPosition",
+        "sin",
+        "pow",
+        "abs",
+        "normalize",
+        "smoothstep",
+        "exp",
+        "texture",
+        "attribute",
+        "applyGlitch",
+        "CommonGeometries",
+        "getWindTextureData",
         "THREE"
       ],
       "unusedExports": [
         {
-          "name": "BudgetMode",
-          "type": "enum",
-          "line": 42,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 3137
-        },
-        {
-          "name": "BudgetType",
-          "type": "type",
-          "line": 54,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 3137
-        },
-        {
-          "name": "BudgetConfig",
-          "type": "interface",
-          "line": 62,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 3137
-        },
-        {
-          "name": "InstanceBudget",
-          "type": "interface",
-          "line": 74,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 3137
-        },
-        {
-          "name": "PerformanceBudgetConfig",
-          "type": "interface",
-          "line": 81,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 3137
-        },
-        {
-          "name": "PerformanceMetrics",
-          "type": "interface",
-          "line": 99,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 3137
-        },
-        {
-          "name": "BudgetViolation",
-          "type": "interface",
-          "line": 109,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 3137
-        },
-        {
-          "name": "AdaptiveSettings",
-          "type": "interface",
-          "line": 120,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 3137
-        },
-        {
-          "name": "DebugOverlayOptions",
-          "type": "interface",
-          "line": 136,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 3137
-        },
-        {
-          "name": "performanceBudget",
+          "name": "eyeGeo",
           "type": "const",
-          "line": 1356,
+          "line": 44,
           "isUsed": false,
           "usedIn": [],
-          "size": 3137
+          "size": 753
+        },
+        {
+          "name": "pupilGeo",
+          "type": "const",
+          "line": 45,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 753
+        },
+        {
+          "name": "_scratchVec2",
+          "type": "const",
+          "line": 49,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 753
+        },
+        {
+          "name": "_scratchVec3",
+          "type": "const",
+          "line": 50,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 753
+        },
+        {
+          "name": "generateNoiseTexture",
+          "type": "function",
+          "line": 95,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 753
+        },
+        {
+          "name": "addRimLight",
+          "type": "const",
+          "line": 228,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 753
+        },
+        {
+          "name": "calculateWindSwayLegacy",
+          "type": "const",
+          "line": 332,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 753
+        },
+        {
+          "name": "createTexturedClay",
+          "type": "function",
+          "line": 741,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 753
+        },
+        {
+          "name": "createSugaredMaterial",
+          "type": "function",
+          "line": 750,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 753
         }
       ],
-      "treeShakingScore": 23
+      "treeShakingScore": 79
     },
     {
       "path": "rendering/shader-warmup.ts",
@@ -7849,81 +8672,84 @@
         {
           "name": "WarmupTarget",
           "type": "type",
-          "line": 27,
+          "line": 28,
           "isUsed": false,
           "usedIn": [],
-          "size": 1651
+          "size": 1874
         },
         {
           "name": "WarmupStats",
           "type": "interface",
-          "line": 36,
+          "line": 37,
           "isUsed": false,
           "usedIn": [],
-          "size": 1651
+          "size": 1874
         },
         {
           "name": "WarmupProgressCallback",
           "type": "type",
-          "line": 47,
+          "line": 48,
           "isUsed": false,
           "usedIn": [],
-          "size": 1651
+          "size": 1874
         },
         {
           "name": "ShaderWarmupOptions",
           "type": "interface",
-          "line": 57,
+          "line": 58,
           "isUsed": false,
           "usedIn": [],
-          "size": 1651
+          "size": 1874
         },
         {
           "name": "ShaderWarmup",
           "type": "class",
-          "line": 191,
+          "line": 197,
           "isUsed": false,
           "usedIn": [],
-          "size": 1651
+          "size": 1874
         },
         {
           "name": "warmupShader",
           "type": "function",
-          "line": 450,
+          "line": 491,
           "isUsed": false,
           "usedIn": [],
-          "size": 1651
+          "size": 1874
         },
         {
           "name": "warmupAllShaders",
           "type": "function",
-          "line": 505,
+          "line": 546,
           "isUsed": false,
           "usedIn": [],
-          "size": 1651
+          "size": 1874
         },
         {
           "name": "getWarmupShaderList",
           "type": "function",
-          "line": 522,
+          "line": 567,
           "isUsed": false,
           "usedIn": [],
-          "size": 1651
+          "size": 1874
         },
         {
           "name": "getWarmupPriorityOrder",
           "type": "function",
-          "line": 533,
+          "line": 578,
           "isUsed": false,
           "usedIn": [],
-          "size": 1651
+          "size": 1874
         },
         {
           "name": "default",
           "type": "function",
-          "line": 552,
+          "line": 597,
           "isUsed": true,
           "usedIn": [
+            "core/init.ts",
+            "systems/music-reactivity.ts",
+            "utils/wasm-loader-core.ts",
             "world/generation.ts"
           ],
           "size": 0
@@ -7937,83 +8763,1523 @@
         "CandyPresets",
         "foliageMaterials",
         "createTerrainMaterial",
+        "CONFIG",
         "THREE"
       ],
       "unusedExports": [
         {
           "name": "WarmupTarget",
           "type": "type",
-          "line": 27,
+          "line": 28,
           "isUsed": false,
           "usedIn": [],
-          "size": 1651
+          "size": 1874
         },
         {
           "name": "WarmupStats",
           "type": "interface",
-          "line": 36,
+          "line": 37,
           "isUsed": false,
           "usedIn": [],
-          "size": 1651
+          "size": 1874
         },
         {
           "name": "WarmupProgressCallback",
           "type": "type",
-          "line": 47,
+          "line": 48,
           "isUsed": false,
           "usedIn": [],
-          "size": 1651
+          "size": 1874
         },
         {
           "name": "ShaderWarmupOptions",
           "type": "interface",
-          "line": 57,
+          "line": 58,
           "isUsed": false,
           "usedIn": [],
-          "size": 1651
+          "size": 1874
         },
         {
           "name": "ShaderWarmup",
           "type": "class",
-          "line": 191,
+          "line": 197,
           "isUsed": false,
           "usedIn": [],
-          "size": 1651
+          "size": 1874
         },
         {
           "name": "warmupShader",
           "type": "function",
-          "line": 450,
+          "line": 491,
           "isUsed": false,
           "usedIn": [],
-          "size": 1651
+          "size": 1874
         },
         {
           "name": "warmupAllShaders",
           "type": "function",
-          "line": 505,
+          "line": 546,
           "isUsed": false,
           "usedIn": [],
-          "size": 1651
+          "size": 1874
         },
         {
           "name": "getWarmupShaderList",
           "type": "function",
-          "line": 522,
+          "line": 567,
           "isUsed": false,
           "usedIn": [],
-          "size": 1651
+          "size": 1874
         },
         {
           "name": "getWarmupPriorityOrder",
           "type": "function",
-          "line": 533,
+          "line": 578,
           "isUsed": false,
           "usedIn": [],
-          "size": 1651
+          "size": 1874
         }
       ],
       "treeShakingScore": 10
+    },
+    {
+      "path": "systems/analytics/index.ts",
+      "exports": [
+        {
+          "name": "./types.ts",
+          "type": "const",
+          "line": 39,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 367
+        },
+        {
+          "name": "AnalyticsSystem",
+          "type": "const",
+          "line": 45,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 367
+        },
+        {
+          "name": "analytics",
+          "type": "const",
+          "line": 45,
+          "isUsed": true,
+          "usedIn": [
+            "systems/analytics/index.ts",
+            "systems/analytics.ts",
+            "ui/analytics-debug.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "PerformanceTracker",
+          "type": "const",
+          "line": 51,
+          "isUsed": true,
+          "usedIn": [
+            "systems/analytics/core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "trackEvent",
+          "type": "function",
+          "line": 65,
+          "isUsed": true,
+          "usedIn": [
+            "systems/analytics/index.ts",
+            "systems/analytics.ts",
+            "ui/analytics-debug.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "trackPerformance",
+          "type": "function",
+          "line": 75,
+          "isUsed": true,
+          "usedIn": [
+            "systems/analytics/index.ts",
+            "systems/analytics.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "trackExploration",
+          "type": "function",
+          "line": 84,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 367
+        },
+        {
+          "name": "trackEntityDiscovered",
+          "type": "function",
+          "line": 97,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 367
+        },
+        {
+          "name": "trackAbilityUsed",
+          "type": "function",
+          "line": 110,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 367
+        },
+        {
+          "name": "trackItemCollected",
+          "type": "function",
+          "line": 119,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 367
+        },
+        {
+          "name": "trackUnlockAchieved",
+          "type": "function",
+          "line": 128,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 367
+        },
+        {
+          "name": "trackMilestoneReached",
+          "type": "function",
+          "line": 137,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 367
+        },
+        {
+          "name": "analytics as default",
+          "type": "const",
+          "line": 145,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 367
+        }
+      ],
+      "imports": [
+        "analytics",
+        "trackEvent",
+        "trackPerformance"
+      ],
+      "unusedExports": [
+        {
+          "name": "./types.ts",
+          "type": "const",
+          "line": 39,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 367
+        },
+        {
+          "name": "AnalyticsSystem",
+          "type": "const",
+          "line": 45,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 367
+        },
+        {
+          "name": "trackExploration",
+          "type": "function",
+          "line": 84,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 367
+        },
+        {
+          "name": "trackEntityDiscovered",
+          "type": "function",
+          "line": 97,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 367
+        },
+        {
+          "name": "trackAbilityUsed",
+          "type": "function",
+          "line": 110,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 367
+        },
+        {
+          "name": "trackItemCollected",
+          "type": "function",
+          "line": 119,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 367
+        },
+        {
+          "name": "trackUnlockAchieved",
+          "type": "function",
+          "line": 128,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 367
+        },
+        {
+          "name": "trackMilestoneReached",
+          "type": "function",
+          "line": 137,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 367
+        },
+        {
+          "name": "analytics as default",
+          "type": "const",
+          "line": 145,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 367
+        }
+      ],
+      "treeShakingScore": 31
+    },
+    {
+      "path": "ui/loading-screen.ts",
+      "exports": [
+        {
+          "name": "LoadingPhase",
+          "type": "interface",
+          "line": 22,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2280
+        },
+        {
+          "name": "LoadingProgress",
+          "type": "interface",
+          "line": 32,
+          "isUsed": true,
+          "usedIn": [
+            "systems/asset-streaming/asset-streaming-core.ts",
+            "systems/asset-streaming/asset-streaming-scheduler.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "LoadingScreenOptions",
+          "type": "interface",
+          "line": 42,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2280
+        },
+        {
+          "name": "DEFAULT_LOADING_PHASES",
+          "type": "const",
+          "line": 59,
+          "isUsed": true,
+          "usedIn": [
+            "systems/loading-manager.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "LoadingScreen",
+          "type": "class",
+          "line": 114,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2280
+        },
+        {
+          "name": "initLoadingScreen",
+          "type": "function",
+          "line": 989,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getLoadingScreen",
+          "type": "function",
+          "line": 1003,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2280
+        },
+        {
+          "name": "showLoadingScreen",
+          "type": "function",
+          "line": 1010,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2280
+        },
+        {
+          "name": "showDeferredIndicator",
+          "type": "function",
+          "line": 1020,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts",
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "hideDeferredIndicator",
+          "type": "function",
+          "line": 1024,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts",
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "hideLoadingScreen",
+          "type": "function",
+          "line": 1028,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2280
+        },
+        {
+          "name": "updateProgress",
+          "type": "function",
+          "line": 1035,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-loader-core.ts",
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "setLoadingStatus",
+          "type": "function",
+          "line": 1052,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2280
+        },
+        {
+          "name": "completePhase",
+          "type": "function",
+          "line": 1063,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2280
+        },
+        {
+          "name": "setLoadingDebug",
+          "type": "function",
+          "line": 1070,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2280
+        },
+        {
+          "name": "installLegacyAPI",
+          "type": "function",
+          "line": 1085,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "default",
+          "type": "function",
+          "line": 1115,
+          "isUsed": true,
+          "usedIn": [
+            "core/init.ts",
+            "systems/music-reactivity.ts",
+            "utils/wasm-loader-core.ts",
+            "world/generation.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "trapFocusInside",
+        "globalLoadingManager",
+        "GlobalProgressState",
+        "TaskState"
+      ],
+      "unusedExports": [
+        {
+          "name": "LoadingPhase",
+          "type": "interface",
+          "line": 22,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2280
+        },
+        {
+          "name": "LoadingScreenOptions",
+          "type": "interface",
+          "line": 42,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2280
+        },
+        {
+          "name": "LoadingScreen",
+          "type": "class",
+          "line": 114,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2280
+        },
+        {
+          "name": "getLoadingScreen",
+          "type": "function",
+          "line": 1003,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2280
+        },
+        {
+          "name": "showLoadingScreen",
+          "type": "function",
+          "line": 1010,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2280
+        },
+        {
+          "name": "hideLoadingScreen",
+          "type": "function",
+          "line": 1028,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2280
+        },
+        {
+          "name": "setLoadingStatus",
+          "type": "function",
+          "line": 1052,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2280
+        },
+        {
+          "name": "completePhase",
+          "type": "function",
+          "line": 1063,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2280
+        },
+        {
+          "name": "setLoadingDebug",
+          "type": "function",
+          "line": 1070,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2280
+        }
+      ],
+      "treeShakingScore": 47
+    },
+    {
+      "path": "utils/geometry-dedup.ts",
+      "exports": [
+        {
+          "name": "GeometryParams",
+          "type": "interface",
+          "line": 10,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 943
+        },
+        {
+          "name": "GeometryStats",
+          "type": "interface",
+          "line": 21,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 943
+        },
+        {
+          "name": "GeometryRegistry",
+          "type": "class",
+          "line": 48,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 943
+        },
+        {
+          "name": "geometryRegistry",
+          "type": "const",
+          "line": 277,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 943
+        },
+        {
+          "name": "getSphereGeometry",
+          "type": "function",
+          "line": 284,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/aurora.ts",
+            "foliage/berries.ts",
+            "foliage/flowers.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getBoxGeometry",
+          "type": "function",
+          "line": 299,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 943
+        },
+        {
+          "name": "getCylinderGeometry",
+          "type": "function",
+          "line": 313,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/flowers.ts",
+            "foliage/tree-batcher.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getConeGeometry",
+          "type": "function",
+          "line": 329,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/lantern-batcher.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getCapsuleGeometry",
+          "type": "function",
+          "line": 344,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 943
+        },
+        {
+          "name": "getPlaneGeometry",
+          "type": "function",
+          "line": 356,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 943
+        },
+        {
+          "name": "getCircleGeometry",
+          "type": "function",
+          "line": 368,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/flowers.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getTorusGeometry",
+          "type": "function",
+          "line": 380,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/flowers.ts",
+            "foliage/lantern-batcher.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getTorusKnotGeometry",
+          "type": "function",
+          "line": 393,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/tree-batcher.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getIcosahedronGeometry",
+          "type": "function",
+          "line": 407,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/cloud-batcher.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "CommonGeometries",
+          "type": "const",
+          "line": 421,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/berries.ts",
+            "foliage/material-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "reportGeometryStats",
+          "type": "function",
+          "line": 486,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 943
+        },
+        {
+          "name": "listRegisteredGeometries",
+          "type": "function",
+          "line": 504,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 943
+        }
+      ],
+      "imports": [
+        "THREE"
+      ],
+      "unusedExports": [
+        {
+          "name": "GeometryParams",
+          "type": "interface",
+          "line": 10,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 943
+        },
+        {
+          "name": "GeometryStats",
+          "type": "interface",
+          "line": 21,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 943
+        },
+        {
+          "name": "GeometryRegistry",
+          "type": "class",
+          "line": 48,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 943
+        },
+        {
+          "name": "geometryRegistry",
+          "type": "const",
+          "line": 277,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 943
+        },
+        {
+          "name": "getBoxGeometry",
+          "type": "function",
+          "line": 299,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 943
+        },
+        {
+          "name": "getCapsuleGeometry",
+          "type": "function",
+          "line": 344,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 943
+        },
+        {
+          "name": "getPlaneGeometry",
+          "type": "function",
+          "line": 356,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 943
+        },
+        {
+          "name": "reportGeometryStats",
+          "type": "function",
+          "line": 486,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 943
+        },
+        {
+          "name": "listRegisteredGeometries",
+          "type": "function",
+          "line": 504,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 943
+        }
+      ],
+      "treeShakingScore": 47
+    },
+    {
+      "path": "utils/wasm-orchestrator.ts",
+      "exports": [
+        {
+          "name": "LOADING_PHASES",
+          "type": "const",
+          "line": 9,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-loader-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "PHASE_STATUS",
+          "type": "const",
+          "line": 20,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 707
+        },
+        {
+          "name": "LoadingPhase",
+          "type": "type",
+          "line": 30,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 707
+        },
+        {
+          "name": "PhaseStatus",
+          "type": "type",
+          "line": 35,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 707
+        },
+        {
+          "name": "getSharedBuffer",
+          "type": "function",
+          "line": 45,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-loader-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "isSharedMemoryAvailable",
+          "type": "function",
+          "line": 53,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-loader-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "initSharedBuffer",
+          "type": "function",
+          "line": 69,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-loader-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "signalPhaseComplete",
+          "type": "function",
+          "line": 87,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 707
+        },
+        {
+          "name": "signalPhaseStart",
+          "type": "function",
+          "line": 98,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 707
+        },
+        {
+          "name": "ParallelWasmLoadOptions",
+          "type": "interface",
+          "line": 142,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 707
+        },
+        {
+          "name": "ParallelWasmLoadResult",
+          "type": "interface",
+          "line": 154,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 707
+        },
+        {
+          "name": "parallelWasmLoad",
+          "type": "function",
+          "line": 166,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-loader-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createPlaceholderScene",
+          "type": "function",
+          "line": 299,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 707
+        },
+        {
+          "name": "removePlaceholderScene",
+          "type": "function",
+          "line": 300,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 707
+        }
+      ],
+      "imports": [
+        "checkWasmFileExists",
+        "inspectWasmExports",
+        "patchWasmInstantiateAliases"
+      ],
+      "unusedExports": [
+        {
+          "name": "PHASE_STATUS",
+          "type": "const",
+          "line": 20,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 707
+        },
+        {
+          "name": "LoadingPhase",
+          "type": "type",
+          "line": 30,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 707
+        },
+        {
+          "name": "PhaseStatus",
+          "type": "type",
+          "line": 35,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 707
+        },
+        {
+          "name": "signalPhaseComplete",
+          "type": "function",
+          "line": 87,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 707
+        },
+        {
+          "name": "signalPhaseStart",
+          "type": "function",
+          "line": 98,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 707
+        },
+        {
+          "name": "ParallelWasmLoadOptions",
+          "type": "interface",
+          "line": 142,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 707
+        },
+        {
+          "name": "ParallelWasmLoadResult",
+          "type": "interface",
+          "line": 154,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 707
+        },
+        {
+          "name": "createPlaceholderScene",
+          "type": "function",
+          "line": 299,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 707
+        },
+        {
+          "name": "removePlaceholderScene",
+          "type": "function",
+          "line": 300,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 707
+        }
+      ],
+      "treeShakingScore": 36
+    },
+    {
+      "path": "compute/gpu-culling-system.ts",
+      "exports": [
+        {
+          "name": "BoundingSphere",
+          "type": "interface",
+          "line": 33,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2823
+        },
+        {
+          "name": "Plane",
+          "type": "interface",
+          "line": 44,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2823
+        },
+        {
+          "name": "Frustum",
+          "type": "interface",
+          "line": 53,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2823
+        },
+        {
+          "name": "CullingConfig",
+          "type": "interface",
+          "line": 60,
+          "isUsed": true,
+          "usedIn": [
+            "rendering/culling/culling-system.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "CullingResult",
+          "type": "interface",
+          "line": 70,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2823
+        },
+        {
+          "name": "GPUCullingSystem",
+          "type": "class",
+          "line": 111,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2823
+        },
+        {
+          "name": "createFrustumFromMatrices",
+          "type": "function",
+          "line": 562,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2823
+        },
+        {
+          "name": "createFrustumFromCamera",
+          "type": "function",
+          "line": 625,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2823
+        },
+        {
+          "name": "LOD_PRESETS",
+          "type": "const",
+          "line": 713,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2823
+        }
+      ],
+      "imports": [
+        "GPUComputeLibrary",
+        "FRUSTUM_CULL_WGSL",
+        "LOD_SELECT_WGSL"
+      ],
+      "unusedExports": [
+        {
+          "name": "BoundingSphere",
+          "type": "interface",
+          "line": 33,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2823
+        },
+        {
+          "name": "Plane",
+          "type": "interface",
+          "line": 44,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2823
+        },
+        {
+          "name": "Frustum",
+          "type": "interface",
+          "line": 53,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2823
+        },
+        {
+          "name": "CullingResult",
+          "type": "interface",
+          "line": 70,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2823
+        },
+        {
+          "name": "GPUCullingSystem",
+          "type": "class",
+          "line": 111,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2823
+        },
+        {
+          "name": "createFrustumFromMatrices",
+          "type": "function",
+          "line": 562,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2823
+        },
+        {
+          "name": "createFrustumFromCamera",
+          "type": "function",
+          "line": 625,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2823
+        },
+        {
+          "name": "LOD_PRESETS",
+          "type": "const",
+          "line": 713,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2823
+        }
+      ],
+      "treeShakingScore": 11
+    },
+    {
+      "path": "ui/save-menu/save-menu.ts",
+      "exports": [
+        {
+          "name": "MenuTab",
+          "type": "type",
+          "line": 43,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2779
+        },
+        {
+          "name": "MenuMode",
+          "type": "type",
+          "line": 44,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2779
+        },
+        {
+          "name": "SaveMenuOptions",
+          "type": "interface",
+          "line": 46,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2779
+        },
+        {
+          "name": "SaveMenu",
+          "type": "class",
+          "line": 57,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2779
+        },
+        {
+          "name": "openSaveMenu",
+          "type": "function",
+          "line": 731,
+          "isUsed": true,
+          "usedIn": [
+            "systems/save-integration-example.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "openLoadMenu",
+          "type": "function",
+          "line": 745,
+          "isUsed": true,
+          "usedIn": [
+            "systems/save-integration-example.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "openSaveGameMenu",
+          "type": "function",
+          "line": 752,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2779
+        },
+        {
+          "name": "closeSaveMenu",
+          "type": "function",
+          "line": 759,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2779
+        },
+        {
+          "name": "isSaveMenuOpen",
+          "type": "function",
+          "line": 767,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2779
+        },
+        {
+          "name": "showSaveIndicator",
+          "type": "function",
+          "line": 778,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2779
+        },
+        {
+          "name": "default",
+          "type": "function",
+          "line": 840,
+          "isUsed": true,
+          "usedIn": [
+            "core/init.ts",
+            "systems/music-reactivity.ts",
+            "utils/wasm-loader-core.ts",
+            "world/generation.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "saveSystem",
+        "SaveData",
+        "SaveSlotInfo",
+        "SettingsSaveData",
+        "KeyBindings",
+        "showToast",
+        "trapFocusInside",
+        "announce",
+        "MENU_STYLES",
+        "renderLoadTab",
+        "renderSaveTab",
+        "handleSlotAction",
+        "handleQuickSave",
+        "renderSettingsTab",
+        "handleSettingChange",
+        "handleSettingClick",
+        "handleKeybindClick",
+        "cancelKeybindListenBase",
+        "updateKeybindBase"
+      ],
+      "unusedExports": [
+        {
+          "name": "MenuTab",
+          "type": "type",
+          "line": 43,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2779
+        },
+        {
+          "name": "MenuMode",
+          "type": "type",
+          "line": 44,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2779
+        },
+        {
+          "name": "SaveMenuOptions",
+          "type": "interface",
+          "line": 46,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2779
+        },
+        {
+          "name": "SaveMenu",
+          "type": "class",
+          "line": 57,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2779
+        },
+        {
+          "name": "openSaveGameMenu",
+          "type": "function",
+          "line": 752,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2779
+        },
+        {
+          "name": "closeSaveMenu",
+          "type": "function",
+          "line": 759,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2779
+        },
+        {
+          "name": "isSaveMenuOpen",
+          "type": "function",
+          "line": 767,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2779
+        },
+        {
+          "name": "showSaveIndicator",
+          "type": "function",
+          "line": 778,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2779
+        }
+      ],
+      "treeShakingScore": 27
+    },
+    {
+      "path": "compute/gpu-particle-system.ts",
+      "exports": [
+        {
+          "name": "vec3",
+          "type": "type",
+          "line": 49,
+          "isUsed": true,
+          "usedIn": [
+            "compute/particle_compute.ts",
+            "foliage/animation-nodes.ts",
+            "foliage/arpeggio-batcher.ts",
+            "foliage/aurora.ts",
+            "foliage/berries.ts",
+            "foliage/celestial-bodies.ts",
+            "foliage/chromatic.ts",
+            "foliage/cloud-batcher.ts",
+            "foliage/dandelion-batcher.ts",
+            "foliage/dandelion-seeds.ts",
+            "foliage/discovery-effect.ts",
+            "foliage/environment.ts",
+            "foliage/fireflies.ts",
+            "foliage/flowers.ts",
+            "foliage/fluid_fog.ts",
+            "foliage/foliage-materials.ts",
+            "foliage/glitch.ts",
+            "foliage/glowing-flower-batcher.ts",
+            "foliage/grass.ts",
+            "foliage/impacts.ts",
+            "foliage/instrument.ts",
+            "foliage/lake_features.ts",
+            "foliage/lantern-batcher.ts",
+            "foliage/lod.ts",
+            "foliage/lotus.ts",
+            "foliage/material-core.ts",
+            "foliage/mirrors.ts",
+            "foliage/moon.ts",
+            "foliage/mushroom-batcher.ts",
+            "foliage/musical_flora.ts",
+            "foliage/panning-pads.ts",
+            "foliage/pollen.ts",
+            "foliage/portamento-batcher.ts",
+            "foliage/post-processing.ts",
+            "foliage/ribbons.ts",
+            "foliage/shield.ts",
+            "foliage/silence-spirits.ts",
+            "foliage/simple-flower-batcher.ts",
+            "foliage/sparkle-trail.ts",
+            "foliage/stars.ts",
+            "foliage/strobe.ts",
+            "foliage/terrain.ts",
+            "foliage/tree-batcher.ts",
+            "foliage/trees.ts",
+            "foliage/water.ts",
+            "foliage/waterfall-batcher.ts",
+            "foliage/waterfalls.ts",
+            "foliage/wisteria-cluster.ts",
+            "gameplay/chord-strike.ts",
+            "gameplay/harpoon-line.ts",
+            "gameplay/jitter-mines.ts",
+            "gameplay/rainbow-blaster.ts",
+            "particles/compute-particles.ts",
+            "particles/cpu-particle-system.ts",
+            "particles/gpu_particles.ts",
+            "rendering/materials.ts",
+            "rendering/shader-warmup.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "GPUParticleConfig",
+          "type": "interface",
+          "line": 52,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 3100
+        },
+        {
+          "name": "GPUParticleAudioState",
+          "type": "interface",
+          "line": 76,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 3100
+        },
+        {
+          "name": "GPUParticleSystem",
+          "type": "class",
+          "line": 127,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 3100
+        },
+        {
+          "name": "createFireworkSystem",
+          "type": "function",
+          "line": 695,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 3100
+        },
+        {
+          "name": "createSparkleSystem",
+          "type": "function",
+          "line": 719,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 3100
+        },
+        {
+          "name": "createRainSystem",
+          "type": "function",
+          "line": 742,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 3100
+        },
+        {
+          "name": "createParticleSystemWithFallback",
+          "type": "function",
+          "line": 770,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 3100
+        },
+        {
+          "name": "default",
+          "type": "function",
+          "line": 797,
+          "isUsed": true,
+          "usedIn": [
+            "core/init.ts",
+            "systems/music-reactivity.ts",
+            "utils/wasm-loader-core.ts",
+            "world/generation.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "GPUComputeLibrary",
+        "PARTICLE_PHYSICS_WGSL",
+        "THREE"
+      ],
+      "unusedExports": [
+        {
+          "name": "GPUParticleConfig",
+          "type": "interface",
+          "line": 52,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 3100
+        },
+        {
+          "name": "GPUParticleAudioState",
+          "type": "interface",
+          "line": 76,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 3100
+        },
+        {
+          "name": "GPUParticleSystem",
+          "type": "class",
+          "line": 127,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 3100
+        },
+        {
+          "name": "createFireworkSystem",
+          "type": "function",
+          "line": 695,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 3100
+        },
+        {
+          "name": "createSparkleSystem",
+          "type": "function",
+          "line": 719,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 3100
+        },
+        {
+          "name": "createRainSystem",
+          "type": "function",
+          "line": 742,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 3100
+        },
+        {
+          "name": "createParticleSystemWithFallback",
+          "type": "function",
+          "line": 770,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 3100
+        }
+      ],
+      "treeShakingScore": 22
     },
     {
       "path": "foliage/berries.ts",
@@ -8021,67 +10287,59 @@
         {
           "name": "uBerrySeasonScale",
           "type": "const",
-          "line": 22,
+          "line": 32,
           "isUsed": false,
           "usedIn": [],
-          "size": 1281
+          "size": 1383
         },
         {
           "name": "BerryClusterOptions",
           "type": "interface",
-          "line": 25,
+          "line": 35,
           "isUsed": false,
           "usedIn": [],
-          "size": 1281
+          "size": 1383
         },
         {
           "name": "BerryClusterUserData",
           "type": "interface",
-          "line": 33,
+          "line": 43,
           "isUsed": false,
           "usedIn": [],
-          "size": 1281
+          "size": 1383
         },
         {
           "name": "FallingBerry",
           "type": "interface",
-          "line": 50,
+          "line": 60,
           "isUsed": false,
           "usedIn": [],
-          "size": 1281
+          "size": 1383
         },
         {
           "name": "BerryBatcher",
           "type": "class",
-          "line": 60,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1281
-        },
-        {
-          "name": "berryBatcher",
-          "type": "const",
-          "line": 284,
+          "line": 71,
           "isUsed": true,
           "usedIn": [
-            "systems/weather.ts"
+            "systems/weather/weather.ts"
           ],
           "size": 0
         },
         {
           "name": "updateGlobalBerryScale",
           "type": "function",
-          "line": 292,
+          "line": 306,
           "isUsed": true,
           "usedIn": [
-            "systems/weather.ts"
+            "systems/weather/weather-atmosphere.ts"
           ],
           "size": 0
         },
         {
           "name": "createBerryCluster",
           "type": "function",
-          "line": 359,
+          "line": 373,
           "isUsed": true,
           "usedIn": [
             "foliage/trees.ts"
@@ -8091,33 +10349,33 @@
         {
           "name": "updateBerryGlow",
           "type": "function",
-          "line": 385,
+          "line": 399,
           "isUsed": false,
           "usedIn": [],
-          "size": 1281
+          "size": 1383
         },
         {
           "name": "chargeBerries",
           "type": "function",
-          "line": 389,
+          "line": 403,
           "isUsed": true,
           "usedIn": [
-            "systems/weather.ts"
+            "systems/weather/weather-atmosphere.ts"
           ],
           "size": 0
         },
         {
           "name": "updateBerrySeasons",
           "type": "function",
-          "line": 398,
+          "line": 412,
           "isUsed": false,
           "usedIn": [],
-          "size": 1281
+          "size": 1383
         },
         {
           "name": "initFallingBerries",
           "type": "function",
-          "line": 408,
+          "line": 428,
           "isUsed": true,
           "usedIn": [
             "world/generation.ts"
@@ -8127,43 +10385,44 @@
         {
           "name": "spawnFallingBerry",
           "type": "function",
-          "line": 457,
+          "line": 451,
           "isUsed": false,
           "usedIn": [],
-          "size": 1281
+          "size": 1383
         },
         {
           "name": "updateFallingBerries",
           "type": "function",
-          "line": 492,
+          "line": 489,
           "isUsed": true,
           "usedIn": [
-            "main.ts"
+            "core/game-loop.ts"
           ],
           "size": 0
         },
         {
           "name": "shakeBerriesLoose",
           "type": "function",
-          "line": 530,
+          "line": 522,
           "isUsed": true,
           "usedIn": [
-            "systems/weather.ts"
+            "systems/weather/weather-atmosphere.ts"
           ],
           "size": 0
         },
         {
           "name": "collectFallingBerries",
           "type": "function",
-          "line": 541,
+          "line": 533,
           "isUsed": true,
           "usedIn": [
-            "main.ts"
+            "core/game-loop.ts"
           ],
           "size": 0
         }
       ],
       "imports": [
+        "StorageInstancedBufferAttribute",
         "color",
         "float",
         "uniform",
@@ -8173,10 +10432,13 @@
         "sin",
         "dot",
         "time",
-        "Node",
-        "UniformNode",
-        "ShaderNodeObject",
         "attribute",
+        "storage",
+        "instanceIndex",
+        "Fn",
+        "If",
+        "vec4",
+        "varyingProperty",
         "CandyPresets",
         "uAudioLow",
         "uTime",
@@ -8185,75 +10447,69 @@
         "foliageGroup",
         "CommonGeometries",
         "getSphereGeometry",
+        "createComputeBerries",
+        "ComputeParticleSystem",
         "THREE"
       ],
       "unusedExports": [
         {
           "name": "uBerrySeasonScale",
           "type": "const",
-          "line": 22,
+          "line": 32,
           "isUsed": false,
           "usedIn": [],
-          "size": 1281
+          "size": 1383
         },
         {
           "name": "BerryClusterOptions",
           "type": "interface",
-          "line": 25,
+          "line": 35,
           "isUsed": false,
           "usedIn": [],
-          "size": 1281
+          "size": 1383
         },
         {
           "name": "BerryClusterUserData",
           "type": "interface",
-          "line": 33,
+          "line": 43,
           "isUsed": false,
           "usedIn": [],
-          "size": 1281
+          "size": 1383
         },
         {
           "name": "FallingBerry",
           "type": "interface",
-          "line": 50,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 1281
-        },
-        {
-          "name": "BerryBatcher",
-          "type": "class",
           "line": 60,
           "isUsed": false,
           "usedIn": [],
-          "size": 1281
+          "size": 1383
         },
         {
           "name": "updateBerryGlow",
           "type": "function",
-          "line": 385,
+          "line": 399,
           "isUsed": false,
           "usedIn": [],
-          "size": 1281
+          "size": 1383
         },
         {
           "name": "updateBerrySeasons",
           "type": "function",
-          "line": 398,
+          "line": 412,
           "isUsed": false,
           "usedIn": [],
-          "size": 1281
+          "size": 1383
         },
         {
           "name": "spawnFallingBerry",
           "type": "function",
-          "line": 457,
+          "line": 451,
           "isUsed": false,
           "usedIn": [],
-          "size": 1281
+          "size": 1383
         }
       ],
-      "treeShakingScore": 50
+      "treeShakingScore": 53
     },
     {
       "path": "foliage/lod.ts",
@@ -8264,7 +10520,7 @@
           "line": 23,
           "isUsed": false,
           "usedIn": [],
-          "size": 3035
+          "size": 3161
         },
         {
           "name": "DEFAULT_LOD_CONFIG",
@@ -8272,15 +10528,17 @@
           "line": 42,
           "isUsed": false,
           "usedIn": [],
-          "size": 3035
+          "size": 3161
         },
         {
           "name": "LODLevel",
           "type": "enum",
           "line": 60,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 3035
+          "isUsed": true,
+          "usedIn": [
+            "rendering/culling/culling-system.ts"
+          ],
+          "size": 0
         },
         {
           "name": "createLODGeometry",
@@ -8288,7 +10546,7 @@
           "line": 74,
           "isUsed": false,
           "usedIn": [],
-          "size": 3035
+          "size": 3161
         },
         {
           "name": "getLODMaterial",
@@ -8296,7 +10554,7 @@
           "line": 136,
           "isUsed": false,
           "usedIn": [],
-          "size": 3035
+          "size": 3161
         },
         {
           "name": "FoliageLODManager",
@@ -8304,30 +10562,33 @@
           "line": 328,
           "isUsed": false,
           "usedIn": [],
-          "size": 3035
+          "size": 3161
         },
         {
           "name": "LODTreeInstance",
           "type": "interface",
-          "line": 756,
+          "line": 771,
           "isUsed": false,
           "usedIn": [],
-          "size": 3035
+          "size": 3161
         },
         {
           "name": "LODTreeBatcher",
           "type": "class",
-          "line": 766,
+          "line": 781,
           "isUsed": false,
           "usedIn": [],
-          "size": 3035
+          "size": 3161
         },
         {
           "name": "default",
           "type": "function",
-          "line": 869,
+          "line": 884,
           "isUsed": true,
           "usedIn": [
+            "core/init.ts",
+            "systems/music-reactivity.ts",
+            "utils/wasm-loader-core.ts",
             "world/generation.ts"
           ],
           "size": 0
@@ -8345,6 +10606,7 @@
         "cos",
         "positionWorld",
         "normalLocal",
+        "varyingProperty",
         "foliageGroup",
         "CandyPresets",
         "calculateWindSway",
@@ -8362,7 +10624,7 @@
           "line": 23,
           "isUsed": false,
           "usedIn": [],
-          "size": 3035
+          "size": 3161
         },
         {
           "name": "DEFAULT_LOD_CONFIG",
@@ -8370,15 +10632,7 @@
           "line": 42,
           "isUsed": false,
           "usedIn": [],
-          "size": 3035
-        },
-        {
-          "name": "LODLevel",
-          "type": "enum",
-          "line": 60,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 3035
+          "size": 3161
         },
         {
           "name": "createLODGeometry",
@@ -8386,7 +10640,7 @@
           "line": 74,
           "isUsed": false,
           "usedIn": [],
-          "size": 3035
+          "size": 3161
         },
         {
           "name": "getLODMaterial",
@@ -8394,7 +10648,7 @@
           "line": 136,
           "isUsed": false,
           "usedIn": [],
-          "size": 3035
+          "size": 3161
         },
         {
           "name": "FoliageLODManager",
@@ -8402,26 +10656,26 @@
           "line": 328,
           "isUsed": false,
           "usedIn": [],
-          "size": 3035
+          "size": 3161
         },
         {
           "name": "LODTreeInstance",
           "type": "interface",
-          "line": 756,
+          "line": 771,
           "isUsed": false,
           "usedIn": [],
-          "size": 3035
+          "size": 3161
         },
         {
           "name": "LODTreeBatcher",
           "type": "class",
-          "line": 766,
+          "line": 781,
           "isUsed": false,
           "usedIn": [],
-          "size": 3035
+          "size": 3161
         }
       ],
-      "treeShakingScore": 11
+      "treeShakingScore": 22
     },
     {
       "path": "particles/gpu_particles.ts",
@@ -8429,58 +10683,58 @@
         {
           "name": "createShimmerParticles",
           "type": "function",
-          "line": 165,
+          "line": 183,
           "isUsed": false,
           "usedIn": [],
-          "size": 2995
+          "size": 3339
         },
         {
           "name": "createBubbleStream",
           "type": "function",
-          "line": 281,
+          "line": 308,
           "isUsed": false,
           "usedIn": [],
-          "size": 2995
+          "size": 3339
         },
         {
           "name": "createPollenCloud",
           "type": "function",
-          "line": 394,
+          "line": 430,
           "isUsed": false,
           "usedIn": [],
-          "size": 2995
+          "size": 3339
         },
         {
           "name": "createLeafConfetti",
           "type": "function",
-          "line": 502,
+          "line": 547,
           "isUsed": false,
           "usedIn": [],
-          "size": 2995
+          "size": 3339
         },
         {
           "name": "createPulseRing",
           "type": "function",
-          "line": 598,
+          "line": 652,
           "isUsed": false,
           "usedIn": [],
-          "size": 2995
+          "size": 3339
         },
         {
           "name": "addAmbientParticles",
           "type": "function",
-          "line": 618,
+          "line": 672,
           "isUsed": false,
           "usedIn": [],
-          "size": 2995
+          "size": 3339
         },
         {
           "name": "disposeParticleSystems",
           "type": "function",
-          "line": 637,
+          "line": 691,
           "isUsed": false,
           "usedIn": [],
-          "size": 2995
+          "size": 3339
         }
       ],
       "imports": [
@@ -8496,6 +10750,7 @@
         "mix",
         "sin",
         "cos",
+        "floor",
         "PointsNodeMaterial",
         "ParticleSystemType",
         "uPulseStrength",
@@ -8506,61 +10761,469 @@
         {
           "name": "createShimmerParticles",
           "type": "function",
-          "line": 165,
+          "line": 183,
           "isUsed": false,
           "usedIn": [],
-          "size": 2995
+          "size": 3339
         },
         {
           "name": "createBubbleStream",
           "type": "function",
-          "line": 281,
+          "line": 308,
           "isUsed": false,
           "usedIn": [],
-          "size": 2995
+          "size": 3339
         },
         {
           "name": "createPollenCloud",
           "type": "function",
-          "line": 394,
+          "line": 430,
           "isUsed": false,
           "usedIn": [],
-          "size": 2995
+          "size": 3339
         },
         {
           "name": "createLeafConfetti",
           "type": "function",
-          "line": 502,
+          "line": 547,
           "isUsed": false,
           "usedIn": [],
-          "size": 2995
+          "size": 3339
         },
         {
           "name": "createPulseRing",
           "type": "function",
-          "line": 598,
+          "line": 652,
           "isUsed": false,
           "usedIn": [],
-          "size": 2995
+          "size": 3339
         },
         {
           "name": "addAmbientParticles",
           "type": "function",
-          "line": 618,
+          "line": 672,
           "isUsed": false,
           "usedIn": [],
-          "size": 2995
+          "size": 3339
         },
         {
           "name": "disposeParticleSystems",
           "type": "function",
-          "line": 637,
+          "line": 691,
           "isUsed": false,
           "usedIn": [],
-          "size": 2995
+          "size": 3339
         }
       ],
       "treeShakingScore": 0
+    },
+    {
+      "path": "core/index.ts",
+      "exports": [
+        {
+          "name": "animate",
+          "type": "const",
+          "line": 4,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "initGameLoopDependencies",
+          "type": "const",
+          "line": 4,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "addCameraShake",
+          "type": "const",
+          "line": 4,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts",
+            "main.ts",
+            "systems/glitch-grenade.ts",
+            "systems/physics/physics-abilities.ts",
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-updates.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getGameTime",
+          "type": "const",
+          "line": 4,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 27
+        },
+        {
+          "name": "getAudioState",
+          "type": "const",
+          "line": 4,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 27
+        },
+        {
+          "name": "getBeatFlashIntensity",
+          "type": "const",
+          "line": 4,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 27
+        },
+        {
+          "name": "updateHUD",
+          "type": "const",
+          "line": 5,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "updateTheme",
+          "type": "const",
+          "line": 5,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts",
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "toggleDayNight",
+          "type": "const",
+          "line": 5,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "setInputSystem",
+          "type": "const",
+          "line": 5,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "initDeferredVisuals",
+          "type": "const",
+          "line": 6,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "initDeferredVisualsDependencies",
+          "type": "const",
+          "line": 6,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "runDeferredWarmup",
+          "type": "const",
+          "line": 6,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "scene",
+          "type": "const",
+          "line": 7,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 27
+        },
+        {
+          "name": "camera",
+          "type": "const",
+          "line": 7,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 27
+        },
+        {
+          "name": "renderer",
+          "type": "const",
+          "line": 7,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 27
+        },
+        {
+          "name": "player",
+          "type": "const",
+          "line": 7,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts",
+            "core/main.ts",
+            "systems/physics/physics-abilities.ts",
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-states.ts",
+            "systems/physics/physics-updates.ts",
+            "systems/save-integration-example.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "addCameraShake",
+          "type": "const",
+          "line": 7,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts",
+            "main.ts",
+            "systems/glitch-grenade.ts",
+            "systems/physics/physics-abilities.ts",
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-updates.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [],
+      "unusedExports": [
+        {
+          "name": "getGameTime",
+          "type": "const",
+          "line": 4,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 27
+        },
+        {
+          "name": "getAudioState",
+          "type": "const",
+          "line": 4,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 27
+        },
+        {
+          "name": "getBeatFlashIntensity",
+          "type": "const",
+          "line": 4,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 27
+        },
+        {
+          "name": "scene",
+          "type": "const",
+          "line": 7,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 27
+        },
+        {
+          "name": "camera",
+          "type": "const",
+          "line": 7,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 27
+        },
+        {
+          "name": "renderer",
+          "type": "const",
+          "line": 7,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 27
+        }
+      ],
+      "treeShakingScore": 67
+    },
+    {
+      "path": "debug/stages.ts",
+      "exports": [
+        {
+          "name": "DebugStages",
+          "type": "interface",
+          "line": 9,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 694
+        },
+        {
+          "name": "DEBUG_STAGES",
+          "type": "const",
+          "line": 42,
+          "isUsed": true,
+          "usedIn": [
+            "debug/panel.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "DEBUG_CONFIG",
+          "type": "const",
+          "line": 62,
+          "isUsed": true,
+          "usedIn": [
+            "debug/panel.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "StageResult",
+          "type": "interface",
+          "line": 70,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 694
+        },
+        {
+          "name": "StageStatus",
+          "type": "enum",
+          "line": 79,
+          "isUsed": true,
+          "usedIn": [
+            "debug/panel.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "StageMetadata",
+          "type": "interface",
+          "line": 90,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 694
+        },
+        {
+          "name": "initStageTracking",
+          "type": "function",
+          "line": 103,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 694
+        },
+        {
+          "name": "getStageStatus",
+          "type": "function",
+          "line": 115,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 694
+        },
+        {
+          "name": "getAllStageStatuses",
+          "type": "function",
+          "line": 122,
+          "isUsed": true,
+          "usedIn": [
+            "debug/panel.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "updateStageStatus",
+          "type": "function",
+          "line": 129,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 694
+        },
+        {
+          "name": "StageLoader",
+          "type": "class",
+          "line": 146,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts",
+            "debug/panel.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "showDebugError",
+          "type": "function",
+          "line": 226,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [],
+      "unusedExports": [
+        {
+          "name": "DebugStages",
+          "type": "interface",
+          "line": 9,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 694
+        },
+        {
+          "name": "StageResult",
+          "type": "interface",
+          "line": 70,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 694
+        },
+        {
+          "name": "StageMetadata",
+          "type": "interface",
+          "line": 90,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 694
+        },
+        {
+          "name": "initStageTracking",
+          "type": "function",
+          "line": 103,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 694
+        },
+        {
+          "name": "getStageStatus",
+          "type": "function",
+          "line": 115,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 694
+        },
+        {
+          "name": "updateStageStatus",
+          "type": "function",
+          "line": 129,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 694
+        }
+      ],
+      "treeShakingScore": 50
     },
     {
       "path": "examples/asset-streaming-usage.ts",
@@ -8675,229 +11338,779 @@
       "treeShakingScore": 0
     },
     {
-      "path": "utils/geometry-dedup.ts",
+      "path": "foliage/wind-compute.ts",
       "exports": [
         {
-          "name": "GeometryParams",
-          "type": "interface",
-          "line": 10,
+          "name": "WIND_TEXTURE_SIZE",
+          "type": "const",
+          "line": 15,
           "isUsed": false,
           "usedIn": [],
-          "size": 943
+          "size": 1848
         },
         {
-          "name": "GeometryStats",
+          "name": "WindConfig",
           "type": "interface",
           "line": 21,
           "isUsed": false,
           "usedIn": [],
-          "size": 943
+          "size": 1848
         },
         {
-          "name": "GeometryRegistry",
+          "name": "DEFAULT_WIND_CONFIG",
+          "type": "const",
+          "line": 39,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1848
+        },
+        {
+          "name": "WindComputeSystem",
           "type": "class",
-          "line": 48,
+          "line": 55,
           "isUsed": false,
           "usedIn": [],
-          "size": 943
+          "size": 1848
         },
         {
-          "name": "geometryRegistry",
+          "name": "windComputeSystem",
           "type": "const",
-          "line": 277,
+          "line": 325,
           "isUsed": true,
           "usedIn": [
-            "foliage/common.ts"
+            "core/game-loop.ts"
           ],
           "size": 0
         },
         {
-          "name": "getSphereGeometry",
+          "name": "getWindTextureData",
           "type": "function",
-          "line": 284,
+          "line": 339,
           "isUsed": true,
           "usedIn": [
-            "foliage/berries.ts",
-            "foliage/common.ts",
-            "foliage/flowers.ts"
+            "foliage/material-core.ts"
           ],
           "size": 0
         },
         {
-          "name": "getBoxGeometry",
-          "type": "function",
-          "line": 299,
+          "name": "WindPerformanceProfiler",
+          "type": "class",
+          "line": 355,
           "isUsed": false,
           "usedIn": [],
-          "size": 943
+          "size": 1848
         },
         {
-          "name": "getCylinderGeometry",
-          "type": "function",
-          "line": 313,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/common.ts",
-            "foliage/flowers.ts",
-            "foliage/tree-batcher.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "getConeGeometry",
-          "type": "function",
-          "line": 329,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/common.ts",
-            "foliage/lantern-batcher.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "getCapsuleGeometry",
-          "type": "function",
-          "line": 344,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/common.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "getPlaneGeometry",
-          "type": "function",
-          "line": 356,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/common.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "getCircleGeometry",
-          "type": "function",
-          "line": 368,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/flowers.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "getTorusGeometry",
-          "type": "function",
-          "line": 380,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/common.ts",
-            "foliage/flowers.ts",
-            "foliage/lantern-batcher.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "getTorusKnotGeometry",
-          "type": "function",
-          "line": 393,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/tree-batcher.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "getIcosahedronGeometry",
-          "type": "function",
-          "line": 407,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/cloud-batcher.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "CommonGeometries",
+          "name": "windProfiler",
           "type": "const",
-          "line": 421,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/berries.ts",
-            "foliage/common.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "reportGeometryStats",
-          "type": "function",
-          "line": 486,
+          "line": 431,
           "isUsed": false,
           "usedIn": [],
-          "size": 943
-        },
-        {
-          "name": "listRegisteredGeometries",
-          "type": "function",
-          "line": 504,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 943
+          "size": 1848
         }
       ],
       "imports": [
+        "DataTexture",
+        "Vector2",
+        "Vector4",
+        "RGBAFormat",
+        "HalfFloatType",
+        "NearestFilter",
+        "RepeatWrapping",
+        "textureStore",
+        "instanceIndex",
+        "Fn",
+        "float",
+        "vec4",
+        "vec2",
+        "ivec2",
+        "mx_noise_float",
+        "sin",
+        "cos",
+        "max",
+        "min",
+        "uniform",
+        "floor",
+        "StorageTexture",
+        "texture",
+        "uv",
+        "getWindTextureNode",
         "THREE"
       ],
       "unusedExports": [
         {
-          "name": "GeometryParams",
-          "type": "interface",
-          "line": 10,
+          "name": "WIND_TEXTURE_SIZE",
+          "type": "const",
+          "line": 15,
           "isUsed": false,
           "usedIn": [],
-          "size": 943
+          "size": 1848
         },
         {
-          "name": "GeometryStats",
+          "name": "WindConfig",
           "type": "interface",
           "line": 21,
           "isUsed": false,
           "usedIn": [],
-          "size": 943
+          "size": 1848
         },
         {
-          "name": "GeometryRegistry",
+          "name": "DEFAULT_WIND_CONFIG",
+          "type": "const",
+          "line": 39,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1848
+        },
+        {
+          "name": "WindComputeSystem",
           "type": "class",
-          "line": 48,
+          "line": 55,
           "isUsed": false,
           "usedIn": [],
-          "size": 943
+          "size": 1848
         },
         {
-          "name": "getBoxGeometry",
-          "type": "function",
-          "line": 299,
+          "name": "WindPerformanceProfiler",
+          "type": "class",
+          "line": 355,
           "isUsed": false,
           "usedIn": [],
-          "size": 943
+          "size": 1848
         },
         {
-          "name": "reportGeometryStats",
-          "type": "function",
-          "line": 486,
+          "name": "windProfiler",
+          "type": "const",
+          "line": 431,
           "isUsed": false,
           "usedIn": [],
-          "size": 943
-        },
-        {
-          "name": "listRegisteredGeometries",
-          "type": "function",
-          "line": 504,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 943
+          "size": 1848
         }
       ],
-      "treeShakingScore": 65
+      "treeShakingScore": 25
+    },
+    {
+      "path": "particles/compute-particles.ts",
+      "exports": [
+        {
+          "name": "ComputeParticleSystem",
+          "type": "class",
+          "line": 71,
+          "isUsed": true,
+          "usedIn": [
+            "compute/particle_compute.ts",
+            "foliage/berries.ts",
+            "particles/compute-integration.ts",
+            "systems/weather/weather-effects.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createComputeFireflies",
+          "type": "function",
+          "line": 626,
+          "isUsed": true,
+          "usedIn": [
+            "particles/compute-integration.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createComputePollen",
+          "type": "function",
+          "line": 642,
+          "isUsed": true,
+          "usedIn": [
+            "particles/compute-integration.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createComputeBerries",
+          "type": "function",
+          "line": 658,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/berries.ts",
+            "particles/compute-integration.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createComputeRain",
+          "type": "function",
+          "line": 674,
+          "isUsed": true,
+          "usedIn": [
+            "particles/compute-integration.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createComputeSparks",
+          "type": "function",
+          "line": 690,
+          "isUsed": true,
+          "usedIn": [
+            "particles/compute-integration.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "initComputeParticleSystems",
+          "type": "function",
+          "line": 707,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1766
+        },
+        {
+          "name": "addComputeSystem",
+          "type": "function",
+          "line": 712,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1766
+        },
+        {
+          "name": "removeComputeSystem",
+          "type": "function",
+          "line": 716,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1766
+        },
+        {
+          "name": "updateAllComputeSystems",
+          "type": "function",
+          "line": 723,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1766
+        },
+        {
+          "name": "disposeAllComputeSystems",
+          "type": "function",
+          "line": 736,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1766
+        },
+        {
+          "name": "getActiveComputeSystems",
+          "type": "function",
+          "line": 745,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1766
+        },
+        {
+          "name": "UPDATE_PARTICLES_WGSL",
+          "type": "const",
+          "line": 750,
+          "isUsed": true,
+          "usedIn": [
+            "particles/compute-particles.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "RENDER_PARTICLES_WGSL",
+          "type": "const",
+          "line": 750,
+          "isUsed": true,
+          "usedIn": [
+            "particles/compute-particles.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "FRAGMENT_PARTICLES_WGSL",
+          "type": "const",
+          "line": 750,
+          "isUsed": true,
+          "usedIn": [
+            "particles/compute-particles.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "default",
+          "type": "function",
+          "line": 756,
+          "isUsed": true,
+          "usedIn": [
+            "core/init.ts",
+            "systems/music-reactivity.ts",
+            "utils/wasm-loader-core.ts",
+            "world/generation.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "MeshStandardNodeMaterial",
+        "PointsNodeMaterial",
+        "StorageBufferAttribute",
+        "Fn",
+        "uniform",
+        "storage",
+        "instanceIndex",
+        "vertexIndex",
+        "float",
+        "vec2",
+        "vec3",
+        "vec4",
+        "mix",
+        "sin",
+        "cos",
+        "normalize",
+        "color",
+        "attribute",
+        "mx_noise_float",
+        "positionLocal",
+        "max",
+        "length",
+        "min",
+        "pow",
+        "abs",
+        "smoothstep",
+        "uv",
+        "distance",
+        "time",
+        "sqrt",
+        "dot",
+        "cross",
+        "cameraPosition",
+        "uTime",
+        "uAudioLow",
+        "uAudioHigh",
+        "uPlayerPosition",
+        "uWindSpeed",
+        "uWindDirection",
+        "getGroundHeight",
+        "ComputeParticleType",
+        "ComputeParticleConfig",
+        "ParticleBuffers",
+        "ParticleAudioData",
+        "FireflyConfig",
+        "PollenConfig",
+        "BerryConfig",
+        "RainConfig",
+        "SparkConfig",
+        "ComputeSystemCollection",
+        "UPDATE_PARTICLES_WGSL",
+        "RENDER_PARTICLES_WGSL",
+        "FRAGMENT_PARTICLES_WGSL",
+        "CPUParticleSystem",
+        "THREE"
+      ],
+      "unusedExports": [
+        {
+          "name": "initComputeParticleSystems",
+          "type": "function",
+          "line": 707,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1766
+        },
+        {
+          "name": "addComputeSystem",
+          "type": "function",
+          "line": 712,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1766
+        },
+        {
+          "name": "removeComputeSystem",
+          "type": "function",
+          "line": 716,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1766
+        },
+        {
+          "name": "updateAllComputeSystems",
+          "type": "function",
+          "line": 723,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1766
+        },
+        {
+          "name": "disposeAllComputeSystems",
+          "type": "function",
+          "line": 736,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1766
+        },
+        {
+          "name": "getActiveComputeSystems",
+          "type": "function",
+          "line": 745,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1766
+        }
+      ],
+      "treeShakingScore": 63
+    },
+    {
+      "path": "systems/physics/physics-types.ts",
+      "exports": [
+        {
+          "name": "AudioState",
+          "type": "interface",
+          "line": 12,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-abilities.ts",
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-states.ts",
+            "systems/physics/physics-updates.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "PlayerExtended",
+          "type": "interface",
+          "line": 21,
+          "isUsed": true,
+          "usedIn": [
+            "systems/save-integration-example.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "GRAVITY",
+          "type": "const",
+          "line": 46,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 156
+        },
+        {
+          "name": "SWIMMING_GRAVITY",
+          "type": "const",
+          "line": 47,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-states.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "SWIMMING_DRAG",
+          "type": "const",
+          "line": 48,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-states.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "PLAYER_HEIGHT_OFFSET",
+          "type": "const",
+          "line": 49,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-states.ts",
+            "systems/physics/physics-updates.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "DANCE_KICK_THRESHOLD",
+          "type": "const",
+          "line": 50,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-states.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "MOVE_ACCEL",
+          "type": "const",
+          "line": 53,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 156
+        },
+        {
+          "name": "PlayerState",
+          "type": "const",
+          "line": 56,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-states.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "PlayerStateType",
+          "type": "type",
+          "line": 64,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 156
+        },
+        {
+          "name": "player",
+          "type": "const",
+          "line": 67,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts",
+            "core/main.ts",
+            "systems/physics/physics-abilities.ts",
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-states.ts",
+            "systems/physics/physics-updates.ts",
+            "systems/save-integration-example.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "_lastInputState",
+          "type": "const",
+          "line": 105,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-abilities.ts",
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-states.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "bpmWind",
+          "type": "const",
+          "line": 116,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-states.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "grooveGravity",
+          "type": "const",
+          "line": 123,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-states.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "_scratchSwimDir",
+          "type": "const",
+          "line": 130,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-states.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "_scratchCamDir",
+          "type": "const",
+          "line": 131,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-abilities.ts",
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-states.ts",
+            "systems/physics/physics-updates.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "_scratchCamRight",
+          "type": "const",
+          "line": 132,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-states.ts",
+            "systems/physics/physics-updates.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "_scratchMoveVec",
+          "type": "const",
+          "line": 133,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-states.ts",
+            "systems/physics/physics-updates.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "_scratchTargetVel",
+          "type": "const",
+          "line": 134,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-updates.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "_scratchUp",
+          "type": "const",
+          "line": 135,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-states.ts",
+            "systems/physics/physics-updates.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "_scratchPlayerState",
+          "type": "const",
+          "line": 137,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-updates.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "_scratchHeadOffset",
+          "type": "const",
+          "line": 139,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 156
+        },
+        {
+          "name": "_scratchPos",
+          "type": "const",
+          "line": 140,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 156
+        },
+        {
+          "name": "_clapColor",
+          "type": "const",
+          "line": 141,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 156
+        },
+        {
+          "name": "cppPhysicsInitialized",
+          "type": "let",
+          "line": 144,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "foliageCaves",
+          "type": "const",
+          "line": 147,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-states.ts",
+            "systems/physics/physics-updates.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "setCppPhysicsInitialized",
+          "type": "function",
+          "line": 150,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "_scratchMatrix",
+          "type": "const",
+          "line": 154,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-updates.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "CorePlayerState",
+        "KeyStates",
+        "THREE"
+      ],
+      "unusedExports": [
+        {
+          "name": "GRAVITY",
+          "type": "const",
+          "line": 46,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 156
+        },
+        {
+          "name": "MOVE_ACCEL",
+          "type": "const",
+          "line": 53,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 156
+        },
+        {
+          "name": "PlayerStateType",
+          "type": "type",
+          "line": 64,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 156
+        },
+        {
+          "name": "_scratchHeadOffset",
+          "type": "const",
+          "line": 139,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 156
+        },
+        {
+          "name": "_scratchPos",
+          "type": "const",
+          "line": 140,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 156
+        },
+        {
+          "name": "_clapColor",
+          "type": "const",
+          "line": 141,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 156
+        }
+      ],
+      "treeShakingScore": 79
     },
     {
       "path": "compute/mesh_deformation_wasm.ts",
@@ -9008,6 +12221,537 @@
       "treeShakingScore": 17
     },
     {
+      "path": "core/hud.ts",
+      "exports": [
+        {
+          "name": "setInputSystem",
+          "type": "function",
+          "line": 68,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "updateTheme",
+          "type": "function",
+          "line": 72,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts",
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "toggleDayNight",
+          "type": "function",
+          "line": 102,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getIsNight",
+          "type": "function",
+          "line": 109,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "setIsNight",
+          "type": "function",
+          "line": 113,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getLastIsNight",
+          "type": "function",
+          "line": 117,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "setLastIsNight",
+          "type": "function",
+          "line": 121,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getLastStrikeState",
+          "type": "function",
+          "line": 125,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "setLastStrikeState",
+          "type": "function",
+          "line": 129,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "updateTrackerHUD",
+          "type": "function",
+          "line": 133,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 925
+        },
+        {
+          "name": "updateEnergyBar",
+          "type": "function",
+          "line": 149,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 925
+        },
+        {
+          "name": "updateDashHUD",
+          "type": "function",
+          "line": 194,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 925
+        },
+        {
+          "name": "updateMineHUD",
+          "type": "function",
+          "line": 235,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 925
+        },
+        {
+          "name": "updatePhaseHUD",
+          "type": "function",
+          "line": 272,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 925
+        },
+        {
+          "name": "updateHUD",
+          "type": "function",
+          "line": 350,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "unlockSystem",
+        "jitterMineSystem",
+        "CYCLE_DURATION",
+        "THREE"
+      ],
+      "unusedExports": [
+        {
+          "name": "updateTrackerHUD",
+          "type": "function",
+          "line": 133,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 925
+        },
+        {
+          "name": "updateEnergyBar",
+          "type": "function",
+          "line": 149,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 925
+        },
+        {
+          "name": "updateDashHUD",
+          "type": "function",
+          "line": 194,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 925
+        },
+        {
+          "name": "updateMineHUD",
+          "type": "function",
+          "line": 235,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 925
+        },
+        {
+          "name": "updatePhaseHUD",
+          "type": "function",
+          "line": 272,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 925
+        }
+      ],
+      "treeShakingScore": 67
+    },
+    {
+      "path": "foliage/index.ts",
+      "exports": [
+        {
+          "name": "applyGlitch",
+          "type": "const",
+          "line": 98,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/arpeggio-batcher.ts",
+            "foliage/material-core.ts",
+            "foliage/musical_flora.ts",
+            "foliage/tree-batcher.ts",
+            "gameplay/jitter-mines.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "updateFoliageMaterials",
+          "type": "const",
+          "line": 101,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createCrescendoFogNode",
+          "type": "const",
+          "line": 112,
+          "isUsed": true,
+          "usedIn": [
+            "core/init.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createSky",
+          "type": "const",
+          "line": 112,
+          "isUsed": true,
+          "usedIn": [
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createStars",
+          "type": "const",
+          "line": 113,
+          "isUsed": true,
+          "usedIn": [
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createMoon",
+          "type": "const",
+          "line": 114,
+          "isUsed": true,
+          "usedIn": [
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createMushroom",
+          "type": "const",
+          "line": 115,
+          "isUsed": true,
+          "usedIn": [
+            "core/deferred-init.ts",
+            "systems/weather/weather-ecosystem.ts",
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createSubwooferLotus",
+          "type": "const",
+          "line": 143,
+          "isUsed": true,
+          "usedIn": [
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createLuminousPlant",
+          "type": "const",
+          "line": 144,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 186
+        },
+        {
+          "name": "LuminousPlantBatcher",
+          "type": "const",
+          "line": 145,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/luminous-plant.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "luminousPlantBatcher",
+          "type": "const",
+          "line": 145,
+          "isUsed": true,
+          "usedIn": [
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createFloatingOrb",
+          "type": "const",
+          "line": 146,
+          "isUsed": true,
+          "usedIn": [
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createFloatingOrbCluster",
+          "type": "const",
+          "line": 146,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 186
+        },
+        {
+          "name": "createKickDrumGeyser",
+          "type": "const",
+          "line": 146,
+          "isUsed": true,
+          "usedIn": [
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createRainingCloud",
+          "type": "const",
+          "line": 147,
+          "isUsed": true,
+          "usedIn": [
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createWaveformWater",
+          "type": "const",
+          "line": 148,
+          "isUsed": true,
+          "usedIn": [
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createFireflies",
+          "type": "const",
+          "line": 149,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 186
+        },
+        {
+          "name": "initFallingBerries",
+          "type": "const",
+          "line": 150,
+          "isUsed": true,
+          "usedIn": [
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "initGrassSystem",
+          "type": "const",
+          "line": 151,
+          "isUsed": true,
+          "usedIn": [
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "addGrassInstance",
+          "type": "const",
+          "line": 151,
+          "isUsed": true,
+          "usedIn": [
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createWisteriaCluster",
+          "type": "const",
+          "line": 159,
+          "isUsed": true,
+          "usedIn": [
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createPanningPad",
+          "type": "const",
+          "line": 160,
+          "isUsed": true,
+          "usedIn": [
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createSilenceSpirit",
+          "type": "const",
+          "line": 161,
+          "isUsed": true,
+          "usedIn": [
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createInstrumentShrine",
+          "type": "const",
+          "line": 162,
+          "isUsed": true,
+          "usedIn": [
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createMelodyMirror",
+          "type": "const",
+          "line": 163,
+          "isUsed": true,
+          "usedIn": [
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createIsland",
+          "type": "const",
+          "line": 164,
+          "isUsed": true,
+          "usedIn": [
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createCaveEntrance",
+          "type": "const",
+          "line": 165,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 186
+        },
+        {
+          "name": "createNeonPollen",
+          "type": "const",
+          "line": 166,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 186
+        },
+        {
+          "name": "createTerrainMaterial",
+          "type": "const",
+          "line": 167,
+          "isUsed": true,
+          "usedIn": [
+            "rendering/shader-warmup.ts",
+            "world/generation.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [],
+      "unusedExports": [
+        {
+          "name": "createLuminousPlant",
+          "type": "const",
+          "line": 144,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 186
+        },
+        {
+          "name": "createFloatingOrbCluster",
+          "type": "const",
+          "line": 146,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 186
+        },
+        {
+          "name": "createFireflies",
+          "type": "const",
+          "line": 149,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 186
+        },
+        {
+          "name": "createCaveEntrance",
+          "type": "const",
+          "line": 165,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 186
+        },
+        {
+          "name": "createNeonPollen",
+          "type": "const",
+          "line": 166,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 186
+        }
+      ],
+      "treeShakingScore": 83
+    },
+    {
       "path": "foliage/musical_flora.ts",
       "exports": [
         {
@@ -9016,7 +12760,7 @@
           "line": 29,
           "isUsed": false,
           "usedIn": [],
-          "size": 1318
+          "size": 1349
         },
         {
           "name": "PortamentoPineOptions",
@@ -9024,7 +12768,7 @@
           "line": 34,
           "isUsed": false,
           "usedIn": [],
-          "size": 1318
+          "size": 1349
         },
         {
           "name": "CymbalDandelionOptions",
@@ -9032,7 +12776,7 @@
           "line": 38,
           "isUsed": false,
           "usedIn": [],
-          "size": 1318
+          "size": 1349
         },
         {
           "name": "SnareTrapOptions",
@@ -9040,7 +12784,7 @@
           "line": 42,
           "isUsed": false,
           "usedIn": [],
-          "size": 1318
+          "size": 1349
         },
         {
           "name": "RetriggerMushroomOptions",
@@ -9048,7 +12792,7 @@
           "line": 47,
           "isUsed": false,
           "usedIn": [],
-          "size": 1318
+          "size": 1349
         },
         {
           "name": "createArpeggioFern",
@@ -9073,7 +12817,7 @@
         {
           "name": "createRetriggerMushroom",
           "type": "function",
-          "line": 239,
+          "line": 242,
           "isUsed": true,
           "usedIn": [
             "world/generation.ts"
@@ -9083,7 +12827,7 @@
         {
           "name": "createPortamentoPine",
           "type": "function",
-          "line": 262,
+          "line": 265,
           "isUsed": true,
           "usedIn": [
             "world/generation.ts"
@@ -9093,7 +12837,7 @@
         {
           "name": "createCymbalDandelion",
           "type": "function",
-          "line": 331,
+          "line": 337,
           "isUsed": true,
           "usedIn": [
             "world/generation.ts"
@@ -9103,12 +12847,13 @@
         {
           "name": "makeInteractive",
           "type": "function",
-          "line": 387,
+          "line": 394,
           "isUsed": true,
           "usedIn": [
             "foliage/instrument.ts",
             "foliage/lotus.ts",
-            "foliage/wisteria-cluster.ts"
+            "foliage/wisteria-cluster.ts",
+            "world/generation.ts"
           ],
           "size": 0
         }
@@ -9156,7 +12901,7 @@
           "line": 29,
           "isUsed": false,
           "usedIn": [],
-          "size": 1318
+          "size": 1349
         },
         {
           "name": "PortamentoPineOptions",
@@ -9164,7 +12909,7 @@
           "line": 34,
           "isUsed": false,
           "usedIn": [],
-          "size": 1318
+          "size": 1349
         },
         {
           "name": "CymbalDandelionOptions",
@@ -9172,7 +12917,7 @@
           "line": 38,
           "isUsed": false,
           "usedIn": [],
-          "size": 1318
+          "size": 1349
         },
         {
           "name": "SnareTrapOptions",
@@ -9180,7 +12925,7 @@
           "line": 42,
           "isUsed": false,
           "usedIn": [],
-          "size": 1318
+          "size": 1349
         },
         {
           "name": "RetriggerMushroomOptions",
@@ -9188,131 +12933,127 @@
           "line": 47,
           "isUsed": false,
           "usedIn": [],
-          "size": 1318
+          "size": 1349
         }
       ],
       "treeShakingScore": 55
     },
     {
-      "path": "foliage/wind-compute.ts",
+      "path": "foliage/post-processing.ts",
       "exports": [
         {
-          "name": "WindConfig",
-          "type": "interface",
-          "line": 25,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2317
-        },
-        {
-          "name": "DEFAULT_WIND_CONFIG",
+          "name": "uBloomStrength",
           "type": "const",
-          "line": 43,
+          "line": 12,
           "isUsed": false,
           "usedIn": [],
-          "size": 2317
+          "size": 1181
         },
         {
-          "name": "WindComputeSystem",
-          "type": "class",
-          "line": 64,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2317
-        },
-        {
-          "name": "windComputeSystem",
+          "name": "uColorSaturation",
           "type": "const",
-          "line": 404,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/common.ts"
-          ],
-          "size": 0
+          "line": 13,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1181
         },
         {
-          "name": "getWindTextureData",
+          "name": "uColorContrast",
+          "type": "const",
+          "line": 14,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1181
+        },
+        {
+          "name": "uVignetteStrength",
+          "type": "const",
+          "line": 15,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1181
+        },
+        {
+          "name": "uAberrationStrength",
+          "type": "const",
+          "line": 16,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1181
+        },
+        {
+          "name": "initPostProcessing",
           "type": "function",
-          "line": 418,
+          "line": 33,
           "isUsed": true,
           "usedIn": [
-            "foliage/common.ts"
+            "core/main.ts"
           ],
           "size": 0
-        },
-        {
-          "name": "WindPerformanceProfiler",
-          "type": "class",
-          "line": 434,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2317
-        },
-        {
-          "name": "windProfiler",
-          "type": "const",
-          "line": 497,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2317
         }
       ],
       "imports": [
-        "DataTexture",
-        "Vector2",
-        "Vector4",
-        "RGBAFormat",
-        "FloatType",
-        "NearestFilter",
-        "RepeatWrapping",
-        "texture",
+        "PostProcessing",
+        "pass",
+        "mix",
+        "vec3",
+        "uniform",
+        "Fn",
+        "float",
         "uv",
-        "getWindTextureNode",
+        "vec2",
+        "distance",
+        "smoothstep",
+        "bloom",
+        "EffectComposer",
+        "RenderPass",
+        "UnrealBloomPass",
+        "isWebGPUMode",
         "THREE"
       ],
       "unusedExports": [
         {
-          "name": "WindConfig",
-          "type": "interface",
-          "line": 25,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2317
-        },
-        {
-          "name": "DEFAULT_WIND_CONFIG",
+          "name": "uBloomStrength",
           "type": "const",
-          "line": 43,
+          "line": 12,
           "isUsed": false,
           "usedIn": [],
-          "size": 2317
+          "size": 1181
         },
         {
-          "name": "WindComputeSystem",
-          "type": "class",
-          "line": 64,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2317
-        },
-        {
-          "name": "WindPerformanceProfiler",
-          "type": "class",
-          "line": 434,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2317
-        },
-        {
-          "name": "windProfiler",
+          "name": "uColorSaturation",
           "type": "const",
-          "line": 497,
+          "line": 13,
           "isUsed": false,
           "usedIn": [],
-          "size": 2317
+          "size": 1181
+        },
+        {
+          "name": "uColorContrast",
+          "type": "const",
+          "line": 14,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1181
+        },
+        {
+          "name": "uVignetteStrength",
+          "type": "const",
+          "line": 15,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1181
+        },
+        {
+          "name": "uAberrationStrength",
+          "type": "const",
+          "line": 16,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1181
         }
       ],
-      "treeShakingScore": 29
+      "treeShakingScore": 17
     },
     {
       "path": "particles/audio_reactive.ts",
@@ -9428,15 +13169,241 @@
       "treeShakingScore": 29
     },
     {
+      "path": "rendering/culling/culling-types.ts",
+      "exports": [
+        {
+          "name": "CullingGroup",
+          "type": "enum",
+          "line": 15,
+          "isUsed": true,
+          "usedIn": [
+            "rendering/culling/culling-system.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "EntityType",
+          "type": "enum",
+          "line": 25,
+          "isUsed": true,
+          "usedIn": [
+            "rendering/culling/culling-system.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "LODLevel",
+          "type": "enum",
+          "line": 39,
+          "isUsed": true,
+          "usedIn": [
+            "rendering/culling/culling-system.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "QualityTier",
+          "type": "enum",
+          "line": 47,
+          "isUsed": true,
+          "usedIn": [
+            "rendering/culling/culling-system.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "CullableObject",
+          "type": "interface",
+          "line": 59,
+          "isUsed": true,
+          "usedIn": [
+            "rendering/culling/culling-components.ts",
+            "rendering/culling/culling-system.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "CullingConfig",
+          "type": "interface",
+          "line": 77,
+          "isUsed": true,
+          "usedIn": [
+            "rendering/culling/culling-system.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "CullingStats",
+          "type": "interface",
+          "line": 103,
+          "isUsed": true,
+          "usedIn": [
+            "rendering/culling/culling-components.ts",
+            "rendering/culling/culling-system.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "LODLevelConfig",
+          "type": "interface",
+          "line": 125,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 536
+        },
+        {
+          "name": "SpatialHashConfig",
+          "type": "interface",
+          "line": 131,
+          "isUsed": true,
+          "usedIn": [
+            "rendering/culling/culling-components.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "OcclusionQueryConfig",
+          "type": "interface",
+          "line": 136,
+          "isUsed": true,
+          "usedIn": [
+            "rendering/culling/culling-components.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "DEFAULT_CULL_DISTANCES",
+          "type": "const",
+          "line": 146,
+          "isUsed": true,
+          "usedIn": [
+            "rendering/culling/culling-system.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "LOD_THRESHOLDS",
+          "type": "const",
+          "line": 160,
+          "isUsed": true,
+          "usedIn": [
+            "rendering/culling/culling-system.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "QUALITY_MULTIPLIERS",
+          "type": "const",
+          "line": 168,
+          "isUsed": true,
+          "usedIn": [
+            "rendering/culling/culling-system.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "DISTANCE_MULTIPLIERS",
+          "type": "const",
+          "line": 176,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 536
+        },
+        {
+          "name": "DEFAULT_CULLING_CONFIG",
+          "type": "const",
+          "line": 179,
+          "isUsed": true,
+          "usedIn": [
+            "rendering/culling/culling-system.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getDitherValue",
+          "type": "function",
+          "line": 198,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 536
+        },
+        {
+          "name": "createLODMeshes",
+          "type": "function",
+          "line": 205,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 536
+        },
+        {
+          "name": "simplifyGeometry",
+          "type": "function",
+          "line": 240,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 536
+        }
+      ],
+      "imports": [
+        "THREE"
+      ],
+      "unusedExports": [
+        {
+          "name": "LODLevelConfig",
+          "type": "interface",
+          "line": 125,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 536
+        },
+        {
+          "name": "DISTANCE_MULTIPLIERS",
+          "type": "const",
+          "line": 176,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 536
+        },
+        {
+          "name": "getDitherValue",
+          "type": "function",
+          "line": 198,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 536
+        },
+        {
+          "name": "createLODMeshes",
+          "type": "function",
+          "line": 205,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 536
+        },
+        {
+          "name": "simplifyGeometry",
+          "type": "function",
+          "line": 240,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 536
+        }
+      ],
+      "treeShakingScore": 72
+    },
+    {
       "path": "systems/physics.core.ts",
       "exports": [
         {
           "name": "PlayerState",
           "type": "interface",
           "line": 9,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 689
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-states.ts"
+          ],
+          "size": 0
         },
         {
           "name": "KeyStates",
@@ -9444,90 +13411,98 @@
           "line": 23,
           "isUsed": true,
           "usedIn": [
-            "systems/physics.ts"
+            "systems/physics/physics-abilities.ts",
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-states.ts",
+            "systems/physics/physics-types.ts",
+            "systems/physics/physics-updates.ts"
           ],
           "size": 0
         },
         {
           "name": "MovementInput",
           "type": "interface",
-          "line": 38,
+          "line": 39,
           "isUsed": false,
           "usedIn": [],
-          "size": 689
+          "size": 749
         },
         {
           "name": "LakeBounds",
           "type": "interface",
-          "line": 43,
+          "line": 44,
           "isUsed": false,
           "usedIn": [],
-          "size": 689
+          "size": 749
         },
         {
           "name": "LakeIslandConfig",
           "type": "interface",
-          "line": 50,
+          "line": 51,
           "isUsed": false,
           "usedIn": [],
-          "size": 689
+          "size": 749
         },
         {
           "name": "calculateMovementInput",
           "type": "function",
-          "line": 97,
+          "line": 101,
           "isUsed": true,
           "usedIn": [
-            "systems/physics.ts"
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-updates.ts"
           ],
           "size": 0
         },
         {
           "name": "isInLakeBasin",
           "type": "function",
-          "line": 141,
+          "line": 145,
           "isUsed": true,
           "usedIn": [
             "gameplay/rainbow-blaster.ts",
-            "systems/physics.ts"
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-updates.ts"
           ],
           "size": 0
         },
         {
           "name": "isOnLakeIsland",
           "type": "function",
-          "line": 154,
-          "isUsed": true,
-          "usedIn": [
-            "systems/physics.ts"
-          ],
-          "size": 0
+          "line": 158,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 749
         },
         {
           "name": "getUnifiedGroundHeightTyped",
           "type": "function",
-          "line": 168,
+          "line": 174,
           "isUsed": true,
           "usedIn": [
-            "systems/physics.ts"
+            "core/main.ts",
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-states.ts",
+            "systems/physics/physics-updates.ts",
+            "world/ground-heightmap.ts"
           ],
           "size": 0
         },
         {
           "name": "applyDamping",
           "type": "function",
-          "line": 224,
+          "line": 235,
           "isUsed": false,
           "usedIn": [],
-          "size": 689
+          "size": 749
         },
         {
           "name": "calculateWaterLevel",
           "type": "function",
-          "line": 237,
+          "line": 248,
           "isUsed": true,
           "usedIn": [
-            "systems/physics.ts"
+            "systems/physics/physics-states.ts"
           ],
           "size": 0
         }
@@ -9537,329 +13512,47 @@
       ],
       "unusedExports": [
         {
-          "name": "PlayerState",
-          "type": "interface",
-          "line": 9,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 689
-        },
-        {
           "name": "MovementInput",
           "type": "interface",
-          "line": 38,
+          "line": 39,
           "isUsed": false,
           "usedIn": [],
-          "size": 689
+          "size": 749
         },
         {
           "name": "LakeBounds",
           "type": "interface",
-          "line": 43,
+          "line": 44,
           "isUsed": false,
           "usedIn": [],
-          "size": 689
+          "size": 749
         },
         {
           "name": "LakeIslandConfig",
           "type": "interface",
-          "line": 50,
+          "line": 51,
           "isUsed": false,
           "usedIn": [],
-          "size": 689
+          "size": 749
+        },
+        {
+          "name": "isOnLakeIsland",
+          "type": "function",
+          "line": 158,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 749
         },
         {
           "name": "applyDamping",
           "type": "function",
-          "line": 224,
+          "line": 235,
           "isUsed": false,
           "usedIn": [],
-          "size": 689
+          "size": 749
         }
       ],
       "treeShakingScore": 55
-    },
-    {
-      "path": "systems/save-system.ts",
-      "exports": [
-        {
-          "name": "SerializableVector3",
-          "type": "interface",
-          "line": 42,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2884
-        },
-        {
-          "name": "PlayerSaveData",
-          "type": "interface",
-          "line": 51,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2884
-        },
-        {
-          "name": "WorldSaveData",
-          "type": "interface",
-          "line": 68,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2884
-        },
-        {
-          "name": "ProgressSaveData",
-          "type": "interface",
-          "line": 81,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2884
-        },
-        {
-          "name": "KeyBindings",
-          "type": "interface",
-          "line": 93,
-          "isUsed": true,
-          "usedIn": [
-            "ui/save-menu.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "SettingsSaveData",
-          "type": "interface",
-          "line": 109,
-          "isUsed": true,
-          "usedIn": [
-            "ui/save-menu.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "SaveMetadata",
-          "type": "interface",
-          "line": 125,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2884
-        },
-        {
-          "name": "SaveData",
-          "type": "interface",
-          "line": 138,
-          "isUsed": true,
-          "usedIn": [
-            "systems/save-integration-example.ts",
-            "ui/save-menu.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "SaveSlotInfo",
-          "type": "interface",
-          "line": 149,
-          "isUsed": true,
-          "usedIn": [
-            "ui/save-menu.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "createPlayerSaveData",
-          "type": "function",
-          "line": 1112,
-          "isUsed": true,
-          "usedIn": [
-            "systems/save-integration-example.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "createWorldSaveData",
-          "type": "function",
-          "line": 1145,
-          "isUsed": true,
-          "usedIn": [
-            "systems/save-integration-example.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "createProgressSaveData",
-          "type": "function",
-          "line": 1172,
-          "isUsed": true,
-          "usedIn": [
-            "systems/save-integration-example.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "saveSystem",
-          "type": "const",
-          "line": 1193,
-          "isUsed": true,
-          "usedIn": [
-            "systems/save-integration-example.ts",
-            "ui/save-menu.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "default",
-          "type": "function",
-          "line": 1260,
-          "isUsed": true,
-          "usedIn": [
-            "world/generation.ts"
-          ],
-          "size": 0
-        }
-      ],
-      "imports": [
-        "showToast"
-      ],
-      "unusedExports": [
-        {
-          "name": "SerializableVector3",
-          "type": "interface",
-          "line": 42,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2884
-        },
-        {
-          "name": "PlayerSaveData",
-          "type": "interface",
-          "line": 51,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2884
-        },
-        {
-          "name": "WorldSaveData",
-          "type": "interface",
-          "line": 68,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2884
-        },
-        {
-          "name": "ProgressSaveData",
-          "type": "interface",
-          "line": 81,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2884
-        },
-        {
-          "name": "SaveMetadata",
-          "type": "interface",
-          "line": 125,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2884
-        }
-      ],
-      "treeShakingScore": 64
-    },
-    {
-      "path": "ui/accessibility-menu.ts",
-      "exports": [
-        {
-          "name": "AccessibilityMenu",
-          "type": "class",
-          "line": 55,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 8205
-        },
-        {
-          "name": "openAccessibilityMenu",
-          "type": "function",
-          "line": 1170,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 8205
-        },
-        {
-          "name": "closeAccessibilityMenu",
-          "type": "function",
-          "line": 1177,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 8205
-        },
-        {
-          "name": "createAccessibilityButton",
-          "type": "function",
-          "line": 1181,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 8205
-        },
-        {
-          "name": "addAccessibilityButtonToPage",
-          "type": "function",
-          "line": 1216,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 8205
-        }
-      ],
-      "imports": [
-        "AccessibilitySystem",
-        "accessibilityPresets",
-        "getAccessibilitySystem",
-        "ColorBlindType",
-        "UIScale",
-        "VerbosityLevel",
-        "CrosshairStyle",
-        "announce",
-        "announceValueChange"
-      ],
-      "unusedExports": [
-        {
-          "name": "AccessibilityMenu",
-          "type": "class",
-          "line": 55,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 8205
-        },
-        {
-          "name": "openAccessibilityMenu",
-          "type": "function",
-          "line": 1170,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 8205
-        },
-        {
-          "name": "closeAccessibilityMenu",
-          "type": "function",
-          "line": 1177,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 8205
-        },
-        {
-          "name": "createAccessibilityButton",
-          "type": "function",
-          "line": 1181,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 8205
-        },
-        {
-          "name": "addAccessibilityButtonToPage",
-          "type": "function",
-          "line": 1216,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 8205
-        }
-      ],
-      "treeShakingScore": 0
     },
     {
       "path": "ui/analytics-debug.ts",
@@ -9867,49 +13560,52 @@
         {
           "name": "analyticsDebug",
           "type": "const",
-          "line": 883,
+          "line": 950,
           "isUsed": false,
           "usedIn": [],
-          "size": 4484
+          "size": 5003
         },
         {
           "name": "toggleAnalyticsDebug",
           "type": "function",
-          "line": 892,
+          "line": 959,
           "isUsed": false,
           "usedIn": [],
-          "size": 4484
+          "size": 5003
         },
         {
           "name": "showAnalyticsDebug",
           "type": "function",
-          "line": 899,
+          "line": 966,
           "isUsed": false,
           "usedIn": [],
-          "size": 4484
+          "size": 5003
         },
         {
           "name": "hideAnalyticsDebug",
           "type": "function",
-          "line": 906,
+          "line": 973,
           "isUsed": false,
           "usedIn": [],
-          "size": 4484
+          "size": 5003
         },
         {
           "name": "registerStatsCommand",
           "type": "function",
-          "line": 917,
+          "line": 984,
           "isUsed": false,
           "usedIn": [],
-          "size": 4484
+          "size": 5003
         },
         {
           "name": "default",
           "type": "function",
-          "line": 956,
+          "line": 1023,
           "isUsed": true,
           "usedIn": [
+            "core/init.ts",
+            "systems/music-reactivity.ts",
+            "utils/wasm-loader-core.ts",
             "world/generation.ts"
           ],
           "size": 0
@@ -9917,318 +13613,149 @@
       ],
       "imports": [
         "analytics",
-        "trackEvent"
+        "trackEvent",
+        "trapFocusInside"
       ],
       "unusedExports": [
         {
           "name": "analyticsDebug",
           "type": "const",
-          "line": 883,
+          "line": 950,
           "isUsed": false,
           "usedIn": [],
-          "size": 4484
+          "size": 5003
         },
         {
           "name": "toggleAnalyticsDebug",
           "type": "function",
-          "line": 892,
+          "line": 959,
           "isUsed": false,
           "usedIn": [],
-          "size": 4484
+          "size": 5003
         },
         {
           "name": "showAnalyticsDebug",
           "type": "function",
-          "line": 899,
+          "line": 966,
           "isUsed": false,
           "usedIn": [],
-          "size": 4484
+          "size": 5003
         },
         {
           "name": "hideAnalyticsDebug",
           "type": "function",
-          "line": 906,
+          "line": 973,
           "isUsed": false,
           "usedIn": [],
-          "size": 4484
+          "size": 5003
         },
         {
           "name": "registerStatsCommand",
           "type": "function",
-          "line": 917,
+          "line": 984,
           "isUsed": false,
           "usedIn": [],
-          "size": 4484
+          "size": 5003
         }
       ],
       "treeShakingScore": 17
     },
     {
-      "path": "ui/save-menu.ts",
+      "path": "compute/mesh-deformation-gpu.ts",
       "exports": [
         {
-          "name": "SaveMenu",
+          "name": "MeshDeformationGPUConfig",
+          "type": "interface",
+          "line": 42,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2120
+        },
+        {
+          "name": "MeshDeformationGPU",
           "type": "class",
-          "line": 612,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 6126
-        },
-        {
-          "name": "openSaveMenu",
-          "type": "function",
-          "line": 1425,
+          "line": 76,
           "isUsed": true,
           "usedIn": [
-            "systems/save-integration-example.ts"
+            "compute/mesh-deformation-gpu.ts"
           ],
           "size": 0
         },
         {
-          "name": "openLoadMenu",
+          "name": "createGPUWaveDeformation",
           "type": "function",
-          "line": 1439,
-          "isUsed": true,
-          "usedIn": [
-            "systems/save-integration-example.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "openSaveGameMenu",
-          "type": "function",
-          "line": 1446,
+          "line": 270,
           "isUsed": false,
           "usedIn": [],
-          "size": 6126
+          "size": 2120
         },
         {
-          "name": "closeSaveMenu",
+          "name": "createGPUJiggleDeformation",
           "type": "function",
-          "line": 1453,
+          "line": 285,
           "isUsed": false,
           "usedIn": [],
-          "size": 6126
+          "size": 2120
         },
         {
-          "name": "isSaveMenuOpen",
+          "name": "createGPUWobbleDeformation",
           "type": "function",
-          "line": 1461,
+          "line": 299,
           "isUsed": false,
           "usedIn": [],
-          "size": 6126
-        },
-        {
-          "name": "showSaveIndicator",
-          "type": "function",
-          "line": 1472,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 6126
-        },
-        {
-          "name": "default",
-          "type": "function",
-          "line": 1537,
-          "isUsed": true,
-          "usedIn": [
-            "world/generation.ts"
-          ],
-          "size": 0
+          "size": 2120
         }
       ],
       "imports": [
-        "saveSystem",
-        "SaveData",
-        "SaveSlotInfo",
-        "SettingsSaveData",
-        "KeyBindings",
-        "showToast"
-      ],
-      "unusedExports": [
-        {
-          "name": "SaveMenu",
-          "type": "class",
-          "line": 612,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 6126
-        },
-        {
-          "name": "openSaveGameMenu",
-          "type": "function",
-          "line": 1446,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 6126
-        },
-        {
-          "name": "closeSaveMenu",
-          "type": "function",
-          "line": 1453,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 6126
-        },
-        {
-          "name": "isSaveMenuOpen",
-          "type": "function",
-          "line": 1461,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 6126
-        },
-        {
-          "name": "showSaveIndicator",
-          "type": "function",
-          "line": 1472,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 6126
-        }
-      ],
-      "treeShakingScore": 38
-    },
-    {
-      "path": "utils/startup-profiler.ts",
-      "exports": [
-        {
-          "name": "startPhase",
-          "type": "function",
-          "line": 311,
-          "isUsed": true,
-          "usedIn": [
-            "main.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "endPhase",
-          "type": "function",
-          "line": 326,
-          "isUsed": true,
-          "usedIn": [
-            "main.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "recordWASMInit",
-          "type": "function",
-          "line": 353,
-          "isUsed": true,
-          "usedIn": [
-            "main.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "recordTSLCompile",
-          "type": "function",
-          "line": 361,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2844
-        },
-        {
-          "name": "enableStartupProfiler",
-          "type": "function",
-          "line": 793,
-          "isUsed": true,
-          "usedIn": [
-            "main.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "disableStartupProfiler",
-          "type": "function",
-          "line": 853,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2844
-        },
-        {
-          "name": "finalizeStartupProfile",
-          "type": "function",
-          "line": 873,
-          "isUsed": true,
-          "usedIn": [
-            "main.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "toggleOverlay",
-          "type": "function",
-          "line": 901,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2844
-        },
-        {
-          "name": "getProfilerStatus",
-          "type": "function",
-          "line": 912,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2844
-        },
-        {
-          "name": "recordCustomPhase",
-          "type": "function",
-          "line": 930,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2844
-        }
-      ],
-      "imports": [
+        "MeshDeformationGPU",
+        "MeshDeformationCompute",
+        "GPUComputeLibrary",
+        "getSharedGPUCompute",
+        "DeformationType",
+        "DeformationTypeValue",
+        "DeformationAudioState",
+        "MESH_DEFORM_WAVE_WGSL",
+        "MESH_DEFORM_JIGGLE_WGSL",
+        "MESH_DEFORM_WOBBLE_WGSL",
+        "NORMAL_RECOMPUTE_WGSL",
+        "NORMAL_NORMALIZE_WGSL",
         "THREE"
       ],
       "unusedExports": [
         {
-          "name": "recordTSLCompile",
-          "type": "function",
-          "line": 361,
+          "name": "MeshDeformationGPUConfig",
+          "type": "interface",
+          "line": 42,
           "isUsed": false,
           "usedIn": [],
-          "size": 2844
+          "size": 2120
         },
         {
-          "name": "disableStartupProfiler",
+          "name": "createGPUWaveDeformation",
           "type": "function",
-          "line": 853,
+          "line": 270,
           "isUsed": false,
           "usedIn": [],
-          "size": 2844
+          "size": 2120
         },
         {
-          "name": "toggleOverlay",
+          "name": "createGPUJiggleDeformation",
           "type": "function",
-          "line": 901,
+          "line": 285,
           "isUsed": false,
           "usedIn": [],
-          "size": 2844
+          "size": 2120
         },
         {
-          "name": "getProfilerStatus",
+          "name": "createGPUWobbleDeformation",
           "type": "function",
-          "line": 912,
+          "line": 299,
           "isUsed": false,
           "usedIn": [],
-          "size": 2844
-        },
-        {
-          "name": "recordCustomPhase",
-          "type": "function",
-          "line": 930,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 2844
+          "size": 2120
         }
       ],
-      "treeShakingScore": 50
+      "treeShakingScore": 20
     },
     {
       "path": "compute/mesh_deformation.ts",
@@ -10239,6 +13766,7 @@
           "line": 29,
           "isUsed": true,
           "usedIn": [
+            "compute/mesh-deformation-gpu.ts",
             "compute/mesh_deformation_wasm.ts"
           ],
           "size": 0
@@ -10249,6 +13777,7 @@
           "line": 38,
           "isUsed": true,
           "usedIn": [
+            "compute/mesh-deformation-gpu.ts",
             "compute/mesh_deformation_wasm.ts"
           ],
           "size": 0
@@ -10267,6 +13796,7 @@
           "line": 62,
           "isUsed": true,
           "usedIn": [
+            "compute/mesh-deformation-gpu.ts",
             "compute/mesh_deformation_wasm.ts"
           ],
           "size": 0
@@ -10277,6 +13807,7 @@
           "line": 73,
           "isUsed": true,
           "usedIn": [
+            "compute/mesh-deformation-gpu.ts",
             "compute/mesh_deformation.ts",
             "compute/mesh_deformation_wasm.ts"
           ],
@@ -10359,7 +13890,7 @@
           "line": 9,
           "isUsed": false,
           "usedIn": [],
-          "size": 1112
+          "size": 1060
         },
         {
           "name": "lerpPalette",
@@ -10367,7 +13898,7 @@
           "line": 21,
           "isUsed": false,
           "usedIn": [],
-          "size": 1112
+          "size": 1060
         },
         {
           "name": "getCycleState",
@@ -10375,7 +13906,7 @@
           "line": 35,
           "isUsed": true,
           "usedIn": [
-            "main.ts"
+            "core/game-loop.ts"
           ],
           "size": 0
         },
@@ -10390,20 +13921,30 @@
           "size": 0
         },
         {
+          "name": "getDayNightBias",
+          "type": "function",
+          "line": 151,
+          "isUsed": true,
+          "usedIn": [
+            "systems/music-reactivity.ts"
+          ],
+          "size": 0
+        },
+        {
           "name": "SeasonalState",
           "type": "interface",
-          "line": 149,
+          "line": 170,
           "isUsed": false,
           "usedIn": [],
-          "size": 1112
+          "size": 1060
         },
         {
           "name": "getSeasonalState",
           "type": "function",
-          "line": 156,
+          "line": 177,
           "isUsed": false,
           "usedIn": [],
-          "size": 1112
+          "size": 1060
         }
       ],
       "imports": [
@@ -10425,7 +13966,7 @@
           "line": 9,
           "isUsed": false,
           "usedIn": [],
-          "size": 1112
+          "size": 1060
         },
         {
           "name": "lerpPalette",
@@ -10433,26 +13974,206 @@
           "line": 21,
           "isUsed": false,
           "usedIn": [],
-          "size": 1112
+          "size": 1060
         },
         {
           "name": "SeasonalState",
           "type": "interface",
-          "line": 149,
+          "line": 170,
           "isUsed": false,
           "usedIn": [],
-          "size": 1112
+          "size": 1060
         },
         {
           "name": "getSeasonalState",
           "type": "function",
-          "line": 156,
+          "line": 177,
           "isUsed": false,
           "usedIn": [],
-          "size": 1112
+          "size": 1060
         }
       ],
-      "treeShakingScore": 33
+      "treeShakingScore": 43
+    },
+    {
+      "path": "core/input/playlist-manager.ts",
+      "exports": [
+        {
+          "name": "initPlaylistManager",
+          "type": "function",
+          "line": 38,
+          "isUsed": true,
+          "usedIn": [
+            "core/input/input.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getIsPlaylistOpen",
+          "type": "function",
+          "line": 233,
+          "isUsed": true,
+          "usedIn": [
+            "core/input/input.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "setIsPlaylistOpen",
+          "type": "function",
+          "line": 240,
+          "isUsed": true,
+          "usedIn": [
+            "core/input/input.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "closePlaylist",
+          "type": "function",
+          "line": 247,
+          "isUsed": true,
+          "usedIn": [
+            "core/input/input.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getReleaseJukeboxFocus",
+          "type": "function",
+          "line": 256,
+          "isUsed": true,
+          "usedIn": [
+            "core/input/input.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "setReleaseJukeboxFocus",
+          "type": "function",
+          "line": 263,
+          "isUsed": true,
+          "usedIn": [
+            "core/input/input.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "renderPlaylist",
+          "type": "function",
+          "line": 270,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1712
+        },
+        {
+          "name": "updateJukeboxButtonState",
+          "type": "function",
+          "line": 403,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1712
+        },
+        {
+          "name": "togglePlaylist",
+          "type": "function",
+          "line": 415,
+          "isUsed": true,
+          "usedIn": [
+            "core/input/input.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getWasPausedBeforePlaylist",
+          "type": "function",
+          "line": 510,
+          "isUsed": true,
+          "usedIn": [
+            "core/input/input.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "setWasPausedBeforePlaylist",
+          "type": "function",
+          "line": 517,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1712
+        },
+        {
+          "name": "getLastFocusedElement",
+          "type": "function",
+          "line": 524,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1712
+        },
+        {
+          "name": "handlePlaylistKeyDown",
+          "type": "function",
+          "line": 532,
+          "isUsed": true,
+          "usedIn": [
+            "core/input/input.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "initLegacyMusicUpload",
+          "type": "function",
+          "line": 606,
+          "isUsed": true,
+          "usedIn": [
+            "core/input/input.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "AudioSystem",
+        "PointerLockControls",
+        "trapFocusInside",
+        "formatSongTitle",
+        "filterValidMusicFiles",
+        "announce"
+      ],
+      "unusedExports": [
+        {
+          "name": "renderPlaylist",
+          "type": "function",
+          "line": 270,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1712
+        },
+        {
+          "name": "updateJukeboxButtonState",
+          "type": "function",
+          "line": 403,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1712
+        },
+        {
+          "name": "setWasPausedBeforePlaylist",
+          "type": "function",
+          "line": 517,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1712
+        },
+        {
+          "name": "getLastFocusedElement",
+          "type": "function",
+          "line": 524,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1712
+        }
+      ],
+      "treeShakingScore": 71
     },
     {
       "path": "foliage/environment.ts",
@@ -10460,31 +14181,31 @@
         {
           "name": "FloatingOrbOptions",
           "type": "interface",
-          "line": 7,
+          "line": 15,
           "isUsed": false,
           "usedIn": [],
-          "size": 1445
+          "size": 1677
         },
         {
           "name": "KickDrumGeyserOptions",
           "type": "interface",
-          "line": 12,
+          "line": 20,
           "isUsed": false,
           "usedIn": [],
-          "size": 1445
+          "size": 1677
         },
         {
           "name": "createMelodyLake",
           "type": "function",
-          "line": 17,
+          "line": 25,
           "isUsed": false,
           "usedIn": [],
-          "size": 1445
+          "size": 1677
         },
         {
           "name": "createFloatingOrb",
           "type": "function",
-          "line": 84,
+          "line": 92,
           "isUsed": true,
           "usedIn": [
             "world/generation.ts"
@@ -10494,15 +14215,15 @@
         {
           "name": "createFloatingOrbCluster",
           "type": "function",
-          "line": 131,
+          "line": 149,
           "isUsed": false,
           "usedIn": [],
-          "size": 1445
+          "size": 1677
         },
         {
           "name": "createKickDrumGeyser",
           "type": "function",
-          "line": 142,
+          "line": 160,
           "isUsed": true,
           "usedIn": [
             "world/generation.ts"
@@ -10515,6 +14236,7 @@
         "PointsNodeMaterial",
         "time",
         "vec3",
+        "vec4",
         "positionLocal",
         "length",
         "sin",
@@ -10527,6 +14249,8 @@
         "smoothstep",
         "color",
         "positionWorld",
+        "normalWorld",
+        "floor",
         "registerReactiveMaterial",
         "attachReactivity",
         "CandyPresets",
@@ -10534,6 +14258,7 @@
         "uAudioLow",
         "uAudioHigh",
         "createJuicyRimLight",
+        "createSugarSparkle",
         "uTwilight",
         "uHorizonColor",
         "THREE"
@@ -10542,34 +14267,34 @@
         {
           "name": "FloatingOrbOptions",
           "type": "interface",
-          "line": 7,
+          "line": 15,
           "isUsed": false,
           "usedIn": [],
-          "size": 1445
+          "size": 1677
         },
         {
           "name": "KickDrumGeyserOptions",
           "type": "interface",
-          "line": 12,
+          "line": 20,
           "isUsed": false,
           "usedIn": [],
-          "size": 1445
+          "size": 1677
         },
         {
           "name": "createMelodyLake",
           "type": "function",
-          "line": 17,
+          "line": 25,
           "isUsed": false,
           "usedIn": [],
-          "size": 1445
+          "size": 1677
         },
         {
           "name": "createFloatingOrbCluster",
           "type": "function",
-          "line": 131,
+          "line": 149,
           "isUsed": false,
           "usedIn": [],
-          "size": 1445
+          "size": 1677
         }
       ],
       "treeShakingScore": 33
@@ -10583,7 +14308,7 @@
           "line": 9,
           "isUsed": false,
           "usedIn": [],
-          "size": 1341
+          "size": 1404
         },
         {
           "name": "MUSHROOM_NOTES",
@@ -10591,7 +14316,7 @@
           "line": 17,
           "isUsed": false,
           "usedIn": [],
-          "size": 1341
+          "size": 1404
         },
         {
           "name": "getMaterialCacheSize",
@@ -10599,7 +14324,7 @@
           "line": 33,
           "isUsed": false,
           "usedIn": [],
-          "size": 1341
+          "size": 1404
         },
         {
           "name": "MushroomOptions",
@@ -10607,7 +14332,7 @@
           "line": 37,
           "isUsed": false,
           "usedIn": [],
-          "size": 1341
+          "size": 1404
         },
         {
           "name": "createMushroom",
@@ -10615,8 +14340,8 @@
           "line": 49,
           "isUsed": true,
           "usedIn": [
-            "main.ts",
-            "systems/weather.ts",
+            "core/deferred-init.ts",
+            "systems/weather/weather-ecosystem.ts",
             "world/generation.ts"
           ],
           "size": 0
@@ -10627,7 +14352,7 @@
           "line": 176,
           "isUsed": true,
           "usedIn": [
-            "systems/weather.ts"
+            "systems/weather/weather-ecosystem.ts"
           ],
           "size": 0
         }
@@ -10645,7 +14370,7 @@
           "line": 9,
           "isUsed": false,
           "usedIn": [],
-          "size": 1341
+          "size": 1404
         },
         {
           "name": "MUSHROOM_NOTES",
@@ -10653,7 +14378,7 @@
           "line": 17,
           "isUsed": false,
           "usedIn": [],
-          "size": 1341
+          "size": 1404
         },
         {
           "name": "getMaterialCacheSize",
@@ -10661,7 +14386,7 @@
           "line": 33,
           "isUsed": false,
           "usedIn": [],
-          "size": 1341
+          "size": 1404
         },
         {
           "name": "MushroomOptions",
@@ -10669,189 +14394,498 @@
           "line": 37,
           "isUsed": false,
           "usedIn": [],
-          "size": 1341
+          "size": 1404
         }
       ],
       "treeShakingScore": 33
     },
     {
-      "path": "systems/physics.ts",
+      "path": "systems/loading-manager.ts",
       "exports": [
         {
-          "name": "AudioState",
+          "name": "LoadingTaskOptions",
           "type": "interface",
-          "line": 38,
+          "line": 10,
           "isUsed": false,
           "usedIn": [],
-          "size": 5010
+          "size": 1235
         },
         {
-          "name": "PlayerExtended",
+          "name": "TaskState",
           "type": "interface",
-          "line": 45,
+          "line": 19,
           "isUsed": true,
           "usedIn": [
-            "systems/save-integration-example.ts"
+            "ui/loading-screen.ts"
           ],
           "size": 0
         },
         {
-          "name": "PlayerState",
-          "type": "const",
-          "line": 73,
+          "name": "GlobalProgressState",
+          "type": "interface",
+          "line": 33,
+          "isUsed": true,
+          "usedIn": [
+            "ui/loading-screen.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "ProgressCallback",
+          "type": "type",
+          "line": 41,
           "isUsed": false,
           "usedIn": [],
-          "size": 5010
+          "size": 1235
         },
         {
-          "name": "player",
-          "type": "const",
-          "line": 82,
-          "isUsed": true,
-          "usedIn": [
-            "main.ts",
-            "systems/save-integration-example.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "bpmWind",
-          "type": "const",
-          "line": 125,
+          "name": "PhaseChangeCallback",
+          "type": "type",
+          "line": 42,
           "isUsed": false,
           "usedIn": [],
-          "size": 5010
+          "size": 1235
         },
         {
-          "name": "grooveGravity",
-          "type": "const",
-          "line": 132,
+          "name": "LoadingManager",
+          "type": "class",
+          "line": 44,
           "isUsed": false,
           "usedIn": [],
-          "size": 5010
+          "size": 1235
         },
         {
-          "name": "grantInvisibility",
-          "type": "function",
-          "line": 160,
+          "name": "globalLoadingManager",
+          "type": "const",
+          "line": 287,
           "isUsed": true,
           "usedIn": [
-            "foliage/silence-spirits.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "registerPhysicsCave",
-          "type": "function",
-          "line": 169,
-          "isUsed": true,
-          "usedIn": [
-            "world/generation.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "triggerHarpoon",
-          "type": "function",
-          "line": 173,
-          "isUsed": true,
-          "usedIn": [
-            "gameplay/rainbow-blaster.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "updatePhysics",
-          "type": "function",
-          "line": 184,
-          "isUsed": true,
-          "usedIn": [
-            "main.ts"
+            "ui/loading-screen.ts"
           ],
           "size": 0
         }
       ],
       "imports": [
-        "getGroundHeight",
-        "initPhysics",
-        "addObstacle",
-        "uploadObstaclesBatch",
-        "setPlayerState",
-        "getPlayerState",
-        "updatePhysicsCPP",
-        "uploadCollisionObjects",
-        "resolveGameCollisionsWASM",
-        "foliageMushrooms",
-        "foliageTrampolines",
-        "foliageClouds",
-        "foliagePanningPads",
-        "foliageGeysers",
-        "foliageTraps",
-        "foliagePortamentoPines",
-        "activeVineSwing",
-        "setActiveVineSwing",
-        "lastVineDetachTime",
-        "setLastVineDetachTime",
-        "vineSwings",
-        "animatedFoliage",
-        "discoverySystem",
-        "DISCOVERY_MAP",
-        "optimizedDiscovery",
-        "checkPlayerDiscovery",
-        "calculateMovementInput",
-        "isInLakeBasin",
-        "isOnLakeIsland",
-        "getUnifiedGroundHeightTyped",
-        "calculateWaterLevel",
-        "CorePlayerState",
-        "KeyStates",
-        "uChromaticIntensity",
-        "uStrobeIntensity",
-        "uGlitchExplosionCenter",
-        "uGlitchExplosionRadius",
-        "spawnImpact",
-        "VineSwing",
-        "unlockSystem",
-        "showToast",
-        "dandelionBatcher",
-        "spawnDandelionExplosion",
-        "THREE"
+        "DEFAULT_LOADING_PHASES"
       ],
       "unusedExports": [
         {
-          "name": "AudioState",
+          "name": "LoadingTaskOptions",
           "type": "interface",
-          "line": 38,
+          "line": 10,
           "isUsed": false,
           "usedIn": [],
-          "size": 5010
+          "size": 1235
         },
         {
-          "name": "PlayerState",
-          "type": "const",
-          "line": 73,
+          "name": "ProgressCallback",
+          "type": "type",
+          "line": 41,
           "isUsed": false,
           "usedIn": [],
-          "size": 5010
+          "size": 1235
         },
         {
-          "name": "bpmWind",
-          "type": "const",
-          "line": 125,
+          "name": "PhaseChangeCallback",
+          "type": "type",
+          "line": 42,
           "isUsed": false,
           "usedIn": [],
-          "size": 5010
+          "size": 1235
         },
         {
-          "name": "grooveGravity",
-          "type": "const",
-          "line": 132,
+          "name": "LoadingManager",
+          "type": "class",
+          "line": 44,
           "isUsed": false,
           "usedIn": [],
-          "size": 5010
+          "size": 1235
         }
       ],
-      "treeShakingScore": 60
+      "treeShakingScore": 43
+    },
+    {
+      "path": "systems/save-system/save-types.ts",
+      "exports": [
+        {
+          "name": "SAVE_VERSION",
+          "type": "const",
+          "line": 9,
+          "isUsed": true,
+          "usedIn": [
+            "systems/save-system/save-database.ts",
+            "systems/save-system/save-system.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "DB_NAME",
+          "type": "const",
+          "line": 10,
+          "isUsed": true,
+          "usedIn": [
+            "systems/save-system/save-database.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "DB_VERSION",
+          "type": "const",
+          "line": 11,
+          "isUsed": true,
+          "usedIn": [
+            "systems/save-system/save-database.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "STORE_NAME",
+          "type": "const",
+          "line": 12,
+          "isUsed": true,
+          "usedIn": [
+            "systems/save-system/save-database.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "AUTO_SAVE_INTERVAL",
+          "type": "const",
+          "line": 14,
+          "isUsed": true,
+          "usedIn": [
+            "systems/save-system/save-system.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "AUTO_SAVE_SLOTS",
+          "type": "const",
+          "line": 15,
+          "isUsed": true,
+          "usedIn": [
+            "systems/save-system/save-system.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "MANUAL_SAVE_SLOTS",
+          "type": "const",
+          "line": 16,
+          "isUsed": true,
+          "usedIn": [
+            "systems/save-system/save-system.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "LOCALSTORAGE_KEY_SETTINGS",
+          "type": "const",
+          "line": 18,
+          "isUsed": true,
+          "usedIn": [
+            "systems/save-system/save-system.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "LOCALSTORAGE_KEY_METADATA",
+          "type": "const",
+          "line": 19,
+          "isUsed": true,
+          "usedIn": [
+            "systems/save-system/save-system.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "COMPRESSION_THRESHOLD",
+          "type": "const",
+          "line": 22,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 176
+        },
+        {
+          "name": "SerializableVector3",
+          "type": "interface",
+          "line": 31,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 176
+        },
+        {
+          "name": "PlayerSaveData",
+          "type": "interface",
+          "line": 40,
+          "isUsed": true,
+          "usedIn": [
+            "systems/save-system/save-system.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "WorldSaveData",
+          "type": "interface",
+          "line": 57,
+          "isUsed": true,
+          "usedIn": [
+            "systems/save-system/save-system.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "ProgressSaveData",
+          "type": "interface",
+          "line": 70,
+          "isUsed": true,
+          "usedIn": [
+            "systems/save-system/save-system.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "KeyBindings",
+          "type": "interface",
+          "line": 82,
+          "isUsed": true,
+          "usedIn": [
+            "ui/save-menu/save-menu.ts",
+            "ui/save-menu/save-settings.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "SettingsSaveData",
+          "type": "interface",
+          "line": 98,
+          "isUsed": true,
+          "usedIn": [
+            "systems/save-system/save-database.ts",
+            "systems/save-system/save-system.ts",
+            "ui/save-menu/save-menu.ts",
+            "ui/save-menu/save-settings.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "SaveMetadata",
+          "type": "interface",
+          "line": 114,
+          "isUsed": true,
+          "usedIn": [
+            "systems/save-system/save-system.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "SaveData",
+          "type": "interface",
+          "line": 127,
+          "isUsed": true,
+          "usedIn": [
+            "systems/save-integration-example.ts",
+            "systems/save-system/save-database.ts",
+            "systems/save-system/save-system.ts",
+            "ui/save-menu/save-menu.ts",
+            "ui/save-menu/save-slots.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "SaveSlotInfo",
+          "type": "interface",
+          "line": 138,
+          "isUsed": true,
+          "usedIn": [
+            "systems/save-system/save-database.ts",
+            "systems/save-system/save-system.ts",
+            "ui/save-menu/save-menu.ts",
+            "ui/save-menu/save-slots.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "SessionMetadata",
+          "type": "interface",
+          "line": 151,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 176
+        },
+        {
+          "name": "UnlockSaveData",
+          "type": "interface",
+          "line": 160,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 176
+        },
+        {
+          "name": "MigrationFunction",
+          "type": "type",
+          "line": 169,
+          "isUsed": true,
+          "usedIn": [
+            "systems/save-system/save-database.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [],
+      "unusedExports": [
+        {
+          "name": "COMPRESSION_THRESHOLD",
+          "type": "const",
+          "line": 22,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 176
+        },
+        {
+          "name": "SerializableVector3",
+          "type": "interface",
+          "line": 31,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 176
+        },
+        {
+          "name": "SessionMetadata",
+          "type": "interface",
+          "line": 151,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 176
+        },
+        {
+          "name": "UnlockSaveData",
+          "type": "interface",
+          "line": 160,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 176
+        }
+      ],
+      "treeShakingScore": 82
+    },
+    {
+      "path": "ui/save-menu/save-settings.ts",
+      "exports": [
+        {
+          "name": "formatKey",
+          "type": "function",
+          "line": 30,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1320
+        },
+        {
+          "name": "formatKeybindAction",
+          "type": "function",
+          "line": 37,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1320
+        },
+        {
+          "name": "renderSettingsTab",
+          "type": "function",
+          "line": 47,
+          "isUsed": true,
+          "usedIn": [
+            "ui/save-menu/save-menu.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "handleSettingChange",
+          "type": "function",
+          "line": 152,
+          "isUsed": true,
+          "usedIn": [
+            "ui/save-menu/save-menu.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "handleSettingClick",
+          "type": "function",
+          "line": 185,
+          "isUsed": true,
+          "usedIn": [
+            "ui/save-menu/save-menu.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "handleKeybindClick",
+          "type": "function",
+          "line": 202,
+          "isUsed": true,
+          "usedIn": [
+            "ui/save-menu/save-menu.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "cancelKeybindListen",
+          "type": "function",
+          "line": 226,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1320
+        },
+        {
+          "name": "updateKeybind",
+          "type": "function",
+          "line": 245,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1320
+        }
+      ],
+      "imports": [
+        "saveSystem",
+        "SettingsSaveData",
+        "KeyBindings",
+        "showToast"
+      ],
+      "unusedExports": [
+        {
+          "name": "formatKey",
+          "type": "function",
+          "line": 30,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1320
+        },
+        {
+          "name": "formatKeybindAction",
+          "type": "function",
+          "line": 37,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1320
+        },
+        {
+          "name": "cancelKeybindListen",
+          "type": "function",
+          "line": 226,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1320
+        },
+        {
+          "name": "updateKeybind",
+          "type": "function",
+          "line": 245,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1320
+        }
+      ],
+      "treeShakingScore": 50
     },
     {
       "path": "utils/shared-buffer-example.ts",
@@ -10932,12 +14966,1164 @@
       "treeShakingScore": 0
     },
     {
+      "path": "utils/startup-profiler.ts",
+      "exports": [
+        {
+          "name": "startPhase",
+          "type": "function",
+          "line": 296,
+          "isUsed": true,
+          "usedIn": [
+            "core/deferred-init.ts",
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "endPhase",
+          "type": "function",
+          "line": 311,
+          "isUsed": true,
+          "usedIn": [
+            "core/deferred-init.ts",
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "recordWASMInit",
+          "type": "function",
+          "line": 338,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "recordTSLCompile",
+          "type": "function",
+          "line": 346,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2803
+        },
+        {
+          "name": "enableStartupProfiler",
+          "type": "function",
+          "line": 778,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "disableStartupProfiler",
+          "type": "function",
+          "line": 838,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2803
+        },
+        {
+          "name": "finalizeStartupProfile",
+          "type": "function",
+          "line": 858,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "toggleOverlay",
+          "type": "function",
+          "line": 886,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getProfilerStatus",
+          "type": "function",
+          "line": 897,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2803
+        },
+        {
+          "name": "recordCustomPhase",
+          "type": "function",
+          "line": 915,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2803
+        }
+      ],
+      "imports": [
+        "THREE"
+      ],
+      "unusedExports": [
+        {
+          "name": "recordTSLCompile",
+          "type": "function",
+          "line": 346,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2803
+        },
+        {
+          "name": "disableStartupProfiler",
+          "type": "function",
+          "line": 838,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2803
+        },
+        {
+          "name": "getProfilerStatus",
+          "type": "function",
+          "line": 897,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2803
+        },
+        {
+          "name": "recordCustomPhase",
+          "type": "function",
+          "line": 915,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2803
+        }
+      ],
+      "treeShakingScore": 60
+    },
+    {
+      "path": "utils/wasm-batch-core.ts",
+      "exports": [
+        {
+          "name": "uploadPositions",
+          "type": "function",
+          "line": 40,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/musical_flora.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "uploadMushroomSpecs",
+          "type": "function",
+          "line": 57,
+          "isUsed": true,
+          "usedIn": [
+            "systems/weather/weather-ecosystem.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "copySharedPositions",
+          "type": "function",
+          "line": 79,
+          "isUsed": true,
+          "usedIn": [
+            "utils/shared-buffer-example.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "uploadAnimationData",
+          "type": "function",
+          "line": 91,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 962
+        },
+        {
+          "name": "batchDistanceCull",
+          "type": "function",
+          "line": 117,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 962
+        },
+        {
+          "name": "batchMushroomSpawnCandidates",
+          "type": "function",
+          "line": 144,
+          "isUsed": true,
+          "usedIn": [
+            "systems/weather/weather-ecosystem.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "readSpawnCandidates",
+          "type": "function",
+          "line": 165,
+          "isUsed": true,
+          "usedIn": [
+            "systems/weather/weather-ecosystem.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "analyzeMaterials",
+          "type": "function",
+          "line": 190,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 962
+        },
+        {
+          "name": "getUniqueShaderCount",
+          "type": "function",
+          "line": 243,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 962
+        }
+      ],
+      "imports": [
+        "wasmInstance",
+        "wasmMemory",
+        "positionView",
+        "animationView",
+        "outputView",
+        "wasmBatchMushroomSpawnCandidates",
+        "type WasmExports",
+        "type Mushroom",
+        "type AnimationData",
+        "type PositionData",
+        "SpawnCandidate",
+        "MaterialAnalysisResult",
+        "DistanceCullResult",
+        "MaterialInfo"
+      ],
+      "unusedExports": [
+        {
+          "name": "uploadAnimationData",
+          "type": "function",
+          "line": 91,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 962
+        },
+        {
+          "name": "batchDistanceCull",
+          "type": "function",
+          "line": 117,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 962
+        },
+        {
+          "name": "analyzeMaterials",
+          "type": "function",
+          "line": 190,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 962
+        },
+        {
+          "name": "getUniqueShaderCount",
+          "type": "function",
+          "line": 243,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 962
+        }
+      ],
+      "treeShakingScore": 56
+    },
+    {
+      "path": "world/generation.ts",
+      "exports": [
+        {
+          "name": "DEFAULT_MAP_CHUNK_SIZE",
+          "type": "const",
+          "line": 48,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "DEFAULT_PROCEDURAL_CHUNK_SIZE",
+          "type": "const",
+          "line": 49,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 3954
+        },
+        {
+          "name": "PROCEDURAL_ENTITY_COUNT",
+          "type": "const",
+          "line": 50,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 3954
+        },
+        {
+          "name": "initWorld",
+          "type": "function",
+          "line": 157,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "safeAddFoliage",
+          "type": "function",
+          "line": 401,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 3954
+        },
+        {
+          "name": "isCriticalEntity",
+          "type": "function",
+          "line": 508,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 3954
+        },
+        {
+          "name": "generateMap",
+          "type": "function",
+          "line": 534,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "spawnNearbyFoliage",
+          "type": "function",
+          "line": 1087,
+          "isUsed": true,
+          "usedIn": [
+            "systems/weather/weather-ecosystem.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "initCriticalWorld",
+          "type": "function",
+          "line": 1148,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "initWorldCritical",
+          "type": "function",
+          "line": 1153,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "initDeferredWorldContent",
+          "type": "function",
+          "line": 1158,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "initWorldContent",
+          "type": "function",
+          "line": 1167,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "updateProgress",
+        "createIntegratedFireflies",
+        "createIntegratedPollen",
+        "createIntegratedSparks",
+        "registerIntegratedSystem",
+        "getGroundHeight",
+        "initCollisionSystem",
+        "addCollisionObject",
+        "checkPositionValidity",
+        "createSky",
+        "createStars",
+        "createMoon",
+        "createMushroom",
+        "createGlowingFlower",
+        "createFlower",
+        "createSubwooferLotus",
+        "createAccordionPalm",
+        "createFiberOpticWillow",
+        "createFloatingOrb",
+        "createSwingableVine",
+        "createVineLadder",
+        "VineSwing",
+        "createPrismRoseBush",
+        "createStarflower",
+        "createVibratoViolet",
+        "createTremoloTulip",
+        "createKickDrumGeyser",
+        "createRainingCloud",
+        "createWaveformWater",
+        "initFallingBerries",
+        "initGrassSystem",
+        "addGrassInstance",
+        "createArpeggioFern",
+        "createPortamentoPine",
+        "createCymbalDandelion",
+        "createSnareTrap",
+        "createBubbleWillow",
+        "createHelixPlant",
+        "createBalloonBush",
+        "createPanningPad",
+        "createSilenceSpirit",
+        "createInstrumentShrine",
+        "createMelodyMirror",
+        "createRetriggerMushroom",
+        "createIsland",
+        "// Added\n    createCaveEntrance",
+        "createTerrainMaterial",
+        "// Added\n    createLuminousPlant",
+        "luminousPlantBatcher",
+        "generateCloudLayer",
+        "validateFoliageMaterials",
+        "foliageMaterials",
+        "createWisteriaCluster",
+        "CONFIG",
+        "generateGroundHeightmap",
+        "disposeHeightmap",
+        "registerPhysicsCave",
+        "initDiscoveryForFoliage",
+        "unlockSystem",
+        "spawnImpact",
+        "makeInteractive",
+        "animatedFoliage",
+        "cpuAnimatedFoliage",
+        "obstacles",
+        "foliageGroup",
+        "foliageMushrooms",
+        "foliageClouds",
+        "foliageTrampolines",
+        "foliagePanningPads",
+        "foliageGeysers",
+        "foliageTraps",
+        "foliagePortamentoPines",
+        "vineSwings",
+        "foliageVineLadders",
+        "worldGroup",
+        "globalBackgroundProcessor",
+        "showDeferredIndicator",
+        "hideDeferredIndicator",
+        "THREE",
+        "mapData",
+        "default"
+      ],
+      "unusedExports": [
+        {
+          "name": "DEFAULT_PROCEDURAL_CHUNK_SIZE",
+          "type": "const",
+          "line": 49,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 3954
+        },
+        {
+          "name": "PROCEDURAL_ENTITY_COUNT",
+          "type": "const",
+          "line": 50,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 3954
+        },
+        {
+          "name": "safeAddFoliage",
+          "type": "function",
+          "line": 401,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 3954
+        },
+        {
+          "name": "isCriticalEntity",
+          "type": "function",
+          "line": 508,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 3954
+        }
+      ],
+      "treeShakingScore": 67
+    },
+    {
+      "path": "compute/gpu-compute-shaders.ts",
+      "exports": [
+        {
+          "name": "MESH_DEFORM_WAVE_WGSL",
+          "type": "const",
+          "line": 61,
+          "isUsed": true,
+          "usedIn": [
+            "compute/mesh-deformation-gpu.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "MESH_DEFORM_JIGGLE_WGSL",
+          "type": "const",
+          "line": 101,
+          "isUsed": true,
+          "usedIn": [
+            "compute/mesh-deformation-gpu.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "MESH_DEFORM_WOBBLE_WGSL",
+          "type": "const",
+          "line": 140,
+          "isUsed": true,
+          "usedIn": [
+            "compute/mesh-deformation-gpu.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "NORMAL_RECOMPUTE_WGSL",
+          "type": "const",
+          "line": 187,
+          "isUsed": true,
+          "usedIn": [
+            "compute/mesh-deformation-gpu.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "NORMAL_NORMALIZE_WGSL",
+          "type": "const",
+          "line": 241,
+          "isUsed": true,
+          "usedIn": [
+            "compute/mesh-deformation-gpu.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "NOISE_FBM_WGSL",
+          "type": "const",
+          "line": 290,
+          "isUsed": true,
+          "usedIn": [
+            "compute/noise-generator-gpu.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "NOISE_HEIGHTMAP_WGSL",
+          "type": "const",
+          "line": 350,
+          "isUsed": true,
+          "usedIn": [
+            "compute/noise-generator-gpu.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "FRUSTUM_CULL_WGSL",
+          "type": "const",
+          "line": 406,
+          "isUsed": true,
+          "usedIn": [
+            "compute/gpu-culling-system.ts",
+            "rendering/culling-system-gpu.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "DISTANCE_CULL_WGSL",
+          "type": "const",
+          "line": 461,
+          "isUsed": true,
+          "usedIn": [
+            "rendering/culling-system-gpu.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "COMBINED_CULL_WGSL",
+          "type": "const",
+          "line": 497,
+          "isUsed": true,
+          "usedIn": [
+            "rendering/culling-system-gpu.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "PARTICLE_PHYSICS_WGSL",
+          "type": "const",
+          "line": 568,
+          "isUsed": true,
+          "usedIn": [
+            "compute/gpu-particle-system.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "FOLIAGE_ANIMATION_WGSL",
+          "type": "const",
+          "line": 712,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1955
+        },
+        {
+          "name": "LOD_SELECT_WGSL",
+          "type": "const",
+          "line": 805,
+          "isUsed": true,
+          "usedIn": [
+            "compute/gpu-culling-system.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "AUDIO_COLOR_WGSL",
+          "type": "const",
+          "line": 860,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1955
+        },
+        {
+          "name": "COMPUTE_SHADERS",
+          "type": "const",
+          "line": 927,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1955
+        }
+      ],
+      "imports": [],
+      "unusedExports": [
+        {
+          "name": "FOLIAGE_ANIMATION_WGSL",
+          "type": "const",
+          "line": 712,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1955
+        },
+        {
+          "name": "AUDIO_COLOR_WGSL",
+          "type": "const",
+          "line": 860,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1955
+        },
+        {
+          "name": "COMPUTE_SHADERS",
+          "type": "const",
+          "line": 927,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1955
+        }
+      ],
+      "treeShakingScore": 80
+    },
+    {
+      "path": "core/deferred-init.ts",
+      "exports": [
+        {
+          "name": "initDeferredVisualsDependencies",
+          "type": "function",
+          "line": 46,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "initDeferredVisuals",
+          "type": "function",
+          "line": 56,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "runDeferredWarmup",
+          "type": "function",
+          "line": 159,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getMelodyRibbon",
+          "type": "function",
+          "line": 225,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getSparkleTrail",
+          "type": "function",
+          "line": 226,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getImpactSystem",
+          "type": "function",
+          "line": 227,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getFluidFog",
+          "type": "function",
+          "line": 228,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getDandelionSeedSystem",
+          "type": "function",
+          "line": 229,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getDiscoveryEffect",
+          "type": "function",
+          "line": 230,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getHarpoonLine",
+          "type": "function",
+          "line": 231,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getAurora",
+          "type": "function",
+          "line": 232,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 629
+        },
+        {
+          "name": "getChromaticPulse",
+          "type": "function",
+          "line": 233,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 629
+        },
+        {
+          "name": "getStrobePulse",
+          "type": "function",
+          "line": 234,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 629
+        },
+        {
+          "name": "getPlayerShieldMesh",
+          "type": "function",
+          "line": 235,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "setPlayerShieldMesh",
+          "type": "function",
+          "line": 236,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "createAurora",
+        "harmonyOrbSystem",
+        "createChromaticPulse",
+        "createStrobePulse",
+        "createMelodyRibbon",
+        "createSparkleTrail",
+        "createImpactSystem",
+        "createShield",
+        "createDandelionSeedSystem",
+        "createDiscoveryEffect",
+        "uTime",
+        "initCelestialBodies",
+        "createFluidFog",
+        "createMushroom",
+        "jitterMineSystem",
+        "chordStrikeSystem",
+        "createHarpoonLine",
+        "fireRainbow",
+        "animatedFoliage",
+        "getGroundHeight",
+        "forceFullSceneWarmup",
+        "startPhase",
+        "endPhase",
+        "THREE"
+      ],
+      "unusedExports": [
+        {
+          "name": "getAurora",
+          "type": "function",
+          "line": 232,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 629
+        },
+        {
+          "name": "getChromaticPulse",
+          "type": "function",
+          "line": 233,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 629
+        },
+        {
+          "name": "getStrobePulse",
+          "type": "function",
+          "line": 234,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 629
+        }
+      ],
+      "treeShakingScore": 80
+    },
+    {
+      "path": "core/game-loop.ts",
+      "exports": [
+        {
+          "name": "initGameLoopDependencies",
+          "type": "function",
+          "line": 162,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "addCameraShake",
+          "type": "function",
+          "line": 215,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts",
+            "main.ts",
+            "systems/glitch-grenade.ts",
+            "systems/physics/physics-abilities.ts",
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-updates.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getGameTime",
+          "type": "function",
+          "line": 219,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 4415
+        },
+        {
+          "name": "getAudioState",
+          "type": "function",
+          "line": 223,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 4415
+        },
+        {
+          "name": "getBeatFlashIntensity",
+          "type": "function",
+          "line": 227,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 4415
+        },
+        {
+          "name": "animate",
+          "type": "function",
+          "line": 231,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "uWindSpeed",
+        "uWindDirection",
+        "uAudioLow",
+        "uAudioHigh",
+        "uGlitchIntensity",
+        "uTime",
+        "uPlayerPosition",
+        "uSkyTopColor",
+        "uSkyBottomColor",
+        "uHorizonColor",
+        "uAtmosphereIntensity",
+        "uStarOpacity",
+        "uAuroraIntensity",
+        "uAuroraColor",
+        "uChromaticIntensity",
+        "harmonyOrbSystem",
+        "updateFallingBerries",
+        "collectFallingBerries",
+        "updateMelodyRibbons",
+        "updateSparkleTrail",
+        "updateDandelionSeeds",
+        "getGroundHeight",
+        "updateImpacts",
+        "createShield",
+        "updateFoliageMaterials",
+        "windComputeSystem",
+        "chordStrikeSystem",
+        "updateFallingClouds",
+        "updateAllIntegratedSystems",
+        "type ParticleAudioData",
+        "WeatherState",
+        "CloudBatcher",
+        "fluidSystem",
+        "updatePhysics",
+        "player",
+        "fireRainbow",
+        "updateBlaster",
+        "jitterMineSystem",
+        "glitchGrenadeSystem",
+        "updateHarpoonLine",
+        "musicReactivitySystem",
+        "unlockSystem",
+        "profiler",
+        "WeatherSystem",
+        "InteractionSystem",
+        "AudioSystem",
+        "BeatSync",
+        "animatedFoliage",
+        "cpuAnimatedFoliage",
+        "foliageClouds",
+        "foliageMushrooms",
+        "getCycleState",
+        "CYCLE_DURATION",
+        "DURATION_SUNRISE",
+        "DURATION_DAY",
+        "DURATION_SUNSET",
+        "DURATION_DUSK_NIGHT",
+        "DURATION_DEEP_NIGHT",
+        "keyStates",
+        "updateHUD",
+        "getLastIsNight",
+        "setLastIsNight",
+        "getIsNight",
+        "setIsNight",
+        "updateTheme",
+        "setLastStrikeState",
+        "getLastStrikeState",
+        "getMelodyRibbon",
+        "getSparkleTrail",
+        "getImpactSystem",
+        "getFluidFog",
+        "getDandelionSeedSystem",
+        "getDiscoveryEffect",
+        "getHarpoonLine",
+        "getPlayerShieldMesh",
+        "setPlayerShieldMesh",
+        "THREE"
+      ],
+      "unusedExports": [
+        {
+          "name": "getGameTime",
+          "type": "function",
+          "line": 219,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 4415
+        },
+        {
+          "name": "getAudioState",
+          "type": "function",
+          "line": 223,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 4415
+        },
+        {
+          "name": "getBeatFlashIntensity",
+          "type": "function",
+          "line": 227,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 4415
+        }
+      ],
+      "treeShakingScore": 50
+    },
+    {
+      "path": "core/input/audio-controls.ts",
+      "exports": [
+        {
+          "name": "initAudioControls",
+          "type": "function",
+          "line": 20,
+          "isUsed": true,
+          "usedIn": [
+            "core/input/input.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "updateMuteUI",
+          "type": "const",
+          "line": 71,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 940
+        },
+        {
+          "name": "toggleMute",
+          "type": "const",
+          "line": 81,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 940
+        },
+        {
+          "name": "adjustVolume",
+          "type": "const",
+          "line": 97,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 940
+        },
+        {
+          "name": "handleMuteKey",
+          "type": "function",
+          "line": 140,
+          "isUsed": true,
+          "usedIn": [
+            "core/input/input.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "handleVolumeKey",
+          "type": "function",
+          "line": 147,
+          "isUsed": true,
+          "usedIn": [
+            "core/input/input.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "AudioSystem",
+        "keyStates",
+        "announce",
+        "announceValueChange"
+      ],
+      "unusedExports": [
+        {
+          "name": "updateMuteUI",
+          "type": "const",
+          "line": 71,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 940
+        },
+        {
+          "name": "toggleMute",
+          "type": "const",
+          "line": 81,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 940
+        },
+        {
+          "name": "adjustVolume",
+          "type": "const",
+          "line": 97,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 940
+        }
+      ],
+      "treeShakingScore": 50
+    },
+    {
       "path": "foliage/flowers.ts",
       "exports": [
         {
           "name": "createFlower",
           "type": "function",
-          "line": 40,
+          "line": 42,
           "isUsed": true,
           "usedIn": [
             "world/generation.ts"
@@ -10947,7 +16133,7 @@
         {
           "name": "createGlowingFlower",
           "type": "function",
-          "line": 81,
+          "line": 92,
           "isUsed": true,
           "usedIn": [
             "world/generation.ts"
@@ -10957,7 +16143,7 @@
         {
           "name": "createStarflower",
           "type": "function",
-          "line": 111,
+          "line": 122,
           "isUsed": true,
           "usedIn": [
             "world/generation.ts"
@@ -10967,23 +16153,23 @@
         {
           "name": "createBellBloom",
           "type": "function",
-          "line": 167,
+          "line": 190,
           "isUsed": false,
           "usedIn": [],
-          "size": 2540
+          "size": 2711
         },
         {
           "name": "createPuffballFlower",
           "type": "function",
-          "line": 206,
+          "line": 241,
           "isUsed": false,
           "usedIn": [],
-          "size": 2540
+          "size": 2711
         },
         {
           "name": "createPrismRoseBush",
           "type": "function",
-          "line": 269,
+          "line": 316,
           "isUsed": true,
           "usedIn": [
             "world/generation.ts"
@@ -10993,7 +16179,7 @@
         {
           "name": "createVibratoViolet",
           "type": "function",
-          "line": 364,
+          "line": 411,
           "isUsed": true,
           "usedIn": [
             "world/generation.ts"
@@ -11003,7 +16189,7 @@
         {
           "name": "createTremoloTulip",
           "type": "function",
-          "line": 470,
+          "line": 517,
           "isUsed": true,
           "usedIn": [
             "world/generation.ts"
@@ -11013,23 +16199,24 @@
         {
           "name": "createLanternFlower",
           "type": "function",
-          "line": 617,
+          "line": 664,
           "isUsed": true,
           "usedIn": [
-            "systems/weather.ts"
+            "systems/weather/weather-ecosystem.ts"
           ],
           "size": 0
         },
         {
           "name": "createGlowingFlowerPatch",
           "type": "function",
-          "line": 649,
+          "line": 696,
           "isUsed": false,
           "usedIn": [],
-          "size": 2540
+          "size": 2711
         }
       ],
       "imports": [
+        "MeshStandardNodeMaterial",
         "mergeGeometries",
         "mergeVertices",
         "foliageMaterials",
@@ -11044,6 +16231,7 @@
         "calculateFlowerBloom",
         "calculateWindSway",
         "applyPlayerInteraction",
+        "getCachedProceduralMaterial",
         "uTime",
         "uAudioHigh",
         "uAudioLow",
@@ -11051,7 +16239,6 @@
         "mix",
         "float",
         "positionLocal",
-        "Node",
         "uv",
         "vec2",
         "sub",
@@ -11060,6 +16247,7 @@
         "sin",
         "length",
         "atan",
+        "atan2",
         "smoothstep",
         "vec3",
         "uTwilight",
@@ -11081,26 +16269,26 @@
         {
           "name": "createBellBloom",
           "type": "function",
-          "line": 167,
+          "line": 190,
           "isUsed": false,
           "usedIn": [],
-          "size": 2540
+          "size": 2711
         },
         {
           "name": "createPuffballFlower",
           "type": "function",
-          "line": 206,
+          "line": 241,
           "isUsed": false,
           "usedIn": [],
-          "size": 2540
+          "size": 2711
         },
         {
           "name": "createGlowingFlowerPatch",
           "type": "function",
-          "line": 649,
+          "line": 696,
           "isUsed": false,
           "usedIn": [],
-          "size": 2540
+          "size": 2711
         }
       ],
       "treeShakingScore": 70
@@ -11111,15 +16299,15 @@
         {
           "name": "moonConfig",
           "type": "const",
-          "line": 8,
+          "line": 10,
           "isUsed": false,
           "usedIn": [],
-          "size": 1472
+          "size": 1816
         },
         {
           "name": "createMoon",
           "type": "function",
-          "line": 14,
+          "line": 16,
           "isUsed": true,
           "usedIn": [
             "world/generation.ts"
@@ -11129,140 +16317,300 @@
         {
           "name": "updateMoon",
           "type": "function",
-          "line": 95,
+          "line": 120,
           "isUsed": false,
           "usedIn": [],
-          "size": 1472
+          "size": 1816
         },
         {
           "name": "triggerMoonBlink",
           "type": "function",
-          "line": 160,
+          "line": 185,
           "isUsed": false,
           "usedIn": [],
-          "size": 1472
+          "size": 1816
         }
       ],
       "imports": [
         "color",
         "vec3",
-        "time",
         "sin",
         "cos",
         "uniform",
         "mix",
         "positionLocal",
         "UniformNode",
+        "smoothstep",
+        "float",
         "MeshStandardNodeMaterial",
         "attachReactivity",
         "CandyPresets",
+        "uAudioLow",
+        "uAudioHigh",
+        "uTime",
+        "createJuicyRimLight",
         "VisualState",
+        "BiomeUniforms",
+        "SkyUniforms",
+        "skyNoteColorNode",
         "THREE"
       ],
       "unusedExports": [
         {
           "name": "moonConfig",
           "type": "const",
-          "line": 8,
+          "line": 10,
           "isUsed": false,
           "usedIn": [],
-          "size": 1472
+          "size": 1816
         },
         {
           "name": "updateMoon",
           "type": "function",
-          "line": 95,
+          "line": 120,
           "isUsed": false,
           "usedIn": [],
-          "size": 1472
+          "size": 1816
         },
         {
           "name": "triggerMoonBlink",
           "type": "function",
-          "line": 160,
+          "line": 185,
           "isUsed": false,
           "usedIn": [],
-          "size": 1472
+          "size": 1816
         }
       ],
       "treeShakingScore": 25
     },
     {
-      "path": "foliage/post-processing.ts",
+      "path": "main.ts",
       "exports": [
         {
-          "name": "uBloomStrength",
-          "type": "const",
-          "line": 7,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 746
-        },
-        {
-          "name": "uColorSaturation",
+          "name": "addCameraShake",
           "type": "const",
           "line": 8,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 746
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts",
+            "main.ts",
+            "systems/glitch-grenade.ts",
+            "systems/physics/physics-abilities.ts",
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-updates.ts"
+          ],
+          "size": 0
         },
         {
-          "name": "uColorContrast",
+          "name": "scene",
           "type": "const",
           "line": 9,
           "isUsed": false,
           "usedIn": [],
-          "size": 746
+          "size": 83
         },
         {
-          "name": "initPostProcessing",
-          "type": "function",
-          "line": 23,
+          "name": "camera",
+          "type": "const",
+          "line": 9,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 83
+        },
+        {
+          "name": "renderer",
+          "type": "const",
+          "line": 9,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 83
+        },
+        {
+          "name": "player",
+          "type": "const",
+          "line": 9,
           "isUsed": true,
           "usedIn": [
-            "main.ts"
+            "core/game-loop.ts",
+            "core/main.ts",
+            "systems/physics/physics-abilities.ts",
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-states.ts",
+            "systems/physics/physics-updates.ts",
+            "systems/save-integration-example.ts"
           ],
           "size": 0
         }
       ],
       "imports": [
-        "PostProcessing",
-        "pass",
-        "mix",
-        "vec3",
-        "uniform",
-        "Fn",
-        "float",
-        "bloom",
-        "THREE"
+        "addCameraShake",
+        "__sideEffect__core/main.ts"
       ],
       "unusedExports": [
         {
-          "name": "uBloomStrength",
-          "type": "const",
-          "line": 7,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 746
-        },
-        {
-          "name": "uColorSaturation",
-          "type": "const",
-          "line": 8,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 746
-        },
-        {
-          "name": "uColorContrast",
+          "name": "scene",
           "type": "const",
           "line": 9,
           "isUsed": false,
           "usedIn": [],
-          "size": 746
+          "size": 83
+        },
+        {
+          "name": "camera",
+          "type": "const",
+          "line": 9,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 83
+        },
+        {
+          "name": "renderer",
+          "type": "const",
+          "line": 9,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 83
+        }
+      ],
+      "treeShakingScore": 40
+    },
+    {
+      "path": "rendering/culling-system-gpu.ts",
+      "exports": [
+        {
+          "name": "BoundingSphereArray",
+          "type": "type",
+          "line": 33,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 3797
+        },
+        {
+          "name": "FrustumPlanes",
+          "type": "type",
+          "line": 36,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 3797
+        },
+        {
+          "name": "CullingGPUConfig",
+          "type": "interface",
+          "line": 38,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 3797
+        },
+        {
+          "name": "CullingSystemGPU",
+          "type": "class",
+          "line": 57,
+          "isUsed": true,
+          "usedIn": [
+            "rendering/culling-system-gpu.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "CullingSystemGPU",
+        "GPUComputeLibrary",
+        "getSharedGPUCompute",
+        "FRUSTUM_CULL_WGSL",
+        "DISTANCE_CULL_WGSL",
+        "COMBINED_CULL_WGSL",
+        "THREE"
+      ],
+      "unusedExports": [
+        {
+          "name": "BoundingSphereArray",
+          "type": "type",
+          "line": 33,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 3797
+        },
+        {
+          "name": "FrustumPlanes",
+          "type": "type",
+          "line": 36,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 3797
+        },
+        {
+          "name": "CullingGPUConfig",
+          "type": "interface",
+          "line": 38,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 3797
         }
       ],
       "treeShakingScore": 25
+    },
+    {
+      "path": "systems/asset-streaming/asset-streaming-scheduler.ts",
+      "exports": [
+        {
+          "name": "AssetScheduler",
+          "type": "class",
+          "line": 40,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 4038
+        },
+        {
+          "name": "BatchCoordinator",
+          "type": "class",
+          "line": 270,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 4038
+        },
+        {
+          "name": "PriorityQueue",
+          "type": "class",
+          "line": 338,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 4038
+        }
+      ],
+      "imports": [
+        "AssetPriority",
+        "AssetRequest",
+        "AssetBatch",
+        "LoadedAsset",
+        "LoadingProgress"
+      ],
+      "unusedExports": [
+        {
+          "name": "AssetScheduler",
+          "type": "class",
+          "line": 40,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 4038
+        },
+        {
+          "name": "BatchCoordinator",
+          "type": "class",
+          "line": 270,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 4038
+        },
+        {
+          "name": "PriorityQueue",
+          "type": "class",
+          "line": 338,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 4038
+        }
+      ],
+      "treeShakingScore": 0
     },
     {
       "path": "systems/discovery.ts",
@@ -11270,14 +16618,17 @@
         {
           "name": "discoverySystem",
           "type": "const",
-          "line": 209,
+          "line": 247,
           "isUsed": true,
           "usedIn": [
-            "core/input.ts",
+            "core/input/input.ts",
             "foliage/lotus.ts",
             "foliage/wisteria-cluster.ts",
             "systems/discovery-optimized.ts",
-            "systems/physics.ts",
+            "systems/physics/physics-abilities.ts",
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-states.ts",
+            "systems/physics/physics-updates.ts",
             "systems/save-integration-example.ts"
           ],
           "size": 0
@@ -11285,7 +16636,7 @@
         {
           "name": "discoveryPersistence",
           "type": "const",
-          "line": 212,
+          "line": 250,
           "isUsed": true,
           "usedIn": [
             "systems/discovery-optimized.ts",
@@ -11296,60 +16647,168 @@
         {
           "name": "exportDiscoveries",
           "type": "const",
-          "line": 212,
+          "line": 250,
           "isUsed": false,
           "usedIn": [],
-          "size": 1499
+          "size": 1814
         },
         {
           "name": "importDiscoveries",
           "type": "const",
-          "line": 212,
+          "line": 250,
           "isUsed": false,
           "usedIn": [],
-          "size": 1499
+          "size": 1814
         },
         {
           "name": "clearLocalDiscoveries",
           "type": "const",
-          "line": 212,
+          "line": 250,
           "isUsed": false,
           "usedIn": [],
-          "size": 1499
+          "size": 1814
         }
       ],
       "imports": [
         "showToast",
         "DISCOVERY_MAP",
-        "discoveryPersistence"
+        "discoveryPersistence",
+        "trapFocusInside"
       ],
       "unusedExports": [
         {
           "name": "exportDiscoveries",
           "type": "const",
-          "line": 212,
+          "line": 250,
           "isUsed": false,
           "usedIn": [],
-          "size": 1499
+          "size": 1814
         },
         {
           "name": "importDiscoveries",
           "type": "const",
-          "line": 212,
+          "line": 250,
           "isUsed": false,
           "usedIn": [],
-          "size": 1499
+          "size": 1814
         },
         {
           "name": "clearLocalDiscoveries",
           "type": "const",
-          "line": 212,
+          "line": 250,
           "isUsed": false,
           "usedIn": [],
-          "size": 1499
+          "size": 1814
         }
       ],
       "treeShakingScore": 40
+    },
+    {
+      "path": "systems/music-reactivity.ts",
+      "exports": [
+        {
+          "name": "_skyMoonNoteVal",
+          "type": "let",
+          "line": 32,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/portamento-batcher.ts",
+            "foliage/wisteria-cluster.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "WeatherReactivityBinding",
+          "type": "interface",
+          "line": 62,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 5419
+        },
+        {
+          "name": "WeatherMusicTargets",
+          "type": "const",
+          "line": 72,
+          "isUsed": true,
+          "usedIn": [
+            "systems/weather/weather.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "IWeatherSystem",
+          "type": "interface",
+          "line": 108,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 5419
+        },
+        {
+          "name": "MusicReactivitySystem",
+          "type": "class",
+          "line": 117,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 5419
+        },
+        {
+          "name": "musicReactivitySystem",
+          "type": "const",
+          "line": 701,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts",
+            "core/main.ts",
+            "systems/weather/weather-ecosystem.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "CONFIG",
+        "CYCLE_DURATION",
+        "getDayNightBias",
+        "animateFoliage",
+        "foliageBatcher",
+        "arpeggioFernBatcher",
+        "portamentoPineBatcher",
+        "mushroomBatcher",
+        "flowerBatcher",
+        "simpleFlowerBatcher",
+        "BiomeUniforms",
+        "SkyUniforms",
+        "LuminousPlantUniforms",
+        "THREE",
+        "musicBindings",
+        "default"
+      ],
+      "unusedExports": [
+        {
+          "name": "WeatherReactivityBinding",
+          "type": "interface",
+          "line": 62,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 5419
+        },
+        {
+          "name": "IWeatherSystem",
+          "type": "interface",
+          "line": 108,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 5419
+        },
+        {
+          "name": "MusicReactivitySystem",
+          "type": "class",
+          "line": 117,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 5419
+        }
+      ],
+      "treeShakingScore": 50
     },
     {
       "path": "systems/unlocks.ts",
@@ -11360,7 +16819,7 @@
           "line": 5,
           "isUsed": false,
           "usedIn": [],
-          "size": 1362
+          "size": 1608
         },
         {
           "name": "UnlockDefinition",
@@ -11368,7 +16827,7 @@
           "line": 10,
           "isUsed": false,
           "usedIn": [],
-          "size": 1362
+          "size": 1608
         },
         {
           "name": "UNLOCK_DEFINITIONS",
@@ -11376,22 +16835,27 @@
           "line": 18,
           "isUsed": false,
           "usedIn": [],
-          "size": 1362
+          "size": 1608
         },
         {
           "name": "unlockSystem",
           "type": "const",
-          "line": 179,
+          "line": 207,
           "isUsed": true,
           "usedIn": [
+            "core/game-loop.ts",
+            "core/hud.ts",
             "foliage/flowers.ts",
             "foliage/instrument.ts",
             "foliage/musical_flora.ts",
+            "gameplay/chord-strike.ts",
             "gameplay/jitter-mines.ts",
             "gameplay/rainbow-blaster.ts",
-            "main.ts",
-            "systems/physics.ts",
-            "systems/save-integration-example.ts"
+            "systems/physics/physics-abilities.ts",
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-updates.ts",
+            "systems/save-integration-example.ts",
+            "world/generation.ts"
           ],
           "size": 0
         }
@@ -11406,7 +16870,7 @@
           "line": 5,
           "isUsed": false,
           "usedIn": [],
-          "size": 1362
+          "size": 1608
         },
         {
           "name": "UnlockDefinition",
@@ -11414,7 +16878,7 @@
           "line": 10,
           "isUsed": false,
           "usedIn": [],
-          "size": 1362
+          "size": 1608
         },
         {
           "name": "UNLOCK_DEFINITIONS",
@@ -11422,214 +16886,393 @@
           "line": 18,
           "isUsed": false,
           "usedIn": [],
-          "size": 1362
+          "size": 1608
         }
       ],
       "treeShakingScore": 25
     },
     {
-      "path": "world/generation.ts",
+      "path": "utils/wasm-batch-particles.ts",
       "exports": [
         {
-          "name": "DEFAULT_MAP_CHUNK_SIZE",
-          "type": "const",
-          "line": 33,
+          "name": "updateParticles",
+          "type": "function",
+          "line": 20,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1699
+        },
+        {
+          "name": "spawnBurst",
+          "type": "function",
+          "line": 50,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1699
+        },
+        {
+          "name": "getHeightmapBatch",
+          "type": "function",
+          "line": 91,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1699
+        }
+      ],
+      "imports": [
+        "wasmUpdateParticles",
+        "wasmSpawnBurst",
+        "cppBatchGroundHeightSimd",
+        "emscriptenInstance",
+        "emscriptenMemory"
+      ],
+      "unusedExports": [
+        {
+          "name": "updateParticles",
+          "type": "function",
+          "line": 20,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1699
+        },
+        {
+          "name": "spawnBurst",
+          "type": "function",
+          "line": 50,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1699
+        },
+        {
+          "name": "getHeightmapBatch",
+          "type": "function",
+          "line": 91,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1699
+        }
+      ],
+      "treeShakingScore": 0
+    },
+    {
+      "path": "compute/gpu-compute-library.ts",
+      "exports": [
+        {
+          "name": "PipelineConfig",
+          "type": "interface",
+          "line": 21,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 3420
+        },
+        {
+          "name": "ComputeMetrics",
+          "type": "interface",
+          "line": 32,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 3420
+        },
+        {
+          "name": "GPUComputeLibrary",
+          "type": "class",
+          "line": 44,
           "isUsed": true,
           "usedIn": [
-            "main.ts"
+            "compute/gpu-culling-system.ts",
+            "compute/gpu-foliage-animator.ts",
+            "compute/gpu-particle-system.ts",
+            "compute/mesh-deformation-gpu.ts",
+            "compute/noise-generator-gpu.ts",
+            "rendering/culling-system-gpu.ts"
           ],
           "size": 0
         },
         {
-          "name": "DEFAULT_PROCEDURAL_CHUNK_SIZE",
-          "type": "const",
-          "line": 34,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 4936
-        },
-        {
-          "name": "PROCEDURAL_ENTITY_COUNT",
-          "type": "const",
-          "line": 35,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 4936
-        },
-        {
-          "name": "initWorld",
+          "name": "getSharedGPUCompute",
           "type": "function",
-          "line": 133,
+          "line": 378,
           "isUsed": true,
           "usedIn": [
-            "main.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "safeAddFoliage",
-          "type": "function",
-          "line": 220,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 4936
-        },
-        {
-          "name": "generateMap",
-          "type": "function",
-          "line": 311,
-          "isUsed": true,
-          "usedIn": [
-            "main.ts"
+            "compute/mesh-deformation-gpu.ts",
+            "compute/noise-generator-gpu.ts",
+            "rendering/culling-system-gpu.ts"
           ],
           "size": 0
         }
       ],
-      "imports": [
-        "getGroundHeight",
-        "initCollisionSystem",
-        "addCollisionObject",
-        "checkPositionValidity",
-        "createSky",
-        "createStars",
-        "createMoon",
-        "createMushroom",
-        "createGlowingFlower",
-        "createFlower",
-        "createSubwooferLotus",
-        "createAccordionPalm",
-        "createFiberOpticWillow",
-        "createFloatingOrb",
-        "createSwingableVine",
-        "VineSwing",
-        "createPrismRoseBush",
-        "createStarflower",
-        "createVibratoViolet",
-        "createTremoloTulip",
-        "createKickDrumGeyser",
-        "createRainingCloud",
-        "createWaveformWater",
-        "createFireflies",
-        "initFallingBerries",
-        "initGrassSystem",
-        "addGrassInstance",
-        "createArpeggioFern",
-        "createPortamentoPine",
-        "createCymbalDandelion",
-        "createSnareTrap",
-        "createBubbleWillow",
-        "createHelixPlant",
-        "createBalloonBush",
-        "createWisteriaCluster",
-        "createPanningPad",
-        "createSilenceSpirit",
-        "createInstrumentShrine",
-        "createMelodyMirror",
-        "createRetriggerMushroom",
-        "createIsland",
-        "// Added\n    createCaveEntrance",
-        "createNeonPollen",
-        "// Added\n    createTerrainMaterial // Added",
-        "generateCloudLayer",
-        "validateFoliageMaterials",
-        "CONFIG",
-        "registerPhysicsCave",
-        "initDiscoveryForFoliage",
-        "animatedFoliage",
-        "obstacles",
-        "foliageGroup",
-        "foliageMushrooms",
-        "foliageClouds",
-        "foliageTrampolines",
-        "foliagePanningPads",
-        "foliageGeysers",
-        "foliageTraps",
-        "foliagePortamentoPines",
-        "vineSwings",
-        "worldGroup",
-        "THREE",
-        "mapData",
-        "default"
-      ],
+      "imports": [],
       "unusedExports": [
         {
-          "name": "DEFAULT_PROCEDURAL_CHUNK_SIZE",
-          "type": "const",
-          "line": 34,
+          "name": "PipelineConfig",
+          "type": "interface",
+          "line": 21,
           "isUsed": false,
           "usedIn": [],
-          "size": 4936
+          "size": 3420
         },
         {
-          "name": "PROCEDURAL_ENTITY_COUNT",
-          "type": "const",
-          "line": 35,
+          "name": "ComputeMetrics",
+          "type": "interface",
+          "line": 32,
           "isUsed": false,
           "usedIn": [],
-          "size": 4936
-        },
-        {
-          "name": "safeAddFoliage",
-          "type": "function",
-          "line": 220,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 4936
+          "size": 3420
         }
       ],
       "treeShakingScore": 50
     },
     {
-      "path": "compute/noise_generator.ts",
+      "path": "compute/noise-generator-gpu.ts",
       "exports": [
         {
-          "name": "NoiseConfig",
+          "name": "NoiseGeneratorGPUConfig",
           "type": "interface",
-          "line": 27,
+          "line": 29,
           "isUsed": false,
           "usedIn": [],
-          "size": 2730
+          "size": 3630
         },
         {
-          "name": "ProceduralNoiseCompute",
+          "name": "NoiseGeneratorGPU",
           "type": "class",
-          "line": 48,
+          "line": 47,
           "isUsed": true,
           "usedIn": [
-            "compute/noise_generator.ts"
+            "compute/noise-generator-gpu.ts"
           ],
           "size": 0
         },
         {
-          "name": "createCandySwirlTexture",
+          "name": "createGPUCandySwirlTexture",
           "type": "function",
-          "line": 279,
+          "line": 302,
           "isUsed": false,
           "usedIn": [],
-          "size": 2730
+          "size": 3630
         }
       ],
       "imports": [
+        "NoiseGeneratorGPU",
+        "GPUComputeLibrary",
+        "getSharedGPUCompute",
         "ProceduralNoiseCompute",
-        "uniform",
+        "NoiseConfig",
+        "NOISE_FBM_WGSL",
+        "NOISE_HEIGHTMAP_WGSL",
         "THREE"
       ],
       "unusedExports": [
         {
-          "name": "NoiseConfig",
+          "name": "NoiseGeneratorGPUConfig",
           "type": "interface",
-          "line": 27,
+          "line": 29,
           "isUsed": false,
           "usedIn": [],
-          "size": 2730
+          "size": 3630
         },
         {
-          "name": "createCandySwirlTexture",
+          "name": "createGPUCandySwirlTexture",
           "type": "function",
-          "line": 279,
+          "line": 302,
           "isUsed": false,
           "usedIn": [],
-          "size": 2730
+          "size": 3630
+        }
+      ],
+      "treeShakingScore": 33
+    },
+    {
+      "path": "core/init.ts",
+      "exports": [
+        {
+          "name": "CandyRenderer",
+          "type": "type",
+          "line": 14,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2686
+        },
+        {
+          "name": "isWebGPUMode",
+          "type": "const",
+          "line": 19,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/post-processing.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "SceneInitResult",
+          "type": "interface",
+          "line": 26,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2686
+        },
+        {
+          "name": "initScene",
+          "type": "function",
+          "line": 93,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "forceFullSceneWarmup",
+          "type": "function",
+          "line": 282,
+          "isUsed": true,
+          "usedIn": [
+            "core/deferred-init.ts",
+            "core/main.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "color",
+        "uniform",
+        "WebGPURenderer",
+        "MeshBasicNodeMaterial",
+        "StorageInstancedBufferAttribute",
+        "StorageBufferAttribute",
+        "PALETTE",
+        "CONFIG",
+        "createCrescendoFogNode",
+        "THREE",
+        "WebGPU",
+        "default"
+      ],
+      "unusedExports": [
+        {
+          "name": "CandyRenderer",
+          "type": "type",
+          "line": 14,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2686
+        },
+        {
+          "name": "SceneInitResult",
+          "type": "interface",
+          "line": 26,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2686
+        }
+      ],
+      "treeShakingScore": 60
+    },
+    {
+      "path": "debug/index.ts",
+      "exports": [
+        {
+          "name": "DebugPanel",
+          "type": "const",
+          "line": 17,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 111
+        },
+        {
+          "name": "getDebugPanel",
+          "type": "const",
+          "line": 17,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 111
+        },
+        {
+          "name": "initDebugPanel",
+          "type": "const",
+          "line": 17,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [],
+      "unusedExports": [
+        {
+          "name": "DebugPanel",
+          "type": "const",
+          "line": 17,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 111
+        },
+        {
+          "name": "getDebugPanel",
+          "type": "const",
+          "line": 17,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 111
+        }
+      ],
+      "treeShakingScore": 33
+    },
+    {
+      "path": "debug/panel.ts",
+      "exports": [
+        {
+          "name": "DebugPanel",
+          "type": "class",
+          "line": 17,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2939
+        },
+        {
+          "name": "getDebugPanel",
+          "type": "function",
+          "line": 331,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2939
+        },
+        {
+          "name": "initDebugPanel",
+          "type": "function",
+          "line": 341,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "DEBUG_CONFIG",
+        "DEBUG_STAGES",
+        "StageLoader",
+        "getAllStageStatuses",
+        "StageStatus",
+        "type DebugStages",
+        "type StageMetadata"
+      ],
+      "unusedExports": [
+        {
+          "name": "DebugPanel",
+          "type": "class",
+          "line": 17,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2939
+        },
+        {
+          "name": "getDebugPanel",
+          "type": "function",
+          "line": 331,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2939
         }
       ],
       "treeShakingScore": 33
@@ -11640,56 +17283,56 @@
         {
           "name": "./types.ts",
           "type": "const",
-          "line": 11,
+          "line": 39,
           "isUsed": false,
           "usedIn": [],
-          "size": 5075
+          "size": 6494
         },
         {
           "name": "triggerGrowth",
           "type": "function",
-          "line": 18,
+          "line": 46,
           "isUsed": true,
           "usedIn": [
-            "systems/weather.ts"
+            "systems/weather/weather-effects.ts",
+            "systems/weather/weather.ts"
           ],
           "size": 0
         },
         {
           "name": "triggerBloom",
           "type": "function",
-          "line": 60,
+          "line": 145,
           "isUsed": true,
           "usedIn": [
-            "systems/weather.ts"
+            "systems/weather/weather-effects.ts"
           ],
           "size": 0
         },
         {
           "name": "updateMaterialsForWeather",
           "type": "function",
-          "line": 105,
+          "line": 252,
           "isUsed": false,
           "usedIn": [],
-          "size": 5075
+          "size": 6494
         },
         {
           "name": "updateFoliageMaterials",
           "type": "function",
-          "line": 124,
+          "line": 271,
           "isUsed": true,
           "usedIn": [
-            "main.ts"
+            "core/game-loop.ts"
           ],
           "size": 0
         },
         {
           "name": "animateFoliage",
           "type": "function",
-          "line": 173,
+          "line": 320,
           "isUsed": true,
           "usedIn": [
-            "main.ts",
             "systems/music-reactivity.ts"
           ],
           "size": 0
@@ -11697,6 +17340,13 @@
       ],
       "imports": [
         "freqToHue",
+        "isWasmReady",
+        "wasmMemory",
+        "wasmSmoothWobble",
+        "wasmBatchGrowth",
+        "wasmBatchBloom",
+        "wasmBatchScaleAnimation",
+        "OUTPUT_OFFSET",
         "reactiveMaterials",
         "_foliageReactiveColor",
         "median",
@@ -11713,18 +17363,18 @@
         {
           "name": "./types.ts",
           "type": "const",
-          "line": 11,
+          "line": 39,
           "isUsed": false,
           "usedIn": [],
-          "size": 5075
+          "size": 6494
         },
         {
           "name": "updateMaterialsForWeather",
           "type": "function",
-          "line": 105,
+          "line": 252,
           "isUsed": false,
           "usedIn": [],
-          "size": 5075
+          "size": 6494
         }
       ],
       "treeShakingScore": 67
@@ -11735,26 +17385,26 @@
         {
           "name": "CaveOptions",
           "type": "interface",
-          "line": 15,
+          "line": 16,
           "isUsed": false,
           "usedIn": [],
-          "size": 3399
+          "size": 3538
         },
         {
           "name": "createCaveEntrance",
           "type": "function",
-          "line": 126,
+          "line": 127,
           "isUsed": false,
           "usedIn": [],
-          "size": 3399
+          "size": 3538
         },
         {
           "name": "updateCaveWaterLevel",
           "type": "function",
-          "line": 241,
+          "line": 243,
           "isUsed": true,
           "usedIn": [
-            "systems/weather.ts"
+            "systems/weather/weather.ts"
           ],
           "size": 0
         }
@@ -11780,18 +17430,18 @@
         {
           "name": "CaveOptions",
           "type": "interface",
-          "line": 15,
+          "line": 16,
           "isUsed": false,
           "usedIn": [],
-          "size": 3399
+          "size": 3538
         },
         {
           "name": "createCaveEntrance",
           "type": "function",
-          "line": 126,
+          "line": 127,
           "isUsed": false,
           "usedIn": [],
-          "size": 3399
+          "size": 3538
         }
       ],
       "treeShakingScore": 33
@@ -11806,7 +17456,7 @@
           "isUsed": true,
           "usedIn": [
             "foliage/clouds.ts",
-            "systems/weather.ts"
+            "systems/weather/weather-effects.ts"
           ],
           "size": 0
         },
@@ -11817,7 +17467,7 @@
           "isUsed": true,
           "usedIn": [
             "foliage/clouds.ts",
-            "systems/weather.ts"
+            "systems/weather/weather-effects.ts"
           ],
           "size": 0
         },
@@ -11828,12 +17478,12 @@
           "isUsed": true,
           "usedIn": [
             "foliage/clouds.ts",
-            "systems/weather.ts"
+            "systems/weather/weather-effects.ts"
           ],
           "size": 0
         },
         {
-          "name": "sharedCloudMaterial",
+          "name": "getSharedCloudMaterial",
           "type": "const",
           "line": 7,
           "isUsed": true,
@@ -11848,7 +17498,7 @@
           "line": 12,
           "isUsed": false,
           "usedIn": [],
-          "size": 423
+          "size": 447
         },
         {
           "name": "createRainingCloud",
@@ -11873,48 +17523,48 @@
         {
           "name": "createDecoCloud",
           "type": "function",
-          "line": 61,
+          "line": 63,
           "isUsed": false,
           "usedIn": [],
-          "size": 423
+          "size": 447
         },
         {
           "name": "updateCloudAttraction",
           "type": "function",
-          "line": 68,
+          "line": 70,
           "isUsed": true,
           "usedIn": [
-            "systems/weather.ts"
+            "systems/weather/weather-ecosystem.ts"
           ],
           "size": 0
         },
         {
           "name": "isCloudOverTarget",
           "type": "function",
-          "line": 104,
+          "line": 106,
           "isUsed": true,
           "usedIn": [
-            "systems/weather.ts"
+            "systems/weather/weather-ecosystem.ts"
           ],
           "size": 0
         },
         {
           "name": "updateFallingClouds",
           "type": "function",
-          "line": 110,
+          "line": 112,
           "isUsed": true,
           "usedIn": [
-            "main.ts"
+            "core/game-loop.ts"
           ],
           "size": 0
         }
       ],
       "imports": [
-        "cloudBatcher",
+        "CloudBatcher",
         "uCloudRainbowIntensity",
         "uCloudLightningStrength",
         "uCloudLightningColor",
-        "sharedCloudMaterial",
+        "getSharedCloudMaterial",
         "THREE"
       ],
       "unusedExports": [
@@ -11924,15 +17574,15 @@
           "line": 12,
           "isUsed": false,
           "usedIn": [],
-          "size": 423
+          "size": 447
         },
         {
           "name": "createDecoCloud",
           "type": "function",
-          "line": 61,
+          "line": 63,
           "isUsed": false,
           "usedIn": [],
-          "size": 423
+          "size": 447
         }
       ],
       "treeShakingScore": 82
@@ -11943,87 +17593,569 @@
         {
           "name": "ImpactType",
           "type": "type",
-          "line": 19,
+          "line": 27,
           "isUsed": false,
           "usedIn": [],
-          "size": 3646
+          "size": 4307
         },
         {
-          "name": "SpawnOptions",
+          "name": "ImpactSystemUserData",
           "type": "interface",
-          "line": 49,
+          "line": 70,
           "isUsed": false,
           "usedIn": [],
-          "size": 3646
+          "size": 4307
         },
         {
           "name": "createImpactSystem",
           "type": "function",
-          "line": 51,
+          "line": 92,
           "isUsed": true,
           "usedIn": [
-            "main.ts"
+            "core/deferred-init.ts"
           ],
           "size": 0
         },
         {
           "name": "spawnImpact",
           "type": "function",
-          "line": 197,
+          "line": 416,
           "isUsed": true,
           "usedIn": [
             "foliage/animation.ts",
+            "foliage/batcher/foliage-batcher-effects.ts",
             "foliage/berries.ts",
             "foliage/flowers.ts",
-            "foliage/foliage-batcher.ts",
             "foliage/instrument.ts",
             "foliage/lotus.ts",
             "foliage/mushroom-batcher.ts",
             "foliage/musical_flora.ts",
             "foliage/panning-pads.ts",
+            "foliage/wisteria-cluster.ts",
+            "gameplay/chord-strike.ts",
             "gameplay/jitter-mines.ts",
             "gameplay/rainbow-blaster.ts",
             "systems/glitch-grenade.ts",
-            "systems/physics.ts"
+            "systems/physics/physics-abilities.ts",
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-states.ts",
+            "systems/physics/physics-updates.ts",
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "updateImpacts",
+          "type": "function",
+          "line": 431,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts"
           ],
           "size": 0
         }
       ],
       "imports": [
         "MeshStandardNodeMaterial",
-        "attribute",
+        "StorageInstancedBufferAttribute",
         "float",
         "sin",
+        "cos",
+        "step",
         "positionLocal",
+        "storage",
+        "Fn",
+        "If",
+        "instanceIndex",
+        "uniform",
         "exp",
         "rotate",
         "normalize",
         "vec4",
         "vec3",
         "smoothstep",
+        "mix",
+        "floor",
         "uTime",
         "uAudioHigh",
+        "uAudioLow",
         "THREE"
       ],
       "unusedExports": [
         {
           "name": "ImpactType",
           "type": "type",
-          "line": 19,
+          "line": 27,
           "isUsed": false,
           "usedIn": [],
-          "size": 3646
+          "size": 4307
         },
         {
-          "name": "SpawnOptions",
+          "name": "ImpactSystemUserData",
           "type": "interface",
-          "line": 49,
+          "line": 70,
           "isUsed": false,
           "usedIn": [],
-          "size": 3646
+          "size": 4307
         }
       ],
-      "treeShakingScore": 50
+      "treeShakingScore": 60
+    },
+    {
+      "path": "foliage/luminous-plant.ts",
+      "exports": [
+        {
+          "name": "LuminousPlantOptions",
+          "type": "interface",
+          "line": 5,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 424
+        },
+        {
+          "name": "createLuminousPlant",
+          "type": "function",
+          "line": 9,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 424
+        }
+      ],
+      "imports": [
+        "LuminousPlantBatcher",
+        "attachReactivity",
+        "THREE"
+      ],
+      "unusedExports": [
+        {
+          "name": "LuminousPlantOptions",
+          "type": "interface",
+          "line": 5,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 424
+        },
+        {
+          "name": "createLuminousPlant",
+          "type": "function",
+          "line": 9,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 424
+        }
+      ],
+      "treeShakingScore": 0
+    },
+    {
+      "path": "rendering/culling/index.ts",
+      "exports": [
+        {
+          "name": "CullingSystem",
+          "type": "const",
+          "line": 50,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 510
+        },
+        {
+          "name": "CullingSystem as default",
+          "type": "const",
+          "line": 51,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 510
+        }
+      ],
+      "imports": [],
+      "unusedExports": [
+        {
+          "name": "CullingSystem",
+          "type": "const",
+          "line": 50,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 510
+        },
+        {
+          "name": "CullingSystem as default",
+          "type": "const",
+          "line": 51,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 510
+        }
+      ],
+      "treeShakingScore": 0
+    },
+    {
+      "path": "systems/asset-streaming/asset-streaming-types.ts",
+      "exports": [
+        {
+          "name": "AssetPriority",
+          "type": "enum",
+          "line": 13,
+          "isUsed": true,
+          "usedIn": [
+            "examples/asset-streaming-usage.ts",
+            "systems/asset-streaming/asset-loading-infrastructure.ts",
+            "systems/asset-streaming/asset-streaming-core.ts",
+            "systems/asset-streaming/asset-streaming-scheduler.ts",
+            "systems/asset-streaming/asset-streaming.ts",
+            "systems/index.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "AssetType",
+          "type": "enum",
+          "line": 22,
+          "isUsed": true,
+          "usedIn": [
+            "systems/asset-streaming/asset-streaming-core.ts",
+            "systems/asset-streaming/asset-streaming-loader.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "TextureFormat",
+          "type": "enum",
+          "line": 33,
+          "isUsed": true,
+          "usedIn": [
+            "systems/asset-streaming/asset-streaming-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "LoadState",
+          "type": "enum",
+          "line": 43,
+          "isUsed": true,
+          "usedIn": [
+            "systems/asset-streaming/asset-streaming-core.ts",
+            "systems/asset-streaming/asset-streaming.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "QualityLevel",
+          "type": "enum",
+          "line": 53,
+          "isUsed": true,
+          "usedIn": [
+            "examples/asset-streaming-usage.ts",
+            "systems/asset-streaming/asset-streaming-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "MemoryPressure",
+          "type": "enum",
+          "line": 62,
+          "isUsed": true,
+          "usedIn": [
+            "systems/asset-streaming/asset-streaming-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "AssetMetadata",
+          "type": "interface",
+          "line": 75,
+          "isUsed": true,
+          "usedIn": [
+            "systems/asset-streaming/asset-streaming-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "AssetManifest",
+          "type": "interface",
+          "line": 92,
+          "isUsed": true,
+          "usedIn": [
+            "systems/asset-streaming/asset-streaming-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "LoadedAsset",
+          "type": "interface",
+          "line": 101,
+          "isUsed": true,
+          "usedIn": [
+            "systems/asset-streaming/asset-streaming-core.ts",
+            "systems/asset-streaming/asset-streaming-scheduler.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "LoadingProgress",
+          "type": "interface",
+          "line": 115,
+          "isUsed": true,
+          "usedIn": [
+            "systems/asset-streaming/asset-streaming-core.ts",
+            "systems/asset-streaming/asset-streaming-scheduler.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "NetworkStats",
+          "type": "interface",
+          "line": 126,
+          "isUsed": true,
+          "usedIn": [
+            "systems/asset-streaming/asset-loading-infrastructure.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "StreamingConfig",
+          "type": "interface",
+          "line": 136,
+          "isUsed": true,
+          "usedIn": [
+            "systems/asset-streaming/asset-loading-infrastructure.ts",
+            "systems/asset-streaming/asset-streaming-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "StreamingStats",
+          "type": "interface",
+          "line": 175,
+          "isUsed": true,
+          "usedIn": [
+            "systems/asset-streaming/asset-streaming-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "AssetRequest",
+          "type": "interface",
+          "line": 194,
+          "isUsed": true,
+          "usedIn": [
+            "systems/asset-streaming/asset-streaming-core.ts",
+            "systems/asset-streaming/asset-streaming-scheduler.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "AssetBatch",
+          "type": "interface",
+          "line": 203,
+          "isUsed": true,
+          "usedIn": [
+            "systems/asset-streaming/asset-streaming-core.ts",
+            "systems/asset-streaming/asset-streaming-scheduler.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "DEFAULT_STREAMING_CONFIG",
+          "type": "const",
+          "line": 215,
+          "isUsed": true,
+          "usedIn": [
+            "systems/asset-streaming/asset-streaming-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "PRIORITY_DISTANCES",
+          "type": "const",
+          "line": 248,
+          "isUsed": true,
+          "usedIn": [
+            "systems/asset-streaming/asset-streaming-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "PRIORITY_DISTANCES_SQ",
+          "type": "const",
+          "line": 257,
+          "isUsed": true,
+          "usedIn": [
+            "systems/asset-streaming/asset-streaming-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "QUALITY_FORMAT_PREFERENCES",
+          "type": "const",
+          "line": 266,
+          "isUsed": true,
+          "usedIn": [
+            "systems/asset-streaming/asset-streaming-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createSampleManifest",
+          "type": "function",
+          "line": 279,
+          "isUsed": true,
+          "usedIn": [
+            "examples/asset-streaming-usage.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "estimateTextureMemory",
+          "type": "function",
+          "line": 290,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 456
+        },
+        {
+          "name": "estimateGeometryMemory",
+          "type": "function",
+          "line": 304,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 456
+        }
+      ],
+      "imports": [
+        "THREE"
+      ],
+      "unusedExports": [
+        {
+          "name": "estimateTextureMemory",
+          "type": "function",
+          "line": 290,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 456
+        },
+        {
+          "name": "estimateGeometryMemory",
+          "type": "function",
+          "line": 304,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 456
+        }
+      ],
+      "treeShakingScore": 91
+    },
+    {
+      "path": "systems/biome-uniforms.ts",
+      "exports": [
+        {
+          "name": "BiomeUniforms",
+          "type": "const",
+          "line": 19,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/arpeggio-batcher.ts",
+            "foliage/lotus.ts",
+            "foliage/moon.ts",
+            "foliage/mushroom-batcher.ts",
+            "foliage/portamento-batcher.ts",
+            "foliage/tree-batcher.ts",
+            "foliage/wisteria-cluster.ts",
+            "systems/music-reactivity.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "LuminousPlantUniforms",
+          "type": "const",
+          "line": 71,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/luminous-plant-batcher.ts",
+            "systems/music-reactivity.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "SkyUniforms",
+          "type": "const",
+          "line": 80,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/moon.ts",
+            "foliage/sky.ts",
+            "systems/music-reactivity.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "skyLutData",
+          "type": "const",
+          "line": 92,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 930
+        },
+        {
+          "name": "skyNoteColorNode",
+          "type": "const",
+          "line": 134,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/moon.ts",
+            "foliage/sky.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "luminousPlantsLutData",
+          "type": "const",
+          "line": 139,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 930
+        },
+        {
+          "name": "luminousPlantsNoteColorNode",
+          "type": "const",
+          "line": 168,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/luminous-plant-batcher.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "uniform",
+        "texture",
+        "vec2",
+        "DataTexture",
+        "RGBAFormat",
+        "HalfFloatType",
+        "Color",
+        "NearestFilter",
+        "DataUtils",
+        "CONFIG",
+        "THREE"
+      ],
+      "unusedExports": [
+        {
+          "name": "skyLutData",
+          "type": "const",
+          "line": 92,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 930
+        },
+        {
+          "name": "luminousPlantsLutData",
+          "type": "const",
+          "line": 139,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 930
+        }
+      ],
+      "treeShakingScore": 71
     },
     {
       "path": "systems/interaction.ts",
@@ -12034,7 +18166,7 @@
           "line": 5,
           "isUsed": false,
           "usedIn": [],
-          "size": 3323
+          "size": 3957
         },
         {
           "name": "ReticleCallback",
@@ -12042,7 +18174,7 @@
           "line": 20,
           "isUsed": false,
           "usedIn": [],
-          "size": 3323
+          "size": 3957
         },
         {
           "name": "InteractionSystem",
@@ -12050,7 +18182,8 @@
           "line": 22,
           "isUsed": true,
           "usedIn": [
-            "main.ts"
+            "core/game-loop.ts",
+            "core/main.ts"
           ],
           "size": 0
         }
@@ -12066,7 +18199,7 @@
           "line": 5,
           "isUsed": false,
           "usedIn": [],
-          "size": 3323
+          "size": 3957
         },
         {
           "name": "ReticleCallback",
@@ -12074,71 +18207,78 @@
           "line": 20,
           "isUsed": false,
           "usedIn": [],
-          "size": 3323
+          "size": 3957
         }
       ],
       "treeShakingScore": 33
     },
     {
-      "path": "systems/music-reactivity.ts",
+      "path": "systems/physics/physics.ts",
       "exports": [
         {
-          "name": "IWeatherSystem",
-          "type": "interface",
-          "line": 29,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 4675
-        },
-        {
-          "name": "MusicReactivitySystem",
-          "type": "class",
-          "line": 38,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 4675
-        },
-        {
-          "name": "musicReactivitySystem",
+          "name": "./physics-core.ts",
           "type": "const",
-          "line": 365,
+          "line": 8,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 93
+        },
+        {
+          "name": "./physics-updates.ts",
+          "type": "const",
+          "line": 9,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 93
+        },
+        {
+          "name": "player",
+          "type": "const",
+          "line": 10,
           "isUsed": true,
           "usedIn": [
-            "main.ts",
-            "systems/weather.ts"
+            "core/game-loop.ts",
+            "core/main.ts",
+            "systems/physics/physics-abilities.ts",
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-states.ts",
+            "systems/physics/physics-updates.ts",
+            "systems/save-integration-example.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "PlayerState",
+          "type": "const",
+          "line": 10,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-states.ts"
           ],
           "size": 0
         }
       ],
-      "imports": [
-        "CONFIG",
-        "CYCLE_DURATION",
-        "animateFoliage",
-        "foliageBatcher",
-        "arpeggioFernBatcher",
-        "portamentoPineBatcher",
-        "mushroomBatcher",
-        "THREE"
-      ],
+      "imports": [],
       "unusedExports": [
         {
-          "name": "IWeatherSystem",
-          "type": "interface",
-          "line": 29,
+          "name": "./physics-core.ts",
+          "type": "const",
+          "line": 8,
           "isUsed": false,
           "usedIn": [],
-          "size": 4675
+          "size": 93
         },
         {
-          "name": "MusicReactivitySystem",
-          "type": "class",
-          "line": 38,
+          "name": "./physics-updates.ts",
+          "type": "const",
+          "line": 9,
           "isUsed": false,
           "usedIn": [],
-          "size": 4675
+          "size": 93
         }
       ],
-      "treeShakingScore": 33
+      "treeShakingScore": 50
     },
     {
       "path": "systems/save-integration-example.ts",
@@ -12146,18 +18286,18 @@
         {
           "name": "initializeSaveSystemIntegration",
           "type": "function",
-          "line": 24,
+          "line": 29,
           "isUsed": false,
           "usedIn": [],
-          "size": 5300
+          "size": 5582
         },
         {
           "name": "addSaveMenuToUI",
           "type": "function",
-          "line": 269,
+          "line": 284,
           "isUsed": false,
           "usedIn": [],
-          "size": 5300
+          "size": 5582
         }
       ],
       "imports": [
@@ -12179,21 +18319,318 @@
         {
           "name": "initializeSaveSystemIntegration",
           "type": "function",
-          "line": 24,
+          "line": 29,
           "isUsed": false,
           "usedIn": [],
-          "size": 5300
+          "size": 5582
         },
         {
           "name": "addSaveMenuToUI",
           "type": "function",
-          "line": 269,
+          "line": 284,
           "isUsed": false,
           "usedIn": [],
-          "size": 5300
+          "size": 5582
         }
       ],
       "treeShakingScore": 0
+    },
+    {
+      "path": "ui/accessibility-menu.ts",
+      "exports": [
+        {
+          "name": "AccessibilityMenuRendering",
+          "type": "const",
+          "line": 18,
+          "isUsed": true,
+          "usedIn": [
+            "ui/accessibility-menu-handlers.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "AccessibilityMenuHandlers",
+          "type": "const",
+          "line": 19,
+          "isUsed": true,
+          "usedIn": [
+            "ui/accessibility-menu.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "AccessibilityMenu",
+          "type": "class",
+          "line": 25,
+          "isUsed": true,
+          "usedIn": [
+            "ui/accessibility-menu-rendering.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "openAccessibilityMenu",
+          "type": "function",
+          "line": 36,
+          "isUsed": true,
+          "usedIn": [
+            "core/input/input.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "closeAccessibilityMenu",
+          "type": "function",
+          "line": 46,
+          "isUsed": true,
+          "usedIn": [
+            "core/input/input.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createAccessibilityButton",
+          "type": "function",
+          "line": 54,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 473
+        },
+        {
+          "name": "addAccessibilityButtonToPage",
+          "type": "function",
+          "line": 94,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 473
+        }
+      ],
+      "imports": [
+        "AccessibilityMenuHandlers"
+      ],
+      "unusedExports": [
+        {
+          "name": "createAccessibilityButton",
+          "type": "function",
+          "line": 54,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 473
+        },
+        {
+          "name": "addAccessibilityButtonToPage",
+          "type": "function",
+          "line": 94,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 473
+        }
+      ],
+      "treeShakingScore": 71
+    },
+    {
+      "path": "ui/save-menu/save-slots.ts",
+      "exports": [
+        {
+          "name": "formatPlaytime",
+          "type": "function",
+          "line": 19,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1940
+        },
+        {
+          "name": "renderSlot",
+          "type": "function",
+          "line": 31,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1940
+        },
+        {
+          "name": "renderLoadTab",
+          "type": "function",
+          "line": 78,
+          "isUsed": true,
+          "usedIn": [
+            "ui/save-menu/save-menu.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "renderSaveTab",
+          "type": "function",
+          "line": 132,
+          "isUsed": true,
+          "usedIn": [
+            "ui/save-menu/save-menu.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "handleSlotAction",
+          "type": "function",
+          "line": 153,
+          "isUsed": true,
+          "usedIn": [
+            "ui/save-menu/save-menu.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "handleQuickSave",
+          "type": "function",
+          "line": 319,
+          "isUsed": true,
+          "usedIn": [
+            "ui/save-menu/save-menu.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "saveSystem",
+        "SaveData",
+        "SaveSlotInfo",
+        "showToast"
+      ],
+      "unusedExports": [
+        {
+          "name": "formatPlaytime",
+          "type": "function",
+          "line": 19,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1940
+        },
+        {
+          "name": "renderSlot",
+          "type": "function",
+          "line": 31,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1940
+        }
+      ],
+      "treeShakingScore": 67
+    },
+    {
+      "path": "utils/background-processor.ts",
+      "exports": [
+        {
+          "name": "DeferredTask",
+          "type": "interface",
+          "line": 8,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1345
+        },
+        {
+          "name": "BackgroundProcessor",
+          "type": "class",
+          "line": 13,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1345
+        },
+        {
+          "name": "globalBackgroundProcessor",
+          "type": "const",
+          "line": 133,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts",
+            "world/generation.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [],
+      "unusedExports": [
+        {
+          "name": "DeferredTask",
+          "type": "interface",
+          "line": 8,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1345
+        },
+        {
+          "name": "BackgroundProcessor",
+          "type": "class",
+          "line": 13,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1345
+        }
+      ],
+      "treeShakingScore": 33
+    },
+    {
+      "path": "world/ground-heightmap.ts",
+      "exports": [
+        {
+          "name": "HeightmapTextures",
+          "type": "interface",
+          "line": 6,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1627
+        },
+        {
+          "name": "generateGroundHeightmap",
+          "type": "function",
+          "line": 13,
+          "isUsed": true,
+          "usedIn": [
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "sampleHeightmapCPU",
+          "type": "function",
+          "line": 125,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1627
+        },
+        {
+          "name": "disposeHeightmap",
+          "type": "function",
+          "line": 168,
+          "isUsed": true,
+          "usedIn": [
+            "world/generation.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "DataUtils",
+        "getUnifiedGroundHeightTyped",
+        "getGroundHeight",
+        "THREE"
+      ],
+      "unusedExports": [
+        {
+          "name": "HeightmapTextures",
+          "type": "interface",
+          "line": 6,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1627
+        },
+        {
+          "name": "sampleHeightmapCPU",
+          "type": "function",
+          "line": 125,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1627
+        }
+      ],
+      "treeShakingScore": 50
     },
     {
       "path": "audio/beat-sync.ts",
@@ -12212,7 +18649,8 @@
           "line": 7,
           "isUsed": true,
           "usedIn": [
-            "main.ts"
+            "core/game-loop.ts",
+            "core/main.ts"
           ],
           "size": 0
         }
@@ -12233,55 +18671,107 @@
       "treeShakingScore": 50
     },
     {
+      "path": "compute/noise_generator.ts",
+      "exports": [
+        {
+          "name": "NoiseConfig",
+          "type": "interface",
+          "line": 27,
+          "isUsed": true,
+          "usedIn": [
+            "compute/noise-generator-gpu.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "ProceduralNoiseCompute",
+          "type": "class",
+          "line": 48,
+          "isUsed": true,
+          "usedIn": [
+            "compute/noise-generator-gpu.ts",
+            "compute/noise_generator.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createCandySwirlTexture",
+          "type": "function",
+          "line": 279,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2730
+        }
+      ],
+      "imports": [
+        "ProceduralNoiseCompute",
+        "uniform",
+        "THREE"
+      ],
+      "unusedExports": [
+        {
+          "name": "createCandySwirlTexture",
+          "type": "function",
+          "line": 279,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2730
+        }
+      ],
+      "treeShakingScore": 67
+    },
+    {
       "path": "core/config.ts",
       "exports": [
         {
           "name": "DURATION_SUNRISE",
           "type": "const",
-          "line": 4,
+          "line": 5,
           "isUsed": true,
           "usedIn": [
             "core/cycle.ts",
-            "main.ts",
-            "systems/weather-utils.ts",
-            "systems/weather.ts"
+            "core/game-loop.ts",
+            "systems/weather/weather-atmosphere.ts",
+            "systems/weather/weather.ts",
+            "systems/weather-utils.ts"
           ],
           "size": 0
         },
         {
           "name": "DURATION_DAY",
           "type": "const",
-          "line": 5,
+          "line": 6,
           "isUsed": true,
           "usedIn": [
             "core/cycle.ts",
-            "main.ts",
-            "systems/weather-utils.ts",
-            "systems/weather.ts"
+            "core/game-loop.ts",
+            "systems/weather/weather-atmosphere.ts",
+            "systems/weather/weather.ts",
+            "systems/weather-utils.ts"
           ],
           "size": 0
         },
         {
           "name": "DURATION_SUNSET",
           "type": "const",
-          "line": 6,
+          "line": 7,
           "isUsed": true,
           "usedIn": [
             "core/cycle.ts",
-            "main.ts",
-            "systems/weather-utils.ts",
-            "systems/weather.ts"
+            "core/game-loop.ts",
+            "systems/weather/weather-atmosphere.ts",
+            "systems/weather-utils.ts"
           ],
           "size": 0
         },
         {
           "name": "DURATION_DUSK_NIGHT",
           "type": "const",
-          "line": 7,
+          "line": 8,
           "isUsed": true,
           "usedIn": [
             "core/cycle.ts",
-            "main.ts",
+            "core/game-loop.ts",
             "systems/weather-utils.ts"
           ],
           "size": 0
@@ -12289,43 +18779,45 @@
         {
           "name": "DURATION_DEEP_NIGHT",
           "type": "const",
-          "line": 8,
+          "line": 9,
           "isUsed": true,
           "usedIn": [
             "core/cycle.ts",
-            "main.ts"
+            "core/game-loop.ts"
           ],
           "size": 0
         },
         {
           "name": "DURATION_PRE_DAWN",
           "type": "const",
-          "line": 9,
+          "line": 10,
           "isUsed": true,
           "usedIn": [
             "core/cycle.ts",
-            "systems/weather.ts"
+            "systems/weather/weather-atmosphere.ts"
           ],
           "size": 0
         },
         {
           "name": "CYCLE_DURATION",
           "type": "const",
-          "line": 10,
+          "line": 11,
           "isUsed": true,
           "usedIn": [
             "core/cycle.ts",
-            "main.ts",
+            "core/game-loop.ts",
+            "core/hud.ts",
             "systems/music-reactivity.ts",
-            "systems/weather-utils.ts",
-            "systems/weather.ts"
+            "systems/weather/weather-atmosphere.ts",
+            "systems/weather/weather.ts",
+            "systems/weather-utils.ts"
           ],
           "size": 0
         },
         {
           "name": "PaletteEntry",
           "type": "interface",
-          "line": 12,
+          "line": 13,
           "isUsed": true,
           "usedIn": [
             "core/cycle.ts"
@@ -12335,33 +18827,50 @@
         {
           "name": "PALETTE",
           "type": "const",
-          "line": 24,
+          "line": 25,
           "isUsed": true,
           "usedIn": [
-            "core/cycle.ts"
+            "core/cycle.ts",
+            "core/init.ts"
           ],
           "size": 0
         },
         {
           "name": "ConfigType",
           "type": "interface",
-          "line": 96,
+          "line": 97,
           "isUsed": false,
           "usedIn": [],
-          "size": 775
+          "size": 1184
         },
         {
           "name": "CONFIG",
           "type": "const",
-          "line": 140,
+          "line": 177,
           "isUsed": true,
           "usedIn": [
+            "core/init.ts",
+            "core/main.ts",
             "foliage/animation.ts",
-            "main.ts",
+            "foliage/arpeggio-batcher.ts",
+            "foliage/dandelion-batcher.ts",
+            "foliage/flower-batcher.ts",
+            "foliage/lantern-batcher.ts",
+            "foliage/lotus.ts",
+            "foliage/luminous-plant-batcher.ts",
+            "foliage/mushroom-batcher.ts",
+            "foliage/portamento-batcher.ts",
+            "foliage/simple-flower-batcher.ts",
+            "foliage/tree-batcher.ts",
+            "foliage/wisteria-cluster.ts",
+            "rendering/shader-warmup.ts",
+            "systems/biome-uniforms.ts",
             "systems/interaction.ts",
             "systems/material-batcher.ts",
             "systems/music-reactivity.ts",
-            "systems/weather.ts",
+            "systems/weather/weather-atmosphere.ts",
+            "systems/weather/weather-effects.ts",
+            "systems/weather/weather.ts",
             "world/generation.ts"
           ],
           "size": 0
@@ -12374,74 +18883,13 @@
         {
           "name": "ConfigType",
           "type": "interface",
-          "line": 96,
+          "line": 97,
           "isUsed": false,
           "usedIn": [],
-          "size": 775
+          "size": 1184
         }
       ],
       "treeShakingScore": 91
-    },
-    {
-      "path": "core/input.ts",
-      "exports": [
-        {
-          "name": "KeyStates",
-          "type": "interface",
-          "line": 7,
-          "isUsed": true,
-          "usedIn": [
-            "systems/physics.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "keyStates",
-          "type": "const",
-          "line": 22,
-          "isUsed": true,
-          "usedIn": [
-            "main.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "InitInputResult",
-          "type": "interface",
-          "line": 70,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 10926
-        },
-        {
-          "name": "initInput",
-          "type": "function",
-          "line": 76,
-          "isUsed": true,
-          "usedIn": [
-            "main.ts"
-          ],
-          "size": 0
-        }
-      ],
-      "imports": [
-        "PointerLockControls",
-        "AudioSystem",
-        "discoverySystem",
-        "trapFocusInside",
-        "THREE"
-      ],
-      "unusedExports": [
-        {
-          "name": "InitInputResult",
-          "type": "interface",
-          "line": 70,
-          "isUsed": false,
-          "usedIn": [],
-          "size": 10926
-        }
-      ],
-      "treeShakingScore": 75
     },
     {
       "path": "foliage/arpeggio-batcher.ts",
@@ -12449,15 +18897,15 @@
         {
           "name": "ArpeggioFernBatcher",
           "type": "class",
-          "line": 25,
+          "line": 30,
           "isUsed": false,
           "usedIn": [],
-          "size": 7451
+          "size": 8932
         },
         {
           "name": "arpeggioFernBatcher",
           "type": "const",
-          "line": 404,
+          "line": 445,
           "isUsed": true,
           "usedIn": [
             "foliage/musical_flora.ts",
@@ -12492,20 +18940,25 @@
         "positionWorld",
         "If",
         "vec4",
+        "varyingProperty",
+        "BiomeUniforms",
         "uTime",
         "uGlitchIntensity",
         "applyGlitch",
         "mergeGeometries",
+        "PlantPoseMachine",
+        "CONFIG",
+        "dynamicRadiiView",
         "THREE"
       ],
       "unusedExports": [
         {
           "name": "ArpeggioFernBatcher",
           "type": "class",
-          "line": 25,
+          "line": 30,
           "isUsed": false,
           "usedIn": [],
-          "size": 7451
+          "size": 8932
         }
       ],
       "treeShakingScore": 50
@@ -12546,41 +18999,53 @@
         {
           "name": "uAuroraIntensity",
           "type": "const",
-          "line": 9,
+          "line": 10,
           "isUsed": true,
           "usedIn": [
-            "main.ts",
-            "systems/weather.ts"
+            "core/game-loop.ts",
+            "systems/weather/weather-effects.ts"
           ],
           "size": 0
         },
         {
           "name": "uAuroraColor",
           "type": "const",
-          "line": 10,
+          "line": 11,
           "isUsed": true,
           "usedIn": [
-            "main.ts"
+            "core/game-loop.ts"
           ],
           "size": 0
         },
         {
           "name": "uAuroraSpeed",
           "type": "const",
-          "line": 11,
+          "line": 12,
           "isUsed": false,
           "usedIn": [],
-          "size": 840
+          "size": 2966
         },
         {
           "name": "createAurora",
           "type": "function",
-          "line": 13,
+          "line": 14,
           "isUsed": true,
           "usedIn": [
-            "main.ts",
+            "core/deferred-init.ts",
             "systems/deferred-loader.ts",
-            "systems/weather.ts"
+            "systems/weather/weather-effects.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "harmonyOrbSystem",
+          "type": "const",
+          "line": 377,
+          "isUsed": true,
+          "usedIn": [
+            "core/deferred-init.ts",
+            "core/game-loop.ts",
+            "systems/physics/physics-updates.ts"
           ],
           "size": 0
         }
@@ -12597,134 +19062,251 @@
         "Fn",
         "time",
         "mx_noise_float",
+        "positionWorld",
+        "positionLocal",
+        "dot",
+        "sin",
+        "cos",
+        "storage",
+        "instanceIndex",
+        "vec2",
+        "If",
         "MeshBasicNodeMaterial",
+        "MeshStandardNodeMaterial",
+        "StorageInstancedBufferAttribute",
         "uAudioLow",
         "uAudioHigh",
+        "CandyPresets",
+        "uTime",
+        "createJuicyRimLight",
+        "getSphereGeometry",
         "THREE"
       ],
       "unusedExports": [
         {
           "name": "uAuroraSpeed",
           "type": "const",
-          "line": 11,
+          "line": 12,
           "isUsed": false,
           "usedIn": [],
-          "size": 840
+          "size": 2966
         }
       ],
-      "treeShakingScore": 75
+      "treeShakingScore": 80
     },
     {
-      "path": "foliage/cloud-batcher.ts",
+      "path": "foliage/batcher/foliage-batcher-core.ts",
       "exports": [
         {
-          "name": "uCloudRainbowIntensity",
-          "type": "const",
-          "line": 17,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/clouds.ts",
-            "systems/weather.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "uCloudLightningStrength",
-          "type": "const",
-          "line": 18,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/clouds.ts",
-            "systems/weather.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "uCloudLightningColor",
-          "type": "const",
-          "line": 19,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/clouds.ts",
-            "systems/weather.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "sharedCloudMaterial",
-          "type": "const",
-          "line": 149,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/clouds.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "CloudBatcher",
+          "name": "FoliageBatcher",
           "type": "class",
-          "line": 159,
+          "line": 38,
           "isUsed": false,
           "usedIn": [],
-          "size": 2050
+          "size": 14954
         },
         {
-          "name": "cloudBatcher",
+          "name": "foliageBatcher",
           "type": "const",
-          "line": 309,
+          "line": 815,
           "isUsed": true,
           "usedIn": [
-            "foliage/clouds.ts",
-            "foliage/procedural-sky.ts",
-            "main.ts"
+            "foliage/animation.ts",
+            "systems/music-reactivity.ts"
           ],
           "size": 0
         }
       ],
       "imports": [
-        "MeshStandardNodeMaterial",
-        "color",
-        "uniform",
-        "mix",
-        "vec3",
-        "positionLocal",
-        "normalLocal",
-        "mx_noise_float",
-        "float",
-        "normalize",
-        "positionWorld",
-        "normalWorld",
-        "cameraPosition",
-        "dot",
-        "abs",
-        "sin",
-        "pow",
-        "uv",
-        "smoothstep",
-        "uTime",
-        "createJuicyRimLight",
-        "uAudioLow",
-        "uAudioHigh",
-        "uWindSpeed",
-        "uWindDirection",
-        "triplanarNoise",
-        "foliageGroup",
-        "getIcosahedronGeometry",
-        "uSkyDarkness",
-        "uTwilight",
+        "getWasmInstance",
+        "BATCH_SIZE",
+        "BATCH_MEMORY_START",
+        "BATCH_ARRAY_SIZE",
+        "EXTENDED_BATCH_START",
+        "ENTRY_STRIDE",
+        "ENTRY_SIZE",
+        "RESULT_STRIDE",
+        "BatchState",
+        "ExtendedBatchState",
+        "FoliageObject",
+        "getVibratoAmount",
+        "getTremoloAmount",
+        "getHighFreqAmount",
+        "getAverageVolume",
+        "getPanActivity",
+        "applySnareSnap",
+        "applyAccordion",
+        "applyFiberWhip",
+        "applySpiralWave",
+        "applyVibratoShake",
+        "applyTremoloPulse",
+        "applyCymbalShake",
+        "applyPanningBob",
+        "applySpiritFade",
         "THREE"
       ],
       "unusedExports": [
         {
-          "name": "CloudBatcher",
+          "name": "FoliageBatcher",
           "type": "class",
-          "line": 159,
+          "line": 38,
           "isUsed": false,
           "usedIn": [],
-          "size": 2050
+          "size": 14954
         }
       ],
-      "treeShakingScore": 83
+      "treeShakingScore": 50
+    },
+    {
+      "path": "foliage/batcher/foliage-batcher-types.ts",
+      "exports": [
+        {
+          "name": "BATCH_SIZE",
+          "type": "const",
+          "line": 8,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/batcher/foliage-batcher-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "BATCH_MEMORY_START",
+          "type": "const",
+          "line": 16,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/batcher/foliage-batcher-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "BATCH_ARRAY_SIZE",
+          "type": "const",
+          "line": 17,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/batcher/foliage-batcher-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "EXTENDED_BATCH_START",
+          "type": "const",
+          "line": 21,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/batcher/foliage-batcher-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "ENTRY_STRIDE",
+          "type": "const",
+          "line": 22,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/batcher/foliage-batcher-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "ENTRY_SIZE",
+          "type": "const",
+          "line": 23,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/batcher/foliage-batcher-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "RESULT_STRIDE",
+          "type": "const",
+          "line": 24,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/batcher/foliage-batcher-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "RESULT_SIZE",
+          "type": "const",
+          "line": 25,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 267
+        },
+        {
+          "name": "BatchState",
+          "type": "interface",
+          "line": 27,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/batcher/foliage-batcher-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "ExtendedBatchState",
+          "type": "interface",
+          "line": 54,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/batcher/foliage-batcher-core.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [],
+      "unusedExports": [
+        {
+          "name": "RESULT_SIZE",
+          "type": "const",
+          "line": 25,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 267
+        }
+      ],
+      "treeShakingScore": 90
+    },
+    {
+      "path": "foliage/batcher/index.ts",
+      "exports": [
+        {
+          "name": "FoliageBatcher",
+          "type": "const",
+          "line": 5,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 497
+        },
+        {
+          "name": "foliageBatcher",
+          "type": "const",
+          "line": 5,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/animation.ts",
+            "systems/music-reactivity.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [],
+      "unusedExports": [
+        {
+          "name": "FoliageBatcher",
+          "type": "const",
+          "line": 5,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 497
+        }
+      ],
+      "treeShakingScore": 50
     },
     {
       "path": "foliage/dandelion-batcher.ts",
@@ -12732,19 +19314,19 @@
         {
           "name": "DandelionBatcher",
           "type": "class",
-          "line": 34,
+          "line": 38,
           "isUsed": false,
           "usedIn": [],
-          "size": 5135
+          "size": 5915
         },
         {
           "name": "dandelionBatcher",
           "type": "const",
-          "line": 283,
+          "line": 303,
           "isUsed": true,
           "usedIn": [
             "foliage/musical_flora.ts",
-            "systems/physics.ts"
+            "systems/physics/physics-abilities.ts"
           ],
           "size": 0
         }
@@ -12759,12 +19341,17 @@
         "uAudioHigh",
         "uTime",
         "createSugarSparkle",
+        "createJuicyRimLight",
+        "getCachedProceduralMaterial",
+        "CONFIG",
+        "uTwilight",
         "float",
         "vec3",
         "positionLocal",
         "attribute",
         "mix",
         "sin",
+        "color",
         "instanceIndex",
         "normalLocal",
         "step",
@@ -12775,13 +19362,153 @@
         {
           "name": "DandelionBatcher",
           "type": "class",
-          "line": 34,
+          "line": 38,
           "isUsed": false,
           "usedIn": [],
-          "size": 5135
+          "size": 5915
         }
       ],
       "treeShakingScore": 50
+    },
+    {
+      "path": "foliage/dandelion-seeds.ts",
+      "exports": [
+        {
+          "name": "DandelionSeedUserData",
+          "type": "interface",
+          "line": 17,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 3025
+        },
+        {
+          "name": "createDandelionSeedSystem",
+          "type": "function",
+          "line": 43,
+          "isUsed": true,
+          "usedIn": [
+            "core/deferred-init.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "spawnDandelionExplosion",
+          "type": "function",
+          "line": 250,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/musical_flora.ts",
+            "systems/physics/physics-abilities.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "updateDandelionSeeds",
+          "type": "function",
+          "line": 317,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "mergeGeometries",
+        "MeshStandardNodeMaterial",
+        "StorageInstancedBufferAttribute",
+        "attribute",
+        "float",
+        "sin",
+        "cos",
+        "positionLocal",
+        "normalLocal",
+        "exp",
+        "rotate",
+        "normalize",
+        "vec4",
+        "vec3",
+        "smoothstep",
+        "step",
+        "mix",
+        "color",
+        "storage",
+        "instanceIndex",
+        "uniform",
+        "Fn",
+        "If",
+        "uTime",
+        "uAudioHigh",
+        "uWindSpeed",
+        "uWindDirection",
+        "createSugarSparkle",
+        "THREE"
+      ],
+      "unusedExports": [
+        {
+          "name": "DandelionSeedUserData",
+          "type": "interface",
+          "line": 17,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 3025
+        }
+      ],
+      "treeShakingScore": 75
+    },
+    {
+      "path": "foliage/fireflies.ts",
+      "exports": [
+        {
+          "name": "createFireflies",
+          "type": "function",
+          "line": 14,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 7297
+        }
+      ],
+      "imports": [
+        "MeshStandardNodeMaterial",
+        "StorageBufferAttribute",
+        "Fn",
+        "uniform",
+        "storage",
+        "instanceIndex",
+        "float",
+        "vec3",
+        "mix",
+        "sin",
+        "cos",
+        "normalize",
+        "color",
+        "mx_noise_float",
+        "positionLocal",
+        "max",
+        "length",
+        "min",
+        "vec4",
+        "positionWorld",
+        "normalLocal",
+        "uTime",
+        "uAudioLow",
+        "uAudioHigh",
+        "uPlayerPosition",
+        "sharedGeometries",
+        "createJuicyRimLight",
+        "THREE"
+      ],
+      "unusedExports": [
+        {
+          "name": "createFireflies",
+          "type": "function",
+          "line": 14,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 7297
+        }
+      ],
+      "treeShakingScore": 0
     },
     {
       "path": "foliage/flower-batcher.ts",
@@ -12792,15 +19519,17 @@
           "line": 32,
           "isUsed": false,
           "usedIn": [],
-          "size": 7315
+          "size": 9965
         },
         {
           "name": "flowerBatcher",
           "type": "const",
-          "line": 340,
+          "line": 427,
           "isUsed": true,
           "usedIn": [
-            "foliage/flowers.ts"
+            "foliage/flowers.ts",
+            "systems/music-reactivity.ts",
+            "systems/weather/weather-ecosystem.ts"
           ],
           "size": 0
         }
@@ -12813,17 +19542,24 @@
         "calculateFlowerBloom",
         "calculateWindSway",
         "applyPlayerInteraction",
+        "attachReactivity",
         "CandyPresets",
-        "createStandardNodeMaterial",
-        "createJuicyRimLight",
         "uAudioHigh",
+        "uAudioLow",
         "uTime",
+        "createJuicyRimLight",
+        "getCachedProceduralMaterial",
+        "createStandardNodeMaterial",
+        "CONFIG",
+        "uTwilight",
         "attribute",
         "positionLocal",
         "mix",
         "color",
         "float",
         "sin",
+        "varyingProperty",
+        "PlantPoseMachine",
         "THREE"
       ],
       "unusedExports": [
@@ -12833,51 +19569,144 @@
           "line": 32,
           "isUsed": false,
           "usedIn": [],
-          "size": 7315
+          "size": 9965
         }
       ],
       "treeShakingScore": 50
     },
     {
-      "path": "foliage/foliage-batcher.ts",
+      "path": "foliage/foliage-reactivity.ts",
       "exports": [
         {
-          "name": "FoliageBatcher",
-          "type": "class",
-          "line": 68,
+          "name": "reactiveObjects",
+          "type": "const",
+          "line": 8,
           "isUsed": false,
           "usedIn": [],
-          "size": 20422
+          "size": 1003
         },
         {
-          "name": "foliageBatcher",
+          "name": "reactiveMaterials",
           "type": "const",
-          "line": 1060,
+          "line": 10,
           "isUsed": true,
           "usedIn": [
-            "foliage/animation.ts",
-            "systems/music-reactivity.ts"
+            "foliage/animation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "_foliageReactiveColor",
+          "type": "const",
+          "line": 11,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/animation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "registerReactiveMaterial",
+          "type": "function",
+          "line": 13,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/arpeggio-batcher.ts",
+            "foliage/environment.ts",
+            "foliage/flowers.ts",
+            "foliage/lotus.ts",
+            "foliage/musical_flora.ts",
+            "foliage/panning-pads.ts",
+            "foliage/portamento-batcher.ts",
+            "foliage/silence-spirits.ts",
+            "foliage/trees.ts",
+            "foliage/waterfall-batcher.ts",
+            "foliage/waterfalls.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "pickAnimation",
+          "type": "function",
+          "line": 17,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/flowers.ts",
+            "foliage/trees.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "attachReactivity",
+          "type": "function",
+          "line": 21,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/celestial-bodies.ts",
+            "foliage/environment.ts",
+            "foliage/flower-batcher.ts",
+            "foliage/flowers.ts",
+            "foliage/instrument.ts",
+            "foliage/lake_features.ts",
+            "foliage/lotus.ts",
+            "foliage/luminous-plant.ts",
+            "foliage/mirrors.ts",
+            "foliage/moon.ts",
+            "foliage/musical_flora.ts",
+            "foliage/panning-pads.ts",
+            "foliage/silence-spirits.ts",
+            "foliage/trees.ts",
+            "foliage/waterfalls.ts",
+            "foliage/wisteria-cluster.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "cleanupReactivity",
+          "type": "function",
+          "line": 31,
+          "isUsed": true,
+          "usedIn": [
+            "systems/weather/weather-ecosystem.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "validateFoliageMaterials",
+          "type": "function",
+          "line": 38,
+          "isUsed": true,
+          "usedIn": [
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "validateNodeGeometries",
+          "type": "function",
+          "line": 62,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
           ],
           "size": 0
         }
       ],
       "imports": [
-        "getWasmInstance",
-        "FoliageObject",
-        "spawnImpact",
+        "_scratchVec1",
         "THREE"
       ],
       "unusedExports": [
         {
-          "name": "FoliageBatcher",
-          "type": "class",
-          "line": 68,
+          "name": "reactiveObjects",
+          "type": "const",
+          "line": 8,
           "isUsed": false,
           "usedIn": [],
-          "size": 20422
+          "size": 1003
         }
       ],
-      "treeShakingScore": 50
+      "treeShakingScore": 89
     },
     {
       "path": "foliage/glitch.ts",
@@ -12888,7 +19717,7 @@
           "line": 10,
           "isUsed": false,
           "usedIn": [],
-          "size": 879
+          "size": 895
         },
         {
           "name": "applyGlitch",
@@ -12897,7 +19726,7 @@
           "isUsed": true,
           "usedIn": [
             "foliage/arpeggio-batcher.ts",
-            "foliage/common.ts",
+            "foliage/material-core.ts",
             "foliage/musical_flora.ts",
             "foliage/tree-batcher.ts",
             "gameplay/jitter-mines.ts"
@@ -12910,8 +19739,7 @@
         "float",
         "floor",
         "mx_noise_float",
-        "mix",
-        "Node"
+        "mix"
       ],
       "unusedExports": [
         {
@@ -12920,7 +19748,7 @@
           "line": 10,
           "isUsed": false,
           "usedIn": [],
-          "size": 879
+          "size": 895
         }
       ],
       "treeShakingScore": 50
@@ -12934,12 +19762,12 @@
           "line": 28,
           "isUsed": false,
           "usedIn": [],
-          "size": 5659
+          "size": 6226
         },
         {
           "name": "glowingFlowerBatcher",
           "type": "const",
-          "line": 266,
+          "line": 278,
           "isUsed": true,
           "usedIn": [
             "foliage/flowers.ts"
@@ -12959,7 +19787,7 @@
         "smoothstep",
         "uniform",
         "mix",
-        "Node",
+        "varyingProperty",
         "sharedGeometries",
         "foliageMaterials",
         "uTime",
@@ -12982,7 +19810,7 @@
           "line": 28,
           "isUsed": false,
           "usedIn": [],
-          "size": 5659
+          "size": 6226
         }
       ],
       "treeShakingScore": 50
@@ -12993,7 +19821,7 @@
         {
           "name": "initGrassSystem",
           "type": "function",
-          "line": 13,
+          "line": 14,
           "isUsed": true,
           "usedIn": [
             "world/generation.ts"
@@ -13003,7 +19831,7 @@
         {
           "name": "addGrassInstance",
           "type": "function",
-          "line": 142,
+          "line": 143,
           "isUsed": true,
           "usedIn": [
             "world/generation.ts"
@@ -13013,10 +19841,10 @@
         {
           "name": "createGrass",
           "type": "function",
-          "line": 159,
+          "line": 161,
           "isUsed": false,
           "usedIn": [],
-          "size": 2567
+          "size": 2640
         }
       ],
       "imports": [
@@ -13047,10 +19875,10 @@
         {
           "name": "createGrass",
           "type": "function",
-          "line": 159,
+          "line": 161,
           "isUsed": false,
           "usedIn": [],
-          "size": 2567
+          "size": 2640
         }
       ],
       "treeShakingScore": 67
@@ -13064,7 +19892,7 @@
           "line": 18,
           "isUsed": false,
           "usedIn": [],
-          "size": 3564
+          "size": 3563
         },
         {
           "name": "createInstrumentShrine",
@@ -13106,7 +19934,53 @@
           "line": 18,
           "isUsed": false,
           "usedIn": [],
-          "size": 3564
+          "size": 3563
+        }
+      ],
+      "treeShakingScore": 50
+    },
+    {
+      "path": "foliage/lake_features.ts",
+      "exports": [
+        {
+          "name": "IslandOptions",
+          "type": "interface",
+          "line": 10,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1963
+        },
+        {
+          "name": "createIsland",
+          "type": "function",
+          "line": 19,
+          "isUsed": true,
+          "usedIn": [
+            "world/generation.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "CandyPresets",
+        "attachReactivity",
+        "positionLocal",
+        "vec3",
+        "float",
+        "sin",
+        "time",
+        "uv",
+        "add",
+        "THREE"
+      ],
+      "unusedExports": [
+        {
+          "name": "IslandOptions",
+          "type": "interface",
+          "line": 10,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1963
         }
       ],
       "treeShakingScore": 50
@@ -13117,15 +19991,15 @@
         {
           "name": "LanternBatcher",
           "type": "class",
-          "line": 27,
+          "line": 29,
           "isUsed": false,
           "usedIn": [],
-          "size": 6562
+          "size": 7148
         },
         {
           "name": "lanternBatcher",
           "type": "const",
-          "line": 343,
+          "line": 356,
           "isUsed": true,
           "usedIn": [
             "foliage/flowers.ts"
@@ -13156,6 +20030,7 @@
         "step",
         "uv",
         "mx_noise_float",
+        "varyingProperty",
         "sharedGeometries",
         "foliageMaterials",
         "uTime",
@@ -13170,16 +20045,18 @@
         "foliageGroup",
         "getTorusGeometry",
         "getConeGeometry",
+        "CONFIG",
+        "uTwilight",
         "THREE"
       ],
       "unusedExports": [
         {
           "name": "LanternBatcher",
           "type": "class",
-          "line": 27,
+          "line": 29,
           "isUsed": false,
           "usedIn": [],
-          "size": 6562
+          "size": 7148
         }
       ],
       "treeShakingScore": 50
@@ -13193,7 +20070,7 @@
           "line": 56,
           "isUsed": false,
           "usedIn": [],
-          "size": 3402
+          "size": 3401
         },
         {
           "name": "createMelodyMirror",
@@ -13235,7 +20112,7 @@
           "line": 56,
           "isUsed": false,
           "usedIn": [],
-          "size": 3402
+          "size": 3401
         }
       ],
       "treeShakingScore": 50
@@ -13246,26 +20123,27 @@
         {
           "name": "MushroomBatcher",
           "type": "class",
-          "line": 29,
+          "line": 44,
           "isUsed": false,
           "usedIn": [],
-          "size": 16740
+          "size": 17943
         },
         {
           "name": "mushroomBatcher",
           "type": "const",
-          "line": 766,
+          "line": 801,
           "isUsed": true,
           "usedIn": [
             "foliage/mushrooms.ts",
             "systems/music-reactivity.ts",
-            "systems/weather.ts"
+            "systems/weather/weather-ecosystem.ts"
           ],
           "size": 0
         }
       ],
       "imports": [
         "MeshStandardNodeMaterial",
+        "instanceIndex",
         "color",
         "float",
         "vec3",
@@ -13293,6 +20171,7 @@
         "cameraPosition",
         "uv",
         "floor",
+        "varyingProperty",
         "sharedGeometries",
         "foliageMaterials",
         "uTime",
@@ -13303,20 +20182,23 @@
         "uPlayerPosition",
         "colorFromNote",
         "createSugarSparkle",
+        "applyPlayerInteraction",
         "uTwilight",
+        "BiomeUniforms",
         "foliageGroup",
         "spawnImpact",
         "uChromaticIntensity",
+        "CONFIG",
         "THREE"
       ],
       "unusedExports": [
         {
           "name": "MushroomBatcher",
           "type": "class",
-          "line": 29,
+          "line": 44,
           "isUsed": false,
           "usedIn": [],
-          "size": 16740
+          "size": 17943
         }
       ],
       "treeShakingScore": 50
@@ -13330,7 +20212,7 @@
           "line": 22,
           "isUsed": false,
           "usedIn": [],
-          "size": 2887
+          "size": 2896
         },
         {
           "name": "createPanningPad",
@@ -13376,10 +20258,105 @@
           "line": 22,
           "isUsed": false,
           "usedIn": [],
-          "size": 2887
+          "size": 2896
         }
       ],
       "treeShakingScore": 50
+    },
+    {
+      "path": "foliage/plant-pose-machine.ts",
+      "exports": [
+        {
+          "name": "PlantPoseConfig",
+          "type": "interface",
+          "line": 13,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2403
+        },
+        {
+          "name": "PlantPoseMachine",
+          "type": "class",
+          "line": 40,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/arpeggio-batcher.ts",
+            "foliage/flower-batcher.ts",
+            "foliage/portamento-batcher.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [],
+      "unusedExports": [
+        {
+          "name": "PlantPoseConfig",
+          "type": "interface",
+          "line": 13,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2403
+        }
+      ],
+      "treeShakingScore": 50
+    },
+    {
+      "path": "foliage/pollen.ts",
+      "exports": [
+        {
+          "name": "createNeonPollen",
+          "type": "function",
+          "line": 12,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 7221
+        }
+      ],
+      "imports": [
+        "PointsNodeMaterial",
+        "StorageBufferAttribute",
+        "Fn",
+        "uniform",
+        "storage",
+        "instanceIndex",
+        "float",
+        "vec3",
+        "mix",
+        "sin",
+        "cos",
+        "normalize",
+        "color",
+        "mx_noise_float",
+        "vertexIndex",
+        "max",
+        "min",
+        "length",
+        "positionLocal",
+        "time",
+        "uv",
+        "distance",
+        "smoothstep",
+        "discard",
+        "vec2",
+        "uTime",
+        "uAudioLow",
+        "uAudioHigh",
+        "uWindSpeed",
+        "uWindDirection",
+        "uPlayerPosition",
+        "THREE"
+      ],
+      "unusedExports": [
+        {
+          "name": "createNeonPollen",
+          "type": "function",
+          "line": 12,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 7221
+        }
+      ],
+      "treeShakingScore": 0
     },
     {
       "path": "foliage/portamento-batcher.ts",
@@ -13387,15 +20364,15 @@
         {
           "name": "PortamentoPineBatcher",
           "type": "class",
-          "line": 22,
+          "line": 37,
           "isUsed": false,
           "usedIn": [],
-          "size": 3969
+          "size": 5651
         },
         {
           "name": "portamentoPineBatcher",
           "type": "const",
-          "line": 234,
+          "line": 287,
           "isUsed": true,
           "usedIn": [
             "foliage/musical_flora.ts",
@@ -13405,12 +20382,21 @@
         }
       ],
       "imports": [
+        "applyInstanceAnimation",
+        "ANIMATION_TYPES",
         "mergeGeometries",
         "foliageGroup",
         "createUnifiedMaterial",
         "registerReactiveMaterial",
         "calculateWindSway",
         "calculatePlayerPush",
+        "createJuicyRimLight",
+        "uAudioHigh",
+        "uAudioLow",
+        "uTime",
+        "_skyMoonNoteVal",
+        "uTwilight",
+        "BiomeUniforms",
         "vec3",
         "positionLocal",
         "attribute",
@@ -13418,16 +20404,20 @@
         "mix",
         "color",
         "float",
+        "sin",
+        "instanceIndex",
+        "PlantPoseMachine",
+        "CONFIG",
         "THREE"
       ],
       "unusedExports": [
         {
           "name": "PortamentoPineBatcher",
           "type": "class",
-          "line": 22,
+          "line": 37,
           "isUsed": false,
           "usedIn": [],
-          "size": 3969
+          "size": 5651
         }
       ],
       "treeShakingScore": 50
@@ -13441,7 +20431,7 @@
           "line": 18,
           "isUsed": false,
           "usedIn": [],
-          "size": 1575
+          "size": 1578
         },
         {
           "name": "createSilenceSpirit",
@@ -13485,7 +20475,7 @@
           "line": 18,
           "isUsed": false,
           "usedIn": [],
-          "size": 1575
+          "size": 1578
         }
       ],
       "treeShakingScore": 50
@@ -13496,18 +20486,19 @@
         {
           "name": "SimpleFlowerBatcher",
           "type": "class",
-          "line": 35,
+          "line": 37,
           "isUsed": false,
           "usedIn": [],
-          "size": 8267
+          "size": 9805
         },
         {
           "name": "simpleFlowerBatcher",
           "type": "const",
-          "line": 401,
+          "line": 444,
           "isUsed": true,
           "usedIn": [
-            "foliage/flowers.ts"
+            "foliage/flowers.ts",
+            "systems/music-reactivity.ts"
           ],
           "size": 0
         }
@@ -13540,17 +20531,23 @@
         "normalize",
         "length",
         "positionWorld",
+        "uv",
+        "distance",
+        "vec2",
+        "varyingProperty",
         "foliageGroup",
+        "CONFIG",
+        "uTwilight",
         "THREE"
       ],
       "unusedExports": [
         {
           "name": "SimpleFlowerBatcher",
           "type": "class",
-          "line": 35,
+          "line": 37,
           "isUsed": false,
           "usedIn": [],
-          "size": 8267
+          "size": 9805
         }
       ],
       "treeShakingScore": 50
@@ -13561,18 +20558,18 @@
         {
           "name": "SparkleTrailUserData",
           "type": "interface",
-          "line": 9,
+          "line": 17,
           "isUsed": false,
           "usedIn": [],
-          "size": 2846
+          "size": 3263
         },
         {
           "name": "createSparkleTrail",
           "type": "function",
-          "line": 15,
+          "line": 38,
           "isUsed": true,
           "usedIn": [
-            "main.ts",
+            "core/deferred-init.ts",
             "systems/deferred-loader.ts"
           ],
           "size": 0
@@ -13580,16 +20577,18 @@
         {
           "name": "updateSparkleTrail",
           "type": "function",
-          "line": 136,
+          "line": 213,
           "isUsed": true,
           "usedIn": [
-            "main.ts"
+            "core/game-loop.ts"
           ],
           "size": 0
         }
       ],
       "imports": [
         "PointsNodeMaterial",
+        "StorageBufferAttribute",
+        "vec4",
         "attribute",
         "float",
         "mix",
@@ -13599,6 +20598,13 @@
         "sin",
         "positionLocal",
         "cos",
+        "Fn",
+        "instanceIndex",
+        "storage",
+        "uniform",
+        "If",
+        "length",
+        "floor",
         "uTime",
         "uAudioHigh",
         "uAudioLow",
@@ -13608,10 +20614,10 @@
         {
           "name": "SparkleTrailUserData",
           "type": "interface",
-          "line": 9,
+          "line": 17,
           "isUsed": false,
           "usedIn": [],
-          "size": 2846
+          "size": 3263
         }
       ],
       "treeShakingScore": 67
@@ -13625,7 +20631,7 @@
           "line": 10,
           "isUsed": false,
           "usedIn": [],
-          "size": 2237
+          "size": 2602
         },
         {
           "name": "uStarOpacity",
@@ -13633,7 +20639,7 @@
           "line": 11,
           "isUsed": true,
           "usedIn": [
-            "main.ts"
+            "core/game-loop.ts"
           ],
           "size": 0
         },
@@ -13676,7 +20682,7 @@
           "line": 10,
           "isUsed": false,
           "usedIn": [],
-          "size": 2237
+          "size": 2602
         }
       ],
       "treeShakingScore": 67
@@ -13687,15 +20693,15 @@
         {
           "name": "TreeBatcher",
           "type": "class",
-          "line": 34,
+          "line": 40,
           "isUsed": false,
           "usedIn": [],
-          "size": 11352
+          "size": 17701
         },
         {
           "name": "treeBatcher",
           "type": "const",
-          "line": 536,
+          "line": 696,
           "isUsed": true,
           "usedIn": [
             "foliage/flowers.ts",
@@ -13705,6 +20711,7 @@
         }
       ],
       "imports": [
+        "instanceIndex",
         "foliageGroup",
         "CandyPresets",
         "createStandardNodeMaterial",
@@ -13729,19 +20736,27 @@
         "positionWorld",
         "smoothstep",
         "mx_noise_float",
+        "normalWorld",
+        "varyingProperty",
         "applyGlitch",
         "getCylinderGeometry",
         "getTorusKnotGeometry",
+        "createSugarSparkle",
+        "uTwilight",
+        "BiomeUniforms",
+        "CONFIG",
+        "applyInstanceAnimation",
+        "ANIMATION_TYPES",
         "THREE"
       ],
       "unusedExports": [
         {
           "name": "TreeBatcher",
           "type": "class",
-          "line": 34,
+          "line": 40,
           "isUsed": false,
           "usedIn": [],
-          "size": 11352
+          "size": 17701
         }
       ],
       "treeShakingScore": 50
@@ -13755,7 +20770,7 @@
           "line": 12,
           "isUsed": false,
           "usedIn": [],
-          "size": 2402
+          "size": 2524
         },
         {
           "name": "createWaveformWater",
@@ -13793,6 +20808,7 @@
         "uAudioLow",
         "uAudioHigh",
         "createRimLight",
+        "createJuicyRimLight",
         "THREE"
       ],
       "unusedExports": [
@@ -13802,7 +20818,7 @@
           "line": 12,
           "isUsed": false,
           "usedIn": [],
-          "size": 2402
+          "size": 2524
         }
       ],
       "treeShakingScore": 50
@@ -13813,19 +20829,20 @@
         {
           "name": "WaterfallBatcher",
           "type": "class",
-          "line": 26,
+          "line": 34,
           "isUsed": false,
           "usedIn": [],
-          "size": 7120
+          "size": 7542
         },
         {
           "name": "waterfallBatcher",
           "type": "const",
-          "line": 364,
+          "line": 376,
           "isUsed": true,
           "usedIn": [
             "foliage/cave.ts",
-            "systems/weather.ts"
+            "systems/weather/weather-ecosystem.ts",
+            "systems/weather/weather.ts"
           ],
           "size": 0
         }
@@ -13857,6 +20874,7 @@
         "storage",
         "mx_noise_float",
         "normalWorld",
+        "floor",
         "sharedGeometries",
         "foliageMaterials",
         "uTime",
@@ -13872,10 +20890,10 @@
         {
           "name": "WaterfallBatcher",
           "type": "class",
-          "line": 26,
+          "line": 34,
           "isUsed": false,
           "usedIn": [],
-          "size": 7120
+          "size": 7542
         }
       ],
       "treeShakingScore": 50
@@ -13886,10 +20904,10 @@
         {
           "name": "createWaterfall",
           "type": "function",
-          "line": 11,
+          "line": 15,
           "isUsed": false,
           "usedIn": [],
-          "size": 6483
+          "size": 7680
         }
       ],
       "imports": [
@@ -13900,21 +20918,38 @@
         "vec2",
         "mix",
         "sin",
-        "uniform",
+        "cos",
+        "step",
+        "// ← added cos + step\n    uniform",
         "UniformNode",
+        "normalWorld",
+        "Fn",
+        "storage",
+        "instanceIndex",
+        "vec3",
+        "positionLocal",
+        "max",
+        "length",
+        "min",
+        "abs",
+        "MeshStandardNodeMaterial",
+        "StorageBufferAttribute",
         "registerReactiveMaterial",
         "attachReactivity",
         "CandyPresets",
+        "uAudioHigh",
+        "uTime",
+        "createJuicyRimLight",
         "THREE"
       ],
       "unusedExports": [
         {
           "name": "createWaterfall",
           "type": "function",
-          "line": 11,
+          "line": 15,
           "isUsed": false,
           "usedIn": [],
-          "size": 6483
+          "size": 7680
         }
       ],
       "treeShakingScore": 0
@@ -13925,15 +20960,15 @@
         {
           "name": "WisteriaClusterOptions",
           "type": "interface",
-          "line": 11,
+          "line": 17,
           "isUsed": false,
           "usedIn": [],
-          "size": 2568
+          "size": 3694
         },
         {
           "name": "createWisteriaCluster",
           "type": "function",
-          "line": 19,
+          "line": 25,
           "isUsed": true,
           "usedIn": [
             "world/generation.ts"
@@ -13953,51 +20988,145 @@
         "mix",
         "float",
         "smoothstep",
-        "CandyPresets",
+        "_skyMoonNoteVal",
         "attachReactivity",
+        "CandyPresets",
         "uAudioHigh",
+        "uAudioLow",
         "uTime",
+        "createJuicyRimLight",
+        "getCachedProceduralMaterial",
         "makeInteractive",
+        "CONFIG",
+        "uTwilight",
+        "BiomeUniforms",
         "discoverySystem",
         "mergeGeometries",
+        "spawnImpact",
         "THREE"
       ],
       "unusedExports": [
         {
           "name": "WisteriaClusterOptions",
           "type": "interface",
-          "line": 11,
+          "line": 17,
           "isUsed": false,
           "usedIn": [],
-          "size": 2568
+          "size": 3694
         }
       ],
       "treeShakingScore": 50
     },
     {
-      "path": "particles/index.ts",
+      "path": "gameplay/chord-strike.ts",
       "exports": [
         {
-          "name": "./particle_config.ts",
-          "type": "const",
-          "line": 7,
+          "name": "ChordStrikeSystem",
+          "type": "class",
+          "line": 10,
           "isUsed": false,
           "usedIn": [],
-          "size": 2272
+          "size": 2953
+        },
+        {
+          "name": "chordStrikeSystem",
+          "type": "const",
+          "line": 151,
+          "isUsed": true,
+          "usedIn": [
+            "core/deferred-init.ts",
+            "core/game-loop.ts"
+          ],
+          "size": 0
         }
       ],
-      "imports": [],
+      "imports": [
+        "MeshStandardNodeMaterial",
+        "color",
+        "float",
+        "vec3",
+        "uv",
+        "positionLocal",
+        "mx_noise_float",
+        "mix",
+        "smoothstep",
+        "normalLocal",
+        "sin",
+        "uAudioLow",
+        "uAudioHigh",
+        "createJuicyRimLight",
+        "uTime",
+        "uChromaticIntensity",
+        "spawnImpact",
+        "unlockSystem",
+        "showToast",
+        "THREE"
+      ],
       "unusedExports": [
         {
-          "name": "./particle_config.ts",
-          "type": "const",
-          "line": 7,
+          "name": "ChordStrikeSystem",
+          "type": "class",
+          "line": 10,
           "isUsed": false,
           "usedIn": [],
-          "size": 2272
+          "size": 2953
         }
       ],
-      "treeShakingScore": 0
+      "treeShakingScore": 50
+    },
+    {
+      "path": "rendering/culling/culling-system.ts",
+      "exports": [
+        {
+          "name": "CullingSystem",
+          "type": "class",
+          "line": 53,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 9203
+        },
+        {
+          "name": "default",
+          "type": "function",
+          "line": 524,
+          "isUsed": true,
+          "usedIn": [
+            "core/init.ts",
+            "systems/music-reactivity.ts",
+            "utils/wasm-loader-core.ts",
+            "world/generation.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "CullingGroup",
+        "EntityType",
+        "LODLevel",
+        "QualityTier",
+        "CullableObject",
+        "CullingConfig",
+        "CullingStats",
+        "DEFAULT_CULL_DISTANCES",
+        "LOD_THRESHOLDS",
+        "QUALITY_MULTIPLIERS",
+        "DEFAULT_CULLING_CONFIG",
+        "SpatialHashGrid",
+        "OcclusionQueryManager",
+        "CullingDebugVisualizer",
+        "THREE"
+      ],
+      "unusedExports": [
+        {
+          "name": "CullingSystem",
+          "type": "class",
+          "line": 53,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 9203
+        }
+      ],
+      "treeShakingScore": 50
     },
     {
       "path": "rendering/index.ts",
@@ -14025,6 +21154,106 @@
       "treeShakingScore": 0
     },
     {
+      "path": "systems/analytics/core.ts",
+      "exports": [
+        {
+          "name": "AnalyticsSystem",
+          "type": "class",
+          "line": 37,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 11557
+        },
+        {
+          "name": "analytics",
+          "type": "const",
+          "line": 856,
+          "isUsed": true,
+          "usedIn": [
+            "systems/analytics/index.ts",
+            "systems/analytics.ts",
+            "ui/analytics-debug.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "type AnalyticsConfig",
+        "type AnalyticsEvent",
+        "type AnalyticsExport",
+        "type EventType",
+        "type ExternalAnalyticsProvider",
+        "type FPSHistogram",
+        "type FrameTimePercentiles",
+        "type SessionData",
+        "DEFAULT_CONFIG",
+        "STORAGE_KEYS",
+        "ANALYTICS_VERSION",
+        "generateSessionId",
+        "getTimestamp",
+        "safeLocalStorage",
+        "shouldSample",
+        "loadConfig",
+        "saveConfig",
+        "loadQueuedEvents",
+        "saveQueuedEvents",
+        "PerformanceTracker"
+      ],
+      "unusedExports": [
+        {
+          "name": "AnalyticsSystem",
+          "type": "class",
+          "line": 37,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 11557
+        }
+      ],
+      "treeShakingScore": 50
+    },
+    {
+      "path": "systems/analytics.ts",
+      "exports": [
+        {
+          "name": "./analytics/index.ts",
+          "type": "const",
+          "line": 37,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 746
+        },
+        {
+          "name": "default",
+          "type": "const",
+          "line": 38,
+          "isUsed": true,
+          "usedIn": [
+            "core/init.ts",
+            "systems/music-reactivity.ts",
+            "utils/wasm-loader-core.ts",
+            "world/generation.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "analytics",
+        "trackEvent",
+        "trackPerformance"
+      ],
+      "unusedExports": [
+        {
+          "name": "./analytics/index.ts",
+          "type": "const",
+          "line": 37,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 746
+        }
+      ],
+      "treeShakingScore": 50
+    },
+    {
       "path": "systems/discovery_map.ts",
       "exports": [
         {
@@ -14033,7 +21262,7 @@
           "line": 6,
           "isUsed": false,
           "usedIn": [],
-          "size": 746
+          "size": 831
         },
         {
           "name": "DISCOVERY_MAP",
@@ -14044,7 +21273,7 @@
             "systems/discovery-optimized.ts",
             "systems/discovery-persistence.ts",
             "systems/discovery.ts",
-            "systems/physics.ts"
+            "systems/physics/physics-updates.ts"
           ],
           "size": 0
         }
@@ -14057,7 +21286,7 @@
           "line": 6,
           "isUsed": false,
           "usedIn": [],
-          "size": 746
+          "size": 831
         }
       ],
       "treeShakingScore": 50
@@ -14068,23 +21297,26 @@
         {
           "name": "FluidSystem",
           "type": "class",
-          "line": 7,
+          "line": 8,
           "isUsed": false,
           "usedIn": [],
-          "size": 1777
+          "size": 1955
         },
         {
           "name": "fluidSystem",
           "type": "const",
-          "line": 105,
+          "line": 109,
           "isUsed": true,
           "usedIn": [
-            "main.ts"
+            "core/game-loop.ts",
+            "core/main.ts",
+            "foliage/fluid_fog.ts"
           ],
           "size": 0
         }
       ],
       "imports": [
+        "DataUtils",
         "fluidInit",
         "fluidStep",
         "fluidAddDensity",
@@ -14097,10 +21329,10 @@
         {
           "name": "FluidSystem",
           "type": "class",
-          "line": 7,
+          "line": 8,
           "isUsed": false,
           "usedIn": [],
-          "size": 1777
+          "size": 1955
         }
       ],
       "treeShakingScore": 50
@@ -14115,6 +21347,7 @@
           "isUsed": true,
           "usedIn": [
             "examples/asset-streaming-usage.ts",
+            "systems/asset-streaming/asset-streaming.ts",
             "systems/index.ts"
           ],
           "size": 0
@@ -14126,7 +21359,7 @@
           "isUsed": true,
           "usedIn": [
             "examples/asset-streaming-usage.ts",
-            "systems/asset-streaming.ts",
+            "systems/asset-streaming/asset-streaming-core.ts",
             "systems/index.ts"
           ],
           "size": 0
@@ -14137,14 +21370,17 @@
           "line": 20,
           "isUsed": false,
           "usedIn": [],
-          "size": 446
+          "size": 484
         },
         {
           "name": "default",
           "type": "const",
-          "line": 85,
+          "line": 87,
           "isUsed": true,
           "usedIn": [
+            "core/init.ts",
+            "systems/music-reactivity.ts",
+            "utils/wasm-loader-core.ts",
             "world/generation.ts"
           ],
           "size": 0
@@ -14162,7 +21398,7 @@
           "line": 20,
           "isUsed": false,
           "usedIn": [],
-          "size": 446
+          "size": 484
         }
       ],
       "treeShakingScore": 75
@@ -14235,6 +21471,803 @@
       "treeShakingScore": 50
     },
     {
+      "path": "systems/performance-budget/index.ts",
+      "exports": [
+        {
+          "name": "PerformanceBudget as default",
+          "type": "const",
+          "line": 71,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2116
+        }
+      ],
+      "imports": [
+        "*   PerformanceBudget",
+        "*   performanceBudget",
+        "*   PERFORMANCE_BUDGETS",
+        "*   BudgetMode",
+        "*   PerformanceBudgetOverlay\n *"
+      ],
+      "unusedExports": [
+        {
+          "name": "PerformanceBudget as default",
+          "type": "const",
+          "line": 71,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2116
+        }
+      ],
+      "treeShakingScore": 0
+    },
+    {
+      "path": "systems/physics/physics-core.ts",
+      "exports": [
+        {
+          "name": "player",
+          "type": "const",
+          "line": 72,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts",
+            "core/main.ts",
+            "systems/physics/physics-abilities.ts",
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-states.ts",
+            "systems/physics/physics-updates.ts",
+            "systems/save-integration-example.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "PlayerState",
+          "type": "const",
+          "line": 72,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-states.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "PhysicsSpatialGrid",
+          "type": "class",
+          "line": 76,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1587
+        },
+        {
+          "name": "physicsFoliageGrid",
+          "type": "const",
+          "line": 136,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-abilities.ts",
+            "systems/physics/physics-updates.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "physicsTrapsGrid",
+          "type": "const",
+          "line": 137,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-updates.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "physicsGeysersGrid",
+          "type": "const",
+          "line": 138,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-updates.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "physicsPinesGrid",
+          "type": "const",
+          "line": 139,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-updates.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "physicsPanningPadsGrid",
+          "type": "const",
+          "line": 140,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-updates.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "populatePhysicsGrids",
+          "type": "function",
+          "line": 146,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "grantInvisibility",
+          "type": "function",
+          "line": 177,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/silence-spirits.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "registerPhysicsCave",
+          "type": "function",
+          "line": 190,
+          "isUsed": true,
+          "usedIn": [
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "triggerHarpoon",
+          "type": "function",
+          "line": 198,
+          "isUsed": true,
+          "usedIn": [
+            "gameplay/rainbow-blaster.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "updatePhysics",
+          "type": "function",
+          "line": 231,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "getGroundHeight",
+        "initPhysics",
+        "uploadObstaclesBatch",
+        "setPlayerState",
+        "getPlayerState",
+        "updatePhysicsCPP",
+        "uploadCollisionObjects",
+        "resolveGameCollisionsWASM",
+        "initDynamicFoliageBridge",
+        "foliageMushrooms",
+        "foliageTrampolines",
+        "foliageClouds",
+        "vineSwings",
+        "animatedFoliage",
+        "foliageTraps",
+        "foliageGeysers",
+        "foliagePortamentoPines",
+        "foliagePanningPads",
+        "activeVineSwing",
+        "lastVineDetachTime",
+        "discoverySystem",
+        "uChromaticIntensity",
+        "uGlitchExplosionCenter",
+        "uGlitchExplosionRadius",
+        "spawnImpact",
+        "showToast",
+        "addCameraShake",
+        "unlockSystem",
+        "calculateMovementInput",
+        "isInLakeBasin",
+        "getUnifiedGroundHeightTyped",
+        "player",
+        "PlayerState",
+        "_lastInputState",
+        "_scratchPlayerState",
+        "_scratchCamDir",
+        "_scratchMoveVec",
+        "grooveGravity",
+        "bpmWind",
+        "foliageCaves",
+        "setCppPhysicsInitialized",
+        "_scratchMatrix",
+        "cppPhysicsInitialized",
+        "AudioState",
+        "KeyStates",
+        "updateSwimmingState",
+        "updateVineState",
+        "updateClimbingState",
+        "updateDancingState",
+        "updateStateTransitions",
+        "updateEnvironmentalModifiers",
+        "handleAbilities",
+        "checkFloraDiscovery",
+        "checkHarmonyOrbs",
+        "checkRetriggerMushrooms",
+        "checkVibratoViolets",
+        "checkPortamentoPines",
+        "checkSnareTraps",
+        "checkGeysers",
+        "checkPanningPads",
+        "checkVineAttachment",
+        "initCppPhysics",
+        "THREE"
+      ],
+      "unusedExports": [
+        {
+          "name": "PhysicsSpatialGrid",
+          "type": "class",
+          "line": 76,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1587
+        }
+      ],
+      "treeShakingScore": 92
+    },
+    {
+      "path": "systems/physics/physics-states.ts",
+      "exports": [
+        {
+          "name": "updateEnvironmentalModifiers",
+          "type": "function",
+          "line": 45,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "updateStateTransitions",
+          "type": "function",
+          "line": 62,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "updateSwimmingState",
+          "type": "function",
+          "line": 150,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "updateVineState",
+          "type": "function",
+          "line": 240,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "updateClimbingState",
+          "type": "function",
+          "line": 265,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "findNearestClimbable",
+          "type": "function",
+          "line": 328,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2343
+        },
+        {
+          "name": "updateDancingState",
+          "type": "function",
+          "line": 356,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "player",
+        "PlayerState",
+        "_lastInputState",
+        "_scratchSwimDir",
+        "_scratchCamDir",
+        "_scratchCamRight",
+        "_scratchMoveVec",
+        "_scratchUp",
+        "SWIMMING_GRAVITY",
+        "SWIMMING_DRAG",
+        "PLAYER_HEIGHT_OFFSET",
+        "DANCE_KICK_THRESHOLD",
+        "bpmWind",
+        "grooveGravity",
+        "AudioState",
+        "KeyStates",
+        "activeVineSwing",
+        "setActiveVineSwing",
+        "lastVineDetachTime",
+        "setLastVineDetachTime",
+        "vineSwings",
+        "foliageVineLadders",
+        "discoverySystem",
+        "spawnImpact",
+        "uChromaticIntensity",
+        "calculateWaterLevel",
+        "getUnifiedGroundHeightTyped",
+        "getGroundHeight",
+        "foliageCaves",
+        "THREE"
+      ],
+      "unusedExports": [
+        {
+          "name": "findNearestClimbable",
+          "type": "function",
+          "line": 328,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2343
+        }
+      ],
+      "treeShakingScore": 86
+    },
+    {
+      "path": "systems/physics/physics-updates.ts",
+      "exports": [
+        {
+          "name": "checkFloraDiscovery",
+          "type": "function",
+          "line": 71,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "checkHarmonyOrbs",
+          "type": "function",
+          "line": 101,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "checkRetriggerMushrooms",
+          "type": "function",
+          "line": 130,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "checkVibratoViolets",
+          "type": "function",
+          "line": 174,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "checkPortamentoPines",
+          "type": "function",
+          "line": 208,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "checkSnareTraps",
+          "type": "function",
+          "line": 260,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "checkGeysers",
+          "type": "function",
+          "line": 300,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "checkPanningPads",
+          "type": "function",
+          "line": 331,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "updateJSFallbackMovement",
+          "type": "function",
+          "line": 365,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1951
+        },
+        {
+          "name": "checkVineAttachment",
+          "type": "function",
+          "line": 427,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "initCppPhysics",
+          "type": "function",
+          "line": 456,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "DISCOVERY_MAP",
+        "optimizedDiscovery",
+        "checkPlayerDiscovery",
+        "discoverySystem",
+        "spawnImpact",
+        "showToast",
+        "harmonyOrbSystem",
+        "addCameraShake",
+        "unlockSystem",
+        "uChromaticIntensity",
+        "uStrobeIntensity",
+        "getGroundHeight",
+        "initPhysics",
+        "uploadObstaclesBatch",
+        "uploadCollisionObjects",
+        "initDynamicFoliageBridge",
+        "foliageMushrooms",
+        "foliageTrampolines",
+        "foliageClouds",
+        "foliageTraps",
+        "foliageGeysers",
+        "foliagePortamentoPines",
+        "foliagePanningPads",
+        "animatedFoliage",
+        "player",
+        "_scratchPlayerState",
+        "_scratchCamDir",
+        "_scratchMoveVec",
+        "_scratchMatrix",
+        "KeyStates",
+        "AudioState",
+        "_scratchCamRight",
+        "_scratchTargetVel",
+        "_scratchUp",
+        "PLAYER_HEIGHT_OFFSET",
+        "foliageCaves",
+        "calculateMovementInput",
+        "isInLakeBasin",
+        "getUnifiedGroundHeightTyped",
+        "physicsFoliageGrid",
+        "physicsTrapsGrid",
+        "physicsGeysersGrid",
+        "physicsPinesGrid",
+        "physicsPanningPadsGrid",
+        "THREE"
+      ],
+      "unusedExports": [
+        {
+          "name": "updateJSFallbackMovement",
+          "type": "function",
+          "line": 365,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1951
+        }
+      ],
+      "treeShakingScore": 91
+    },
+    {
+      "path": "systems/save-system/index.ts",
+      "exports": [
+        {
+          "name": "saveSystem as default",
+          "type": "const",
+          "line": 70,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1961
+        }
+      ],
+      "imports": [],
+      "unusedExports": [
+        {
+          "name": "saveSystem as default",
+          "type": "const",
+          "line": 70,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1961
+        }
+      ],
+      "treeShakingScore": 0
+    },
+    {
+      "path": "systems/save-system/save-system.ts",
+      "exports": [
+        {
+          "name": "SaveSystem",
+          "type": "class",
+          "line": 37,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 4631
+        },
+        {
+          "name": "createPlayerSaveData",
+          "type": "function",
+          "line": 725,
+          "isUsed": true,
+          "usedIn": [
+            "systems/save-integration-example.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createWorldSaveData",
+          "type": "function",
+          "line": 758,
+          "isUsed": true,
+          "usedIn": [
+            "systems/save-integration-example.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createProgressSaveData",
+          "type": "function",
+          "line": 785,
+          "isUsed": true,
+          "usedIn": [
+            "systems/save-integration-example.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "saveSystem",
+          "type": "const",
+          "line": 806,
+          "isUsed": true,
+          "usedIn": [
+            "systems/save-integration-example.ts",
+            "ui/save-menu/save-menu.ts",
+            "ui/save-menu/save-settings.ts",
+            "ui/save-menu/save-slots.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "default",
+          "type": "function",
+          "line": 867,
+          "isUsed": true,
+          "usedIn": [
+            "core/init.ts",
+            "systems/music-reactivity.ts",
+            "utils/wasm-loader-core.ts",
+            "world/generation.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "showToast",
+        "SAVE_VERSION",
+        "SAVE_VERSION_CONST",
+        "AUTO_SAVE_INTERVAL",
+        "AUTO_SAVE_SLOTS",
+        "MANUAL_SAVE_SLOTS",
+        "LOCALSTORAGE_KEY_SETTINGS",
+        "LOCALSTORAGE_KEY_METADATA",
+        "SaveData",
+        "PlayerSaveData",
+        "WorldSaveData",
+        "ProgressSaveData",
+        "SettingsSaveData",
+        "SaveSlotInfo",
+        "SaveMetadata",
+        "SaveDatabase",
+        "MigrationSystem",
+        "LZString"
+      ],
+      "unusedExports": [
+        {
+          "name": "SaveSystem",
+          "type": "class",
+          "line": 37,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 4631
+        }
+      ],
+      "treeShakingScore": 83
+    },
+    {
+      "path": "systems/weather/weather-effects.ts",
+      "exports": [
+        {
+          "name": "EffectsState",
+          "type": "interface",
+          "line": 19,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 5735
+        },
+        {
+          "name": "EffectsManager",
+          "type": "class",
+          "line": 32,
+          "isUsed": true,
+          "usedIn": [
+            "systems/weather/weather.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "createRainbow",
+        "uRainbowOpacity",
+        "createAurora",
+        "uAuroraIntensity",
+        "uCloudRainbowIntensity",
+        "uCloudLightningStrength",
+        "uCloudLightningColor",
+        "uChromaticIntensity",
+        "triggerGrowth",
+        "triggerBloom",
+        "ComputeParticleSystem",
+        "createIntegratedRain",
+        "Phase4ComputeSystem",
+        "WeatherState",
+        "CONFIG",
+        "THREE"
+      ],
+      "unusedExports": [
+        {
+          "name": "EffectsState",
+          "type": "interface",
+          "line": 19,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 5735
+        }
+      ],
+      "treeShakingScore": 50
+    },
+    {
+      "path": "ui/accessibility-menu-core.ts",
+      "exports": [
+        {
+          "name": "MenuSection",
+          "type": "type",
+          "line": 29,
+          "isUsed": true,
+          "usedIn": [
+            "ui/accessibility-menu-handlers.ts",
+            "ui/accessibility-menu-rendering.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "MenuItem",
+          "type": "interface",
+          "line": 37,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2610
+        },
+        {
+          "name": "AccessibilityMenu",
+          "type": "class",
+          "line": 59,
+          "isUsed": true,
+          "usedIn": [
+            "ui/accessibility-menu-rendering.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "AccessibilitySystem",
+        "getAccessibilitySystem",
+        "announce"
+      ],
+      "unusedExports": [
+        {
+          "name": "MenuItem",
+          "type": "interface",
+          "line": 37,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2610
+        }
+      ],
+      "treeShakingScore": 67
+    },
+    {
+      "path": "ui/save-menu/index.ts",
+      "exports": [
+        {
+          "name": "MENU_STYLES",
+          "type": "const",
+          "line": 26,
+          "isUsed": true,
+          "usedIn": [
+            "ui/save-menu/save-menu.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "SaveMenu as default",
+          "type": "const",
+          "line": 51,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 463
+        }
+      ],
+      "imports": [],
+      "unusedExports": [
+        {
+          "name": "SaveMenu as default",
+          "type": "const",
+          "line": 51,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 463
+        }
+      ],
+      "treeShakingScore": 50
+    },
+    {
       "path": "utils/interaction-utils.ts",
       "exports": [
         {
@@ -14251,30 +22284,37 @@
         {
           "name": "makeInteractiveSphere",
           "type": "function",
-          "line": 106,
+          "line": 107,
           "isUsed": false,
           "usedIn": [],
-          "size": 2309
+          "size": 2385
         },
         {
           "name": "makeInteractive",
           "type": "function",
-          "line": 164,
+          "line": 166,
           "isUsed": true,
           "usedIn": [
             "foliage/instrument.ts",
             "foliage/lotus.ts",
-            "foliage/wisteria-cluster.ts"
+            "foliage/wisteria-cluster.ts",
+            "world/generation.ts"
           ],
           "size": 0
         },
         {
           "name": "trapFocusInside",
           "type": "function",
-          "line": 203,
+          "line": 205,
           "isUsed": true,
           "usedIn": [
-            "core/input.ts"
+            "core/input/input.ts",
+            "core/input/playlist-manager.ts",
+            "systems/discovery.ts",
+            "ui/accessibility-menu-rendering.ts",
+            "ui/analytics-debug.ts",
+            "ui/loading-screen.ts",
+            "ui/save-menu/save-menu.ts"
           ],
           "size": 0
         }
@@ -14286,10 +22326,104 @@
         {
           "name": "makeInteractiveSphere",
           "type": "function",
-          "line": 106,
+          "line": 107,
           "isUsed": false,
           "usedIn": [],
-          "size": 2309
+          "size": 2385
+        }
+      ],
+      "treeShakingScore": 75
+    },
+    {
+      "path": "utils/profiler.ts",
+      "exports": [
+        {
+          "name": "Profiler",
+          "type": "class",
+          "line": 21,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2383
+        },
+        {
+          "name": "profiler",
+          "type": "const",
+          "line": 179,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts",
+            "core/main.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [],
+      "unusedExports": [
+        {
+          "name": "Profiler",
+          "type": "class",
+          "line": 21,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 2383
+        }
+      ],
+      "treeShakingScore": 50
+    },
+    {
+      "path": "utils/wasm-utils.ts",
+      "exports": [
+        {
+          "name": "WasmFileCheckResult",
+          "type": "interface",
+          "line": 19,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1734
+        },
+        {
+          "name": "checkWasmFileExists",
+          "type": "function",
+          "line": 37,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-loader-core.ts",
+            "utils/wasm-orchestrator.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "inspectWasmExports",
+          "type": "function",
+          "line": 90,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-loader-core.ts",
+            "utils/wasm-orchestrator.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "patchWasmInstantiateAliases",
+          "type": "function",
+          "line": 155,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-loader-core.ts",
+            "utils/wasm-orchestrator.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [],
+      "unusedExports": [
+        {
+          "name": "WasmFileCheckResult",
+          "type": "interface",
+          "line": 19,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 1734
         }
       ],
       "treeShakingScore": 75
@@ -14401,6 +22535,271 @@
       "treeShakingScore": 75
     },
     {
+      "path": "world/state.ts",
+      "exports": [
+        {
+          "name": "animatedFoliage",
+          "type": "const",
+          "line": 5,
+          "isUsed": true,
+          "usedIn": [
+            "core/deferred-init.ts",
+            "core/game-loop.ts",
+            "core/main.ts",
+            "systems/physics/physics-abilities.ts",
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-updates.ts",
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "cpuAnimatedFoliage",
+          "type": "const",
+          "line": 6,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts",
+            "systems/weather/weather-ecosystem.ts",
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "obstacles",
+          "type": "const",
+          "line": 7,
+          "isUsed": true,
+          "usedIn": [
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "foliageMushrooms",
+          "type": "const",
+          "line": 10,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts",
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-updates.ts",
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "foliageTrampolines",
+          "type": "const",
+          "line": 11,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-updates.ts",
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "foliagePanningPads",
+          "type": "const",
+          "line": 12,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-updates.ts",
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "foliageClouds",
+          "type": "const",
+          "line": 13,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts",
+            "gameplay/rainbow-blaster.ts",
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-updates.ts",
+            "systems/weather/weather-ecosystem.ts",
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "foliageGeysers",
+          "type": "const",
+          "line": 14,
+          "isUsed": true,
+          "usedIn": [
+            "gameplay/rainbow-blaster.ts",
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-updates.ts",
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "foliageTraps",
+          "type": "const",
+          "line": 15,
+          "isUsed": true,
+          "usedIn": [
+            "gameplay/rainbow-blaster.ts",
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-updates.ts",
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "foliagePortamentoPines",
+          "type": "const",
+          "line": 16,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-updates.ts",
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "vineSwings",
+          "type": "const",
+          "line": 17,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-states.ts",
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "foliageVineLadders",
+          "type": "const",
+          "line": 18,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-states.ts",
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "computeFoliageObjects",
+          "type": "const",
+          "line": 22,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 89
+        },
+        {
+          "name": "interactiveObjects",
+          "type": "const",
+          "line": 24,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "worldGroup",
+          "type": "const",
+          "line": 27,
+          "isUsed": true,
+          "usedIn": [
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "foliageGroup",
+          "type": "const",
+          "line": 28,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/arpeggio-batcher.ts",
+            "foliage/berries.ts",
+            "foliage/cloud-batcher.ts",
+            "foliage/dandelion-batcher.ts",
+            "foliage/flower-batcher.ts",
+            "foliage/glowing-flower-batcher.ts",
+            "foliage/lantern-batcher.ts",
+            "foliage/lod.ts",
+            "foliage/mushroom-batcher.ts",
+            "foliage/portamento-batcher.ts",
+            "foliage/simple-flower-batcher.ts",
+            "foliage/tree-batcher.ts",
+            "foliage/waterfall-batcher.ts",
+            "world/generation.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "activeVineSwing",
+          "type": "let",
+          "line": 31,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-states.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "lastVineDetachTime",
+          "type": "let",
+          "line": 32,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-states.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "setActiveVineSwing",
+          "type": "function",
+          "line": 34,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-states.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "setLastVineDetachTime",
+          "type": "function",
+          "line": 38,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-states.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "VineSwing",
+        "FoliageObject",
+        "THREE"
+      ],
+      "unusedExports": [
+        {
+          "name": "computeFoliageObjects",
+          "type": "const",
+          "line": 22,
+          "isUsed": false,
+          "usedIn": [],
+          "size": 89
+        }
+      ],
+      "treeShakingScore": 95
+    },
+    {
       "path": "accessibility-index.ts",
       "exports": [],
       "imports": [],
@@ -14428,7 +22827,7 @@
           "usedIn": [
             "foliage/moon.ts",
             "systems/fluid_system.ts",
-            "systems/weather.ts"
+            "systems/weather/weather.ts"
           ],
           "size": 0
         },
@@ -14439,8 +22838,11 @@
           "isUsed": true,
           "usedIn": [
             "audio/beat-sync.ts",
-            "core/input.ts",
-            "main.ts"
+            "core/game-loop.ts",
+            "core/input/audio-controls.ts",
+            "core/input/input.ts",
+            "core/input/playlist-manager.ts",
+            "core/main.ts"
           ],
           "size": 0
         }
@@ -14455,11 +22857,13 @@
         {
           "name": "ComputeParticleSystem",
           "type": "const",
-          "line": 7,
+          "line": 15,
           "isUsed": true,
           "usedIn": [
             "compute/particle_compute.ts",
-            "particles/compute-integration.ts"
+            "foliage/berries.ts",
+            "particles/compute-integration.ts",
+            "systems/weather/weather-effects.ts"
           ],
           "size": 0
         }
@@ -14474,11 +22878,13 @@
         {
           "name": "ComputeParticleSystem",
           "type": "class",
-          "line": 68,
+          "line": 72,
           "isUsed": true,
           "usedIn": [
             "compute/particle_compute.ts",
-            "particles/compute-integration.ts"
+            "foliage/berries.ts",
+            "particles/compute-integration.ts",
+            "systems/weather/weather-effects.ts"
           ],
           "size": 0
         }
@@ -14495,9 +22901,484 @@
         "sin",
         "If",
         "Fn",
+        "uv",
+        "distance",
+        "smoothstep",
+        "vec2",
         "StorageInstancedBufferAttribute",
         "PointsNodeMaterial",
         "THREE"
+      ],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "core/input/index.ts",
+      "exports": [
+        {
+          "name": "initInput",
+          "type": "const",
+          "line": 6,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "keyStates",
+          "type": "const",
+          "line": 6,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts",
+            "core/input/audio-controls.ts",
+            "core/input/input.ts",
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "formatSongTitle",
+          "type": "const",
+          "line": 10,
+          "isUsed": true,
+          "usedIn": [
+            "core/input/playlist-manager.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "filterValidMusicFiles",
+          "type": "const",
+          "line": 10,
+          "isUsed": true,
+          "usedIn": [
+            "core/input/input.ts",
+            "core/input/playlist-manager.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "core/input/input-types.ts",
+      "exports": [
+        {
+          "name": "KeyStates",
+          "type": "interface",
+          "line": 6,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-abilities.ts",
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-states.ts",
+            "systems/physics/physics-types.ts",
+            "systems/physics/physics-updates.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "keyStates",
+          "type": "const",
+          "line": 23,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts",
+            "core/input/audio-controls.ts",
+            "core/input/input.ts",
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "triggerAbility",
+          "type": "function",
+          "line": 40,
+          "isUsed": true,
+          "usedIn": [
+            "core/input/input.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "InitInputResult",
+          "type": "interface",
+          "line": 52,
+          "isUsed": true,
+          "usedIn": [
+            "core/input/input.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "formatSongTitle",
+          "type": "const",
+          "line": 60,
+          "isUsed": true,
+          "usedIn": [
+            "core/input/playlist-manager.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "filterValidMusicFiles",
+          "type": "const",
+          "line": 73,
+          "isUsed": true,
+          "usedIn": [
+            "core/input/input.ts",
+            "core/input/playlist-manager.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "core/input/input.ts",
+      "exports": [
+        {
+          "name": "keyStates",
+          "type": "const",
+          "line": 32,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts",
+            "core/input/audio-controls.ts",
+            "core/input/input.ts",
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "initInput",
+          "type": "function",
+          "line": 35,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "PointerLockControls",
+        "AudioSystem",
+        "discoverySystem",
+        "trapFocusInside",
+        "openAccessibilityMenu",
+        "closeAccessibilityMenu",
+        "keyStates",
+        "InitInputResult",
+        "filterValidMusicFiles",
+        "triggerAbility",
+        "initPlaylistManager",
+        "getIsPlaylistOpen",
+        "setIsPlaylistOpen",
+        "closePlaylist",
+        "getReleaseJukeboxFocus",
+        "setReleaseJukeboxFocus",
+        "getWasPausedBeforePlaylist",
+        "togglePlaylist",
+        "handlePlaylistKeyDown",
+        "initLegacyMusicUpload",
+        "initAudioControls",
+        "handleMuteKey",
+        "handleVolumeKey",
+        "THREE"
+      ],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "core/main.ts",
+      "exports": [
+        {
+          "name": "scene",
+          "type": "const",
+          "line": 49,
+          "isUsed": true,
+          "usedIn": [
+            "main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "camera",
+          "type": "const",
+          "line": 49,
+          "isUsed": true,
+          "usedIn": [
+            "main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "renderer",
+          "type": "const",
+          "line": 49,
+          "isUsed": true,
+          "usedIn": [
+            "main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "player",
+          "type": "const",
+          "line": 49,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts",
+            "core/main.ts",
+            "main.ts",
+            "systems/physics/physics-abilities.ts",
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-states.ts",
+            "systems/physics/physics-updates.ts",
+            "systems/save-integration-example.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "addCameraShake",
+          "type": "const",
+          "line": 49,
+          "isUsed": true,
+          "usedIn": [
+            "core/main.ts",
+            "main.ts",
+            "main.ts",
+            "systems/glitch-grenade.ts",
+            "systems/physics/physics-abilities.ts",
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-updates.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "validateNodeGeometries",
+        "InteractionSystem",
+        "musicReactivitySystem",
+        "fluidSystem",
+        "AudioSystem",
+        "BeatSync",
+        "WeatherSystem",
+        "initWasm",
+        "getGroundHeight",
+        "getUnifiedGroundHeightTyped",
+        "profiler",
+        "enableStartupProfiler",
+        "finalizeStartupProfile",
+        "recordWASMInit",
+        "toggleOverlay",
+        "startPhase",
+        "endPhase",
+        "glitchGrenadeSystem",
+        "CONFIG",
+        "initScene",
+        "forceFullSceneWarmup",
+        "initInput",
+        "keyStates",
+        "initPostProcessing",
+        "initCriticalWorld",
+        "initDeferredWorldContent",
+        "initWorld",
+        "initWorldCritical",
+        "initWorldContent",
+        "generateMap",
+        "DEFAULT_MAP_CHUNK_SIZE",
+        "animatedFoliage",
+        "interactiveObjects",
+        "fireRainbow",
+        "player",
+        "populatePhysicsGrids",
+        "animate",
+        "initGameLoopDependencies",
+        "addCameraShake",
+        "updateTheme",
+        "toggleDayNight",
+        "setInputSystem",
+        "initDeferredVisuals",
+        "initDeferredVisualsDependencies",
+        "runDeferredWarmup",
+        "globalBackgroundProcessor",
+        "showDeferredIndicator",
+        "hideDeferredIndicator",
+        "DeferredLoader",
+        "LoadPriority",
+        "initLoadingScreen",
+        "installLegacyAPI",
+        "StageLoader",
+        "showDebugError",
+        "initDebugPanel",
+        "THREE"
+      ],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "foliage/batcher/foliage-batcher-audio.ts",
+      "exports": [
+        {
+          "name": "getVibratoAmount",
+          "type": "function",
+          "line": 8,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/batcher/foliage-batcher-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getTremoloAmount",
+          "type": "function",
+          "line": 23,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/batcher/foliage-batcher-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getHighFreqAmount",
+          "type": "function",
+          "line": 39,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/batcher/foliage-batcher-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getAverageVolume",
+          "type": "function",
+          "line": 49,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/batcher/foliage-batcher-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getPanActivity",
+          "type": "function",
+          "line": 61,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/batcher/foliage-batcher-core.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "foliage/batcher/foliage-batcher-effects.ts",
+      "exports": [
+        {
+          "name": "applySnareSnap",
+          "type": "function",
+          "line": 11,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/batcher/foliage-batcher-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "applyAccordion",
+          "type": "function",
+          "line": 34,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/batcher/foliage-batcher-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "applyFiberWhip",
+          "type": "function",
+          "line": 53,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/batcher/foliage-batcher-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "applySpiralWave",
+          "type": "function",
+          "line": 99,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/batcher/foliage-batcher-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "applyVibratoShake",
+          "type": "function",
+          "line": 112,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/batcher/foliage-batcher-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "applyTremoloPulse",
+          "type": "function",
+          "line": 135,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/batcher/foliage-batcher-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "applyCymbalShake",
+          "type": "function",
+          "line": 166,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/batcher/foliage-batcher-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "applyPanningBob",
+          "type": "function",
+          "line": 191,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/batcher/foliage-batcher-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "applySpiritFade",
+          "type": "function",
+          "line": 214,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/batcher/foliage-batcher-core.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "FoliageObject",
+        "spawnImpact"
       ],
       "unusedExports": [],
       "treeShakingScore": 100
@@ -14511,7 +23392,7 @@
           "line": 210,
           "isUsed": true,
           "usedIn": [
-            "main.ts",
+            "core/deferred-init.ts",
             "systems/deferred-loader.ts"
           ],
           "size": 0
@@ -14548,25 +23429,29 @@
         {
           "name": "uChromaticIntensity",
           "type": "const",
-          "line": 15,
+          "line": 19,
           "isUsed": true,
           "usedIn": [
+            "core/game-loop.ts",
             "foliage/berries.ts",
             "foliage/mushroom-batcher.ts",
+            "gameplay/chord-strike.ts",
             "gameplay/jitter-mines.ts",
-            "main.ts",
-            "systems/physics.ts",
-            "systems/weather.ts"
+            "systems/physics/physics-abilities.ts",
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-states.ts",
+            "systems/physics/physics-updates.ts",
+            "systems/weather/weather-effects.ts"
           ],
           "size": 0
         },
         {
           "name": "createChromaticPulse",
           "type": "function",
-          "line": 26,
+          "line": 30,
           "isUsed": true,
           "usedIn": [
-            "main.ts",
+            "core/deferred-init.ts",
             "systems/deferred-loader.ts"
           ],
           "size": 0
@@ -14581,59 +23466,107 @@
         "uniform",
         "viewportSharedTexture",
         "screenUV",
+        "time",
+        "sin",
+        "cos",
+        "vec2",
         "THREE"
       ],
       "unusedExports": [],
       "treeShakingScore": 100
     },
     {
-      "path": "foliage/dandelion-seeds.ts",
+      "path": "foliage/cloud-batcher.ts",
       "exports": [
         {
-          "name": "createDandelionSeedSystem",
-          "type": "function",
-          "line": 27,
+          "name": "uCloudRainbowIntensity",
+          "type": "const",
+          "line": 18,
           "isUsed": true,
           "usedIn": [
-            "main.ts"
+            "foliage/clouds.ts",
+            "systems/weather/weather-effects.ts"
           ],
           "size": 0
         },
         {
-          "name": "spawnDandelionExplosion",
-          "type": "function",
-          "line": 210,
+          "name": "uCloudLightningStrength",
+          "type": "const",
+          "line": 19,
           "isUsed": true,
           "usedIn": [
-            "foliage/musical_flora.ts",
-            "systems/physics.ts"
+            "foliage/clouds.ts",
+            "systems/weather/weather-effects.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "uCloudLightningColor",
+          "type": "const",
+          "line": 20,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/clouds.ts",
+            "systems/weather/weather-effects.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "getSharedCloudMaterial",
+          "type": "function",
+          "line": 184,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/clouds.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "CloudBatcher",
+          "type": "class",
+          "line": 200,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts",
+            "foliage/clouds.ts",
+            "foliage/procedural-sky.ts"
           ],
           "size": 0
         }
       ],
       "imports": [
-        "mergeGeometries",
         "MeshStandardNodeMaterial",
-        "attribute",
-        "float",
-        "sin",
-        "cos",
+        "color",
+        "uniform",
+        "mix",
+        "vec3",
         "positionLocal",
         "normalLocal",
-        "exp",
-        "rotate",
+        "mx_noise_float",
+        "float",
         "normalize",
-        "vec4",
-        "vec3",
+        "positionWorld",
+        "normalWorld",
+        "cameraPosition",
+        "dot",
+        "abs",
+        "sin",
+        "pow",
+        "uv",
         "smoothstep",
-        "step",
-        "mix",
-        "color",
         "uTime",
+        "createJuicyRimLight",
+        "uAudioLow",
         "uAudioHigh",
         "uWindSpeed",
         "uWindDirection",
-        "createSugarSparkle",
+        "triplanarNoise",
+        "uPlayerPosition",
+        "attribute",
+        "foliageGroup",
+        "getIcosahedronGeometry",
+        "uSkyDarkness",
+        "uTwilight",
         "THREE"
       ],
       "unusedExports": [],
@@ -14648,7 +23581,7 @@
           "line": 12,
           "isUsed": true,
           "usedIn": [
-            "main.ts",
+            "core/deferred-init.ts",
             "systems/deferred-loader.ts"
           ],
           "size": 0
@@ -14660,6 +23593,7 @@
         "color",
         "positionLocal",
         "vec3",
+        "vec4",
         "attribute",
         "float",
         "mix",
@@ -14674,14 +23608,63 @@
       "treeShakingScore": 100
     },
     {
-      "path": "foliage/fireflies.ts",
+      "path": "foliage/fluid_fog.ts",
       "exports": [
         {
-          "name": "createFireflies",
+          "name": "createFluidFog",
           "type": "function",
-          "line": 14,
+          "line": 7,
           "isUsed": true,
           "usedIn": [
+            "core/deferred-init.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "MeshStandardNodeMaterial",
+        "texture",
+        "vec4",
+        "color",
+        "vec3",
+        "uv",
+        "mx_noise_float",
+        "positionLocal",
+        "mix",
+        "smoothstep",
+        "normalLocal",
+        "fluidSystem",
+        "uTime",
+        "THREE"
+      ],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "foliage/foliage-batcher.ts",
+      "exports": [],
+      "imports": [],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "foliage/foliage-materials.ts",
+      "exports": [
+        {
+          "name": "foliageMaterials",
+          "type": "const",
+          "line": 24,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/flower-batcher.ts",
+            "foliage/flowers.ts",
+            "foliage/glowing-flower-batcher.ts",
+            "foliage/lantern-batcher.ts",
+            "foliage/mushroom-batcher.ts",
+            "foliage/simple-flower-batcher.ts",
+            "foliage/trees.ts",
+            "foliage/waterfall-batcher.ts",
+            "rendering/shader-warmup.ts",
             "world/generation.ts"
           ],
           "size": 0
@@ -14689,32 +23672,28 @@
       ],
       "imports": [
         "MeshStandardNodeMaterial",
-        "StorageBufferAttribute",
-        "Fn",
-        "uniform",
-        "storage",
-        "instanceIndex",
+        "color",
         "float",
         "vec3",
-        "mix",
-        "sin",
-        "cos",
-        "normalize",
-        "color",
-        "mx_noise_float",
         "positionLocal",
-        "max",
-        "length",
-        "min",
-        "vec4",
         "positionWorld",
-        "normalLocal",
+        "uv",
+        "sin",
+        "pow",
+        "abs",
+        "smoothstep",
+        "CandyPresets",
+        "createUnifiedMaterial",
+        "createStandardNodeMaterial",
+        "calculateWindSway",
+        "calculateFlowerBloom",
+        "createJuicyRimLight",
+        "applyPlayerInteraction",
         "uTime",
         "uAudioLow",
-        "uAudioHigh",
-        "uPlayerPosition",
-        "sharedGeometries",
-        "createJuicyRimLight",
+        "uWindSpeed",
+        "uWindDirection",
+        "mx_noise_float",
         "THREE"
       ],
       "unusedExports": [],
@@ -14726,7 +23705,7 @@
         {
           "name": "createSubwooferLotus",
           "type": "function",
-          "line": 35,
+          "line": 38,
           "isUsed": true,
           "usedIn": [
             "world/generation.ts"
@@ -14760,7 +23739,10 @@
         "uAudioLow",
         "uGlitchIntensity",
         "uTime",
+        "BiomeUniforms",
         "makeInteractive",
+        "CONFIG",
+        "uTwilight",
         "discoverySystem",
         "showToast",
         "spawnImpact",
@@ -14770,12 +23752,22 @@
       "treeShakingScore": 100
     },
     {
-      "path": "foliage/pollen.ts",
+      "path": "foliage/luminous-plant-batcher.ts",
       "exports": [
         {
-          "name": "createNeonPollen",
-          "type": "function",
-          "line": 12,
+          "name": "LuminousPlantBatcher",
+          "type": "class",
+          "line": 9,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/luminous-plant.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "luminousPlantBatcher",
+          "type": "const",
+          "line": 107,
           "isUsed": true,
           "usedIn": [
             "world/generation.ts"
@@ -14784,37 +23776,21 @@
         }
       ],
       "imports": [
-        "PointsNodeMaterial",
-        "StorageBufferAttribute",
-        "Fn",
-        "uniform",
-        "storage",
-        "instanceIndex",
-        "float",
-        "vec3",
-        "mix",
-        "sin",
-        "cos",
-        "normalize",
+        "MeshStandardNodeMaterial",
         "color",
-        "mx_noise_float",
-        "vertexIndex",
-        "max",
-        "min",
-        "length",
+        "float",
+        "sin",
         "positionLocal",
-        "time",
-        "uv",
-        "distance",
-        "smoothstep",
-        "discard",
-        "vec2",
+        "normalLocal",
+        "mix",
+        "attribute",
         "uTime",
-        "uAudioLow",
-        "uAudioHigh",
-        "uWindSpeed",
-        "uWindDirection",
-        "uPlayerPosition",
+        "createJuicyRimLight",
+        "createStandardNodeMaterial",
+        "calculateWindSway",
+        "LuminousPlantUniforms",
+        "luminousPlantsNoteColorNode",
+        "CONFIG",
         "THREE"
       ],
       "unusedExports": [],
@@ -14836,7 +23812,7 @@
       ],
       "imports": [
         "createCloud",
-        "cloudBatcher",
+        "CloudBatcher",
         "THREE"
       ],
       "unusedExports": [],
@@ -14851,7 +23827,7 @@
           "line": 5,
           "isUsed": true,
           "usedIn": [
-            "systems/weather.ts"
+            "systems/weather/weather-effects.ts"
           ],
           "size": 0
         },
@@ -14861,7 +23837,7 @@
           "line": 7,
           "isUsed": true,
           "usedIn": [
-            "systems/weather.ts"
+            "systems/weather/weather-effects.ts"
           ],
           "size": 0
         }
@@ -14891,7 +23867,7 @@
           "line": 57,
           "isUsed": true,
           "usedIn": [
-            "main.ts"
+            "core/deferred-init.ts"
           ],
           "size": 0
         },
@@ -14901,7 +23877,7 @@
           "line": 157,
           "isUsed": true,
           "usedIn": [
-            "main.ts"
+            "core/game-loop.ts"
           ],
           "size": 0
         }
@@ -14937,7 +23913,8 @@
           "line": 20,
           "isUsed": true,
           "usedIn": [
-            "main.ts"
+            "core/deferred-init.ts",
+            "core/game-loop.ts"
           ],
           "size": 0
         }
@@ -14962,77 +23939,126 @@
         {
           "name": "uSkyTopColor",
           "type": "const",
-          "line": 8,
+          "line": 10,
           "isUsed": true,
           "usedIn": [
-            "main.ts"
+            "core/game-loop.ts"
           ],
           "size": 0
         },
         {
           "name": "uSkyBottomColor",
           "type": "const",
-          "line": 9,
+          "line": 11,
           "isUsed": true,
           "usedIn": [
-            "main.ts"
+            "core/game-loop.ts"
           ],
           "size": 0
         },
         {
           "name": "uHorizonColor",
           "type": "const",
-          "line": 10,
+          "line": 12,
           "isUsed": true,
           "usedIn": [
-            "foliage/environment.ts",
-            "main.ts"
+            "core/game-loop.ts",
+            "foliage/environment.ts"
           ],
           "size": 0
         },
         {
           "name": "uAtmosphereIntensity",
           "type": "const",
-          "line": 11,
+          "line": 13,
           "isUsed": true,
           "usedIn": [
-            "main.ts"
+            "core/game-loop.ts"
           ],
           "size": 0
         },
         {
           "name": "uSkyDarkness",
           "type": "const",
-          "line": 13,
+          "line": 15,
           "isUsed": true,
           "usedIn": [
             "foliage/cloud-batcher.ts",
             "foliage/grass.ts",
-            "systems/weather.ts"
+            "systems/weather/weather-atmosphere.ts"
           ],
           "size": 0
         },
         {
           "name": "uTwilight",
           "type": "const",
-          "line": 17,
+          "line": 19,
           "isUsed": true,
           "usedIn": [
             "foliage/cave.ts",
             "foliage/cloud-batcher.ts",
+            "foliage/dandelion-batcher.ts",
             "foliage/environment.ts",
+            "foliage/flower-batcher.ts",
             "foliage/flowers.ts",
             "foliage/glowing-flower-batcher.ts",
+            "foliage/lantern-batcher.ts",
+            "foliage/lotus.ts",
             "foliage/mushroom-batcher.ts",
+            "foliage/portamento-batcher.ts",
+            "foliage/simple-flower-batcher.ts",
+            "foliage/tree-batcher.ts",
             "foliage/trees.ts",
-            "systems/weather.ts"
+            "foliage/wisteria-cluster.ts",
+            "systems/weather/weather-atmosphere.ts",
+            "systems/weather/weather.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "uCrescendoFogDensity",
+          "type": "const",
+          "line": 23,
+          "isUsed": true,
+          "usedIn": [
+            "systems/weather/weather-atmosphere.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "uFogNear",
+          "type": "const",
+          "line": 24,
+          "isUsed": true,
+          "usedIn": [
+            "systems/weather/weather-atmosphere.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "uFogFar",
+          "type": "const",
+          "line": 25,
+          "isUsed": true,
+          "usedIn": [
+            "systems/weather/weather-atmosphere.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "createCrescendoFogNode",
+          "type": "function",
+          "line": 27,
+          "isUsed": true,
+          "usedIn": [
+            "core/init.ts"
           ],
           "size": 0
         },
         {
           "name": "createSky",
           "type": "function",
-          "line": 20,
+          "line": 43,
           "isUsed": true,
           "usedIn": [
             "world/generation.ts"
@@ -15048,7 +24074,16 @@
         "uniform",
         "smoothstep",
         "UniformNode",
+        "rangeFog",
+        "nodeObject",
+        "sin",
+        "pow",
         "MeshBasicNodeMaterial",
+        "uAudioLow",
+        "uAudioHigh",
+        "uTime",
+        "SkyUniforms",
+        "skyNoteColorNode",
         "THREE"
       ],
       "unusedExports": [],
@@ -15063,8 +24098,7 @@
           "line": 17,
           "isUsed": true,
           "usedIn": [
-            "main.ts",
-            "systems/physics.ts"
+            "systems/physics/physics-updates.ts"
           ],
           "size": 0
         },
@@ -15074,7 +24108,7 @@
           "line": 28,
           "isUsed": true,
           "usedIn": [
-            "main.ts"
+            "core/deferred-init.ts"
           ],
           "size": 0
         }
@@ -15102,16 +24136,16 @@
         {
           "name": "createTerrainMaterial",
           "type": "function",
-          "line": 18,
+          "line": 17,
           "isUsed": true,
           "usedIn": [
-            "rendering/shader-warmup.ts"
+            "rendering/shader-warmup.ts",
+            "world/generation.ts"
           ],
           "size": 0
         }
       ],
       "imports": [
-        "MeshStandardNodeMaterial",
         "color",
         "float",
         "vec3",
@@ -15127,6 +24161,8 @@
         "normalLocal",
         "distance",
         "max",
+        "uv",
+        "texture",
         "CandyPresets",
         "uAudioLow",
         "uAudioHigh",
@@ -15167,8 +24203,7 @@
           "line": 21,
           "isUsed": true,
           "usedIn": [
-            "foliage/animation.ts",
-            "foliage/common.ts"
+            "foliage/animation.ts"
           ],
           "size": 0
         },
@@ -15180,9 +24215,20 @@
           "usedIn": [
             "foliage/animation.ts",
             "foliage/arpeggio.ts",
-            "foliage/foliage-batcher.ts",
+            "foliage/batcher/foliage-batcher-core.ts",
+            "foliage/batcher/foliage-batcher-effects.ts",
             "foliage/trees.ts",
             "world/state.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "FoliageGrowthOptions",
+          "type": "interface",
+          "line": 100,
+          "isUsed": true,
+          "usedIn": [
+            "systems/weather/weather-ecosystem.ts"
           ],
           "size": 0
         }
@@ -15202,7 +24248,7 @@
           "line": 13,
           "isUsed": true,
           "usedIn": [
-            "main.ts",
+            "core/deferred-init.ts",
             "systems/deferred-loader.ts"
           ],
           "size": 0
@@ -15210,10 +24256,10 @@
         {
           "name": "updateHarpoonLine",
           "type": "function",
-          "line": 51,
+          "line": 80,
           "isUsed": true,
           "usedIn": [
-            "main.ts"
+            "core/game-loop.ts"
           ],
           "size": 0
         }
@@ -15222,9 +24268,13 @@
         "MeshStandardNodeMaterial",
         "float",
         "color",
+        "positionLocal",
+        "sin",
+        "cos",
+        "vec3",
         "uAudioHigh",
         "createJuicyRimLight",
-        "CandyPresets",
+        "uTime",
         "THREE"
       ],
       "unusedExports": [],
@@ -15236,10 +24286,12 @@
         {
           "name": "jitterMineSystem",
           "type": "const",
-          "line": 222,
+          "line": 336,
           "isUsed": true,
           "usedIn": [
-            "main.ts",
+            "core/deferred-init.ts",
+            "core/game-loop.ts",
+            "core/hud.ts",
             "systems/deferred-loader.ts"
           ],
           "size": 0
@@ -15249,6 +24301,7 @@
         "createClayMaterial",
         "uGlitchIntensity",
         "uTime",
+        "uAudioLow",
         "applyGlitch",
         "uChromaticIntensity",
         "spawnImpact",
@@ -15257,7 +24310,16 @@
         "uv",
         "float",
         "sin",
+        "cos",
         "vec3",
+        "uniform",
+        "attribute",
+        "vec4",
+        "vec2",
+        "step",
+        "mix",
+        "smoothstep",
+        "Fn",
         "THREE"
       ],
       "unusedExports": [],
@@ -15269,26 +24331,29 @@
         {
           "name": "fireRainbow",
           "type": "function",
-          "line": 334,
+          "line": 460,
           "isUsed": true,
           "usedIn": [
-            "main.ts"
+            "core/deferred-init.ts",
+            "core/game-loop.ts",
+            "core/main.ts"
           ],
           "size": 0
         },
         {
           "name": "updateBlaster",
           "type": "function",
-          "line": 342,
+          "line": 468,
           "isUsed": true,
           "usedIn": [
-            "main.ts"
+            "core/game-loop.ts"
           ],
           "size": 0
         }
       ],
       "imports": [
         "MeshStandardNodeMaterial",
+        "StorageInstancedBufferAttribute",
         "vec3",
         "float",
         "positionLocal",
@@ -15301,6 +24366,15 @@
         "positionWorld",
         "color",
         "attribute",
+        "storage",
+        "instanceIndex",
+        "Fn",
+        "If",
+        "exp",
+        "vec4",
+        "uniform",
+        "rotate",
+        "varyingProperty",
         "foliageClouds",
         "foliageGeysers",
         "foliageTraps",
@@ -15319,91 +24393,504 @@
       "treeShakingScore": 100
     },
     {
-      "path": "main.ts",
-      "exports": [],
+      "path": "particles/compute-particles-shaders.ts",
+      "exports": [
+        {
+          "name": "UPDATE_PARTICLES_WGSL",
+          "type": "const",
+          "line": 9,
+          "isUsed": true,
+          "usedIn": [
+            "particles/compute-particles.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "RENDER_PARTICLES_WGSL",
+          "type": "const",
+          "line": 269,
+          "isUsed": true,
+          "usedIn": [
+            "particles/compute-particles.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "FRAGMENT_PARTICLES_WGSL",
+          "type": "const",
+          "line": 352,
+          "isUsed": true,
+          "usedIn": [
+            "particles/compute-particles.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "particles/compute-particles-types.ts",
+      "exports": [
+        {
+          "name": "ComputeParticleType",
+          "type": "type",
+          "line": 8,
+          "isUsed": true,
+          "usedIn": [
+            "particles/compute-particles.ts",
+            "particles/cpu-particle-system.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "ComputeParticleConfig",
+          "type": "interface",
+          "line": 10,
+          "isUsed": true,
+          "usedIn": [
+            "particles/compute-particles.ts",
+            "particles/cpu-particle-system.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "ParticleBuffers",
+          "type": "interface",
+          "line": 27,
+          "isUsed": true,
+          "usedIn": [
+            "particles/compute-particles.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "ParticleAudioData",
+          "type": "interface",
+          "line": 36,
+          "isUsed": true,
+          "usedIn": [
+            "particles/compute-particles.ts",
+            "particles/cpu-particle-system.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "FireflyConfig",
+          "type": "interface",
+          "line": 48,
+          "isUsed": true,
+          "usedIn": [
+            "particles/compute-particles.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "PollenConfig",
+          "type": "interface",
+          "line": 53,
+          "isUsed": true,
+          "usedIn": [
+            "particles/compute-particles.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "BerryConfig",
+          "type": "interface",
+          "line": 58,
+          "isUsed": true,
+          "usedIn": [
+            "particles/compute-particles.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "RainConfig",
+          "type": "interface",
+          "line": 63,
+          "isUsed": true,
+          "usedIn": [
+            "particles/compute-particles.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "SparkConfig",
+          "type": "interface",
+          "line": 68,
+          "isUsed": true,
+          "usedIn": [
+            "particles/compute-particles.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "ComputeSystemCollection",
+          "type": "interface",
+          "line": 73,
+          "isUsed": true,
+          "usedIn": [
+            "particles/compute-particles.ts"
+          ],
+          "size": 0
+        }
+      ],
       "imports": [
-        "uWindSpeed",
-        "uWindDirection",
-        "uSkyTopColor",
-        "uSkyBottomColor",
-        "uHorizonColor",
-        "uAtmosphereIntensity",
-        "uStarOpacity",
-        "uAuroraIntensity",
-        "uAuroraColor",
-        "uAudioLow",
-        "uAudioHigh",
-        "uGlitchIntensity",
-        "uChromaticIntensity",
-        "uTime",
-        "uPlayerPosition",
-        "createAurora",
-        "createChromaticPulse",
-        "createStrobePulse",
-        "uStrobeIntensity",
-        "animateFoliage",
-        "updateFoliageMaterials",
-        "updateFallingBerries",
-        "collectFallingBerries",
-        "createMushroom",
-        "validateNodeGeometries",
-        "createMelodyRibbon",
-        "updateMelodyRibbons",
-        "createSparkleTrail",
-        "updateSparkleTrail",
-        "createImpactSystem",
-        "createShield",
-        "createDandelionSeedSystem",
-        "createDiscoveryEffect",
-        "initCelestialBodies",
-        "InteractionSystem",
-        "unlockSystem",
-        "musicReactivitySystem",
-        "fluidSystem",
-        "createFluidFog",
-        "AudioSystem",
-        "BeatSync",
-        "WeatherSystem",
-        "WeatherState",
-        "initWasm",
-        "getGroundHeight",
-        "profiler",
-        "enableStartupProfiler",
-        "finalizeStartupProfile",
-        "recordWASMInit",
-        "startPhase",
-        "endPhase",
-        "CONFIG",
-        "CYCLE_DURATION",
-        "DURATION_SUNRISE",
-        "DURATION_DAY",
-        "DURATION_SUNSET",
-        "DURATION_DUSK_NIGHT",
-        "DURATION_DEEP_NIGHT",
-        "initScene",
-        "forceFullSceneWarmup",
-        "initInput",
-        "keyStates",
-        "initPostProcessing",
-        "getCycleState",
-        "initWorld",
-        "generateMap",
-        "DEFAULT_MAP_CHUNK_SIZE",
-        "animatedFoliage",
-        "foliageClouds",
-        "foliageMushrooms",
-        "updatePhysics",
-        "player",
-        "fireRainbow",
-        "updateBlaster",
-        "jitterMineSystem",
-        "glitchGrenadeSystem",
-        "createHarpoonLine",
-        "updateHarpoonLine",
-        "updateFallingClouds",
-        "cloudBatcher",
         "THREE"
       ],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "particles/cpu-particle-system.ts",
+      "exports": [
+        {
+          "name": "CPUParticleSystem",
+          "type": "class",
+          "line": 15,
+          "isUsed": true,
+          "usedIn": [
+            "particles/compute-particles.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "PointsNodeMaterial",
+        "uv",
+        "distance",
+        "vec2",
+        "vec3",
+        "smoothstep",
+        "ComputeParticleType",
+        "ComputeParticleConfig",
+        "ParticleAudioData",
+        "THREE"
+      ],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "particles/index.ts",
+      "exports": [
+        {
+          "name": "CPUParticleSystem",
+          "type": "const",
+          "line": 30,
+          "isUsed": true,
+          "usedIn": [
+            "particles/compute-particles.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "default",
+          "type": "const",
+          "line": 49,
+          "isUsed": true,
+          "usedIn": [
+            "core/init.ts",
+            "systems/music-reactivity.ts",
+            "utils/wasm-loader-core.ts",
+            "world/generation.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "rendering/culling/culling-components.ts",
+      "exports": [
+        {
+          "name": "SpatialHashGrid",
+          "type": "class",
+          "line": 36,
+          "isUsed": true,
+          "usedIn": [
+            "rendering/culling/culling-system.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "OcclusionQueryManager",
+          "type": "class",
+          "line": 175,
+          "isUsed": true,
+          "usedIn": [
+            "rendering/culling/culling-system.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "CullingDebugVisualizer",
+          "type": "class",
+          "line": 263,
+          "isUsed": true,
+          "usedIn": [
+            "rendering/culling/culling-system.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "CullableObject",
+        "CullingStats",
+        "SpatialHashConfig",
+        "OcclusionQueryConfig",
+        "THREE"
+      ],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "systems/analytics/performance.ts",
+      "exports": [
+        {
+          "name": "PerformanceTracker",
+          "type": "class",
+          "line": 28,
+          "isUsed": true,
+          "usedIn": [
+            "systems/analytics/core.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "type FPSHistogram",
+        "type FrameTimePercentiles",
+        "type LoadingPhaseTiming",
+        "type MemorySnapshot",
+        "type PerformanceMetrics",
+        "type EventType",
+        "type SessionData",
+        "getTimestamp"
+      ],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "systems/asset-streaming/asset-loading-infrastructure.ts",
+      "exports": [
+        {
+          "name": "LRUCache",
+          "type": "class",
+          "line": 22,
+          "isUsed": true,
+          "usedIn": [
+            "systems/asset-streaming/asset-streaming-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "NetworkManager",
+          "type": "class",
+          "line": 136,
+          "isUsed": true,
+          "usedIn": [
+            "systems/asset-streaming/asset-streaming-core.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "AssetPriority",
+        "StreamingConfig",
+        "NetworkStats"
+      ],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "systems/asset-streaming/asset-streaming-core.ts",
+      "exports": [
+        {
+          "name": "AssetStreamer",
+          "type": "class",
+          "line": 78,
+          "isUsed": true,
+          "usedIn": [
+            "examples/asset-streaming-usage.ts",
+            "systems/asset-streaming/asset-streaming.ts",
+            "systems/index.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "RegionManager",
+        "GridCell",
+        "CellState",
+        "AssetPriority",
+        "AssetType",
+        "TextureFormat",
+        "LoadState",
+        "QualityLevel",
+        "MemoryPressure",
+        "AssetMetadata",
+        "AssetManifest",
+        "LoadedAsset",
+        "LoadingProgress",
+        "StreamingConfig",
+        "StreamingStats",
+        "AssetRequest",
+        "AssetBatch",
+        "DEFAULT_STREAMING_CONFIG",
+        "PRIORITY_DISTANCES",
+        "PRIORITY_DISTANCES_SQ",
+        "QUALITY_FORMAT_PREFERENCES",
+        "LRUCache",
+        "NetworkManager",
+        "ProgressiveTextureLoader",
+        "AudioStreamingLoader",
+        "GeometryLODLoader",
+        "PlaceholderManager",
+        "THREE"
+      ],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "systems/asset-streaming/asset-streaming-loader.ts",
+      "exports": [
+        {
+          "name": "ProgressiveTextureLoader",
+          "type": "class",
+          "line": 23,
+          "isUsed": true,
+          "usedIn": [
+            "systems/asset-streaming/asset-streaming-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "AudioStreamingLoader",
+          "type": "class",
+          "line": 89,
+          "isUsed": true,
+          "usedIn": [
+            "systems/asset-streaming/asset-streaming-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "GeometryLODLoader",
+          "type": "class",
+          "line": 151,
+          "isUsed": true,
+          "usedIn": [
+            "systems/asset-streaming/asset-streaming-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "PlaceholderManager",
+          "type": "class",
+          "line": 198,
+          "isUsed": true,
+          "usedIn": [
+            "systems/asset-streaming/asset-streaming-core.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "AssetType",
+        "THREE"
+      ],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "systems/asset-streaming/asset-streaming.ts",
+      "exports": [
+        {
+          "name": "AssetStreamer",
+          "type": "const",
+          "line": 24,
+          "isUsed": true,
+          "usedIn": [
+            "examples/asset-streaming-usage.ts",
+            "systems/asset-streaming/asset-streaming.ts",
+            "systems/index.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "AssetStreamer",
+        "AssetPriority",
+        "LoadState"
+      ],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "systems/asset-streaming/index.ts",
+      "exports": [
+        {
+          "name": "AssetStreamer",
+          "type": "const",
+          "line": 51,
+          "isUsed": true,
+          "usedIn": [
+            "examples/asset-streaming-usage.ts",
+            "systems/asset-streaming/asset-streaming.ts",
+            "systems/index.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "AssetStreamer",
+          "type": "const",
+          "line": 51,
+          "isUsed": true,
+          "usedIn": [
+            "examples/asset-streaming-usage.ts",
+            "systems/asset-streaming/asset-streaming.ts",
+            "systems/index.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "RegionManager",
+          "type": "const",
+          "line": 54,
+          "isUsed": true,
+          "usedIn": [
+            "examples/asset-streaming-usage.ts",
+            "systems/asset-streaming/asset-streaming-core.ts",
+            "systems/index.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "GridCell",
+          "type": "const",
+          "line": 54,
+          "isUsed": true,
+          "usedIn": [
+            "systems/asset-streaming/asset-streaming-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "CellState",
+          "type": "const",
+          "line": 54,
+          "isUsed": true,
+          "usedIn": [
+            "systems/asset-streaming/asset-streaming-core.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [],
       "unusedExports": [],
       "treeShakingScore": 100
     },
@@ -15416,6 +24903,7 @@
           "line": 95,
           "isUsed": true,
           "usedIn": [
+            "core/main.ts",
             "systems/deferred-loader.ts"
           ],
           "size": 0
@@ -15426,6 +24914,7 @@
           "line": 145,
           "isUsed": true,
           "usedIn": [
+            "core/main.ts",
             "systems/deferred-loader.ts"
           ],
           "size": 0
@@ -15436,6 +24925,9 @@
           "line": 417,
           "isUsed": true,
           "usedIn": [
+            "core/init.ts",
+            "systems/music-reactivity.ts",
+            "utils/wasm-loader-core.ts",
             "world/generation.ts"
           ],
           "size": 0
@@ -15478,7 +24970,7 @@
           "line": 413,
           "isUsed": true,
           "usedIn": [
-            "systems/physics.ts"
+            "systems/physics/physics-updates.ts"
           ],
           "size": 0
         },
@@ -15498,7 +24990,7 @@
           "line": 442,
           "isUsed": true,
           "usedIn": [
-            "systems/physics.ts"
+            "systems/physics/physics-updates.ts"
           ],
           "size": 0
         }
@@ -15520,10 +25012,11 @@
         {
           "name": "glitchGrenadeSystem",
           "type": "const",
-          "line": 189,
+          "line": 284,
           "isUsed": true,
           "usedIn": [
-            "main.ts"
+            "core/game-loop.ts",
+            "core/main.ts"
           ],
           "size": 0
         }
@@ -15533,11 +25026,509 @@
         "uGlitchExplosionRadius",
         "sharedGeometries",
         "MeshStandardNodeMaterial",
+        "StorageInstancedBufferAttribute",
         "color",
         "float",
+        "attribute",
+        "storage",
+        "instanceIndex",
+        "Fn",
+        "If",
+        "vec4",
+        "uniform",
+        "positionLocal",
+        "smoothstep",
         "getGroundHeight",
         "spawnImpact",
+        "addCameraShake",
         "THREE"
+      ],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "systems/performance-budget/performance-budget-core.ts",
+      "exports": [
+        {
+          "name": "PerformanceBudget",
+          "type": "class",
+          "line": 65,
+          "isUsed": true,
+          "usedIn": [
+            "systems/performance-budget/performance-budget-core.ts",
+            "systems/performance-budget/performance-budget-overlay.ts",
+            "systems/performance-budget.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "performanceBudget",
+          "type": "const",
+          "line": 962,
+          "isUsed": true,
+          "usedIn": [
+            "systems/performance-budget/performance-budget-overlay.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "default",
+          "type": "function",
+          "line": 965,
+          "isUsed": true,
+          "usedIn": [
+            "core/init.ts",
+            "systems/music-reactivity.ts",
+            "utils/wasm-loader-core.ts",
+            "world/generation.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "PerformanceBudget",
+        "PERFORMANCE_BUDGETS",
+        "BudgetMode",
+        "BudgetType",
+        "BudgetConfig",
+        "InstanceBudget",
+        "PerformanceBudgetConfig",
+        "PerformanceMetrics",
+        "BudgetViolation",
+        "AdaptiveSettings"
+      ],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "systems/performance-budget/performance-budget-overlay.ts",
+      "exports": [
+        {
+          "name": "DebugOverlayOptions",
+          "type": "const",
+          "line": 23,
+          "isUsed": true,
+          "usedIn": [
+            "systems/performance-budget/performance-budget-overlay.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "PerformanceBudgetOverlay",
+          "type": "class",
+          "line": 35,
+          "isUsed": true,
+          "usedIn": [
+            "systems/performance-budget/performance-budget-overlay.ts",
+            "systems/performance-budget.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "default",
+          "type": "function",
+          "line": 352,
+          "isUsed": true,
+          "usedIn": [
+            "core/init.ts",
+            "systems/music-reactivity.ts",
+            "utils/wasm-loader-core.ts",
+            "world/generation.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "PerformanceBudgetOverlay",
+        "performanceBudget",
+        "BudgetType",
+        "DebugOverlayOptions",
+        "PerformanceBudget"
+      ],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "systems/performance-budget/performance-budget-types.ts",
+      "exports": [
+        {
+          "name": "BudgetMode",
+          "type": "enum",
+          "line": 9,
+          "isUsed": true,
+          "usedIn": [
+            "systems/performance-budget/performance-budget-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "BudgetType",
+          "type": "type",
+          "line": 21,
+          "isUsed": true,
+          "usedIn": [
+            "systems/performance-budget/performance-budget-core.ts",
+            "systems/performance-budget/performance-budget-overlay.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "BudgetConfig",
+          "type": "interface",
+          "line": 29,
+          "isUsed": true,
+          "usedIn": [
+            "systems/performance-budget/performance-budget-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "InstanceBudget",
+          "type": "interface",
+          "line": 41,
+          "isUsed": true,
+          "usedIn": [
+            "systems/performance-budget/performance-budget-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "PerformanceBudgetConfig",
+          "type": "interface",
+          "line": 48,
+          "isUsed": true,
+          "usedIn": [
+            "systems/performance-budget/performance-budget-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "PerformanceMetrics",
+          "type": "interface",
+          "line": 66,
+          "isUsed": true,
+          "usedIn": [
+            "systems/performance-budget/performance-budget-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "BudgetViolation",
+          "type": "interface",
+          "line": 76,
+          "isUsed": true,
+          "usedIn": [
+            "systems/performance-budget/performance-budget-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "AdaptiveSettings",
+          "type": "interface",
+          "line": 87,
+          "isUsed": true,
+          "usedIn": [
+            "systems/performance-budget/performance-budget-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "DebugOverlayOptions",
+          "type": "interface",
+          "line": 103,
+          "isUsed": true,
+          "usedIn": [
+            "systems/performance-budget/performance-budget-overlay.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "PERFORMANCE_BUDGETS",
+          "type": "const",
+          "line": 116,
+          "isUsed": true,
+          "usedIn": [
+            "systems/performance-budget/performance-budget-core.ts",
+            "systems/performance-budget.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "systems/performance-budget.ts",
+      "exports": [],
+      "imports": [
+        "PerformanceBudget",
+        "PERFORMANCE_BUDGETS",
+        "PerformanceBudgetOverlay"
+      ],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "systems/physics/index.ts",
+      "exports": [],
+      "imports": [],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "systems/physics/physics-abilities.ts",
+      "exports": [
+        {
+          "name": "handleAbilities",
+          "type": "function",
+          "line": 18,
+          "isUsed": true,
+          "usedIn": [
+            "systems/physics/physics-core.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "player",
+        "_lastInputState",
+        "_scratchCamDir",
+        "AudioState",
+        "KeyStates",
+        "spawnImpact",
+        "spawnDandelionExplosion",
+        "dandelionBatcher",
+        "animatedFoliage",
+        "physicsFoliageGrid",
+        "discoverySystem",
+        "unlockSystem",
+        "showToast",
+        "uChromaticIntensity",
+        "addCameraShake",
+        "THREE"
+      ],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "systems/save-system/save-database.ts",
+      "exports": [
+        {
+          "name": "LZString",
+          "type": "const",
+          "line": 24,
+          "isUsed": true,
+          "usedIn": [
+            "systems/save-system/save-system.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "SaveDatabase",
+          "type": "class",
+          "line": 104,
+          "isUsed": true,
+          "usedIn": [
+            "systems/save-system/save-system.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "MigrationSystem",
+          "type": "class",
+          "line": 280,
+          "isUsed": true,
+          "usedIn": [
+            "systems/save-system/save-system.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "SAVE_VERSION",
+        "DB_NAME",
+        "DB_VERSION",
+        "STORE_NAME",
+        "SaveData",
+        "SaveSlotInfo",
+        "SettingsSaveData",
+        "MigrationFunction"
+      ],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "systems/weather/index.ts",
+      "exports": [
+        {
+          "name": "WeatherState",
+          "type": "const",
+          "line": 4,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts",
+            "systems/weather/weather-atmosphere.ts",
+            "systems/weather/weather-effects.ts",
+            "systems/weather/weather.ts",
+            "systems/weather-utils.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "WeatherSystem",
+          "type": "const",
+          "line": 5,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts",
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "EcosystemManager",
+          "type": "const",
+          "line": 6,
+          "isUsed": true,
+          "usedIn": [
+            "systems/weather/weather.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "AtmosphereManager",
+          "type": "const",
+          "line": 7,
+          "isUsed": true,
+          "usedIn": [
+            "systems/weather/weather.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "EffectsManager",
+          "type": "const",
+          "line": 8,
+          "isUsed": true,
+          "usedIn": [
+            "systems/weather/weather.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "systems/weather/weather-atmosphere.ts",
+      "exports": [
+        {
+          "name": "AtmosphereManager",
+          "type": "class",
+          "line": 16,
+          "isUsed": true,
+          "usedIn": [
+            "systems/weather/weather.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "WeatherState",
+        "CYCLE_DURATION",
+        "DURATION_SUNRISE",
+        "DURATION_DAY",
+        "DURATION_SUNSET",
+        "DURATION_PRE_DAWN",
+        "CONFIG",
+        "uSkyDarkness",
+        "uTwilight",
+        "uCrescendoFogDensity",
+        "uFogNear",
+        "uFogFar",
+        "chargeBerries",
+        "shakeBerriesLoose",
+        "updateGlobalBerryScale",
+        "THREE"
+      ],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "systems/weather/weather-ecosystem.ts",
+      "exports": [
+        {
+          "name": "EcosystemManager",
+          "type": "class",
+          "line": 26,
+          "isUsed": true,
+          "usedIn": [
+            "systems/weather/weather.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "cpuAnimatedFoliage",
+        "getGroundHeight",
+        "uploadMushroomSpecs",
+        "batchMushroomSpawnCandidates",
+        "readSpawnCandidates",
+        "isWasmReady",
+        "createMushroom",
+        "FoliageGrowthOptions",
+        "spawnNearbyFoliage",
+        "createLanternFlower",
+        "cleanupReactivity",
+        "updateCloudAttraction",
+        "isCloudOverTarget",
+        "foliageClouds",
+        "replaceMushroomWithGiant",
+        "mushroomBatcher",
+        "flowerBatcher",
+        "waterfallBatcher",
+        "musicReactivitySystem",
+        "THREE"
+      ],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "systems/weather/weather.ts",
+      "exports": [
+        {
+          "name": "WeatherSystem",
+          "type": "class",
+          "line": 29,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts",
+            "core/main.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "WeatherState",
+        "calculateTimeOfDayBias",
+        "EcosystemManager",
+        "AtmosphereManager",
+        "EffectsManager",
+        "CYCLE_DURATION",
+        "DURATION_SUNRISE",
+        "DURATION_DAY",
+        "CONFIG",
+        "VisualState",
+        "WeatherMusicTargets",
+        "uTwilight",
+        "updateCaveWaterLevel",
+        "BerryBatcher",
+        "triggerGrowth",
+        "waterfallBatcher",
+        "THREE",
+        "Cycle"
       ],
       "unusedExports": [],
       "treeShakingScore": 100
@@ -15551,9 +25542,11 @@
           "line": 1,
           "isUsed": true,
           "usedIn": [
-            "main.ts",
-            "systems/weather-utils.ts",
-            "systems/weather.ts"
+            "core/game-loop.ts",
+            "systems/weather/weather-atmosphere.ts",
+            "systems/weather/weather-effects.ts",
+            "systems/weather/weather.ts",
+            "systems/weather-utils.ts"
           ],
           "size": 0
         }
@@ -15571,7 +25564,7 @@
           "line": 10,
           "isUsed": true,
           "usedIn": [
-            "systems/weather.ts"
+            "systems/weather/weather.ts"
           ],
           "size": 0
         }
@@ -15592,63 +25585,104 @@
       "exports": [
         {
           "name": "WeatherSystem",
-          "type": "class",
-          "line": 38,
+          "type": "const",
+          "line": 5,
           "isUsed": true,
           "usedIn": [
-            "main.ts"
+            "core/game-loop.ts",
+            "core/main.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "WeatherState",
+          "type": "const",
+          "line": 5,
+          "isUsed": true,
+          "usedIn": [
+            "core/game-loop.ts",
+            "systems/weather/weather-atmosphere.ts",
+            "systems/weather/weather-effects.ts",
+            "systems/weather/weather.ts",
+            "systems/weather-utils.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "EcosystemManager",
+          "type": "const",
+          "line": 5,
+          "isUsed": true,
+          "usedIn": [
+            "systems/weather/weather.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "AtmosphereManager",
+          "type": "const",
+          "line": 5,
+          "isUsed": true,
+          "usedIn": [
+            "systems/weather/weather.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "EffectsManager",
+          "type": "const",
+          "line": 5,
+          "isUsed": true,
+          "usedIn": [
+            "systems/weather/weather.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "ui/accessibility-menu-handlers.ts",
+      "exports": [
+        {
+          "name": "AccessibilityMenuHandlers",
+          "type": "class",
+          "line": 14,
+          "isUsed": true,
+          "usedIn": [
+            "ui/accessibility-menu.ts"
           ],
           "size": 0
         }
       ],
       "imports": [
-        "getGroundHeight",
-        "uploadPositions",
-        "uploadAnimationData",
-        "uploadMushroomSpecs",
-        "batchMushroomSpawnCandidates",
-        "readSpawnCandidates",
-        "isWasmReady",
-        "chargeBerries",
-        "triggerGrowth",
-        "triggerBloom",
-        "shakeBerriesLoose",
-        "createMushroom",
-        "createLanternFlower",
-        "cleanupReactivity",
-        "musicReactivitySystem",
-        "updateGlobalBerryScale",
-        "berryBatcher",
-        "waterfallBatcher",
-        "createRainbow",
-        "uRainbowOpacity",
-        "createAurora",
-        "uAuroraIntensity",
-        "CYCLE_DURATION",
-        "CONFIG",
-        "DURATION_SUNRISE",
-        "DURATION_DAY",
-        "DURATION_SUNSET",
-        "DURATION_PRE_DAWN",
-        "uCloudRainbowIntensity",
-        "uCloudLightningStrength",
-        "uCloudLightningColor",
-        "updateCloudAttraction",
-        "isCloudOverTarget",
-        "uSkyDarkness",
-        "uTwilight",
-        "uChromaticIntensity",
-        "updateCaveWaterLevel",
-        "LegacyParticleSystem",
-        "WasmParticleSystem",
-        "foliageClouds",
-        "replaceMushroomWithGiant",
-        "mushroomBatcher",
-        "VisualState",
-        "WeatherState",
-        "calculateTimeOfDayBias",
-        "THREE",
-        "Cycle"
+        "AccessibilityMenuRendering",
+        "MenuSection",
+        "announce"
+      ],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "ui/accessibility-menu-rendering.ts",
+      "exports": [
+        {
+          "name": "AccessibilityMenuRendering",
+          "type": "class",
+          "line": 14,
+          "isUsed": true,
+          "usedIn": [
+            "ui/accessibility-menu-handlers.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "AccessibilityMenu",
+        "MenuSection",
+        "trapFocusInside"
       ],
       "unusedExports": [],
       "treeShakingScore": 100
@@ -15659,14 +25693,141 @@
         {
           "name": "default",
           "type": "const",
-          "line": 49,
+          "line": 53,
           "isUsed": true,
           "usedIn": [
+            "core/init.ts",
+            "systems/music-reactivity.ts",
+            "utils/wasm-loader-core.ts",
             "world/generation.ts"
           ],
           "size": 0
         }
       ],
+      "imports": [],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "ui/save-menu/save-menu-styles.ts",
+      "exports": [
+        {
+          "name": "MENU_STYLES",
+          "type": "const",
+          "line": 7,
+          "isUsed": true,
+          "usedIn": [
+            "ui/save-menu/save-menu.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "default",
+          "type": "function",
+          "line": 697,
+          "isUsed": true,
+          "usedIn": [
+            "core/init.ts",
+            "systems/music-reactivity.ts",
+            "utils/wasm-loader-core.ts",
+            "world/generation.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "utils/toast.ts",
+      "exports": [
+        {
+          "name": "showToast",
+          "type": "function",
+          "line": 14,
+          "isUsed": true,
+          "usedIn": [
+            "foliage/lotus.ts",
+            "gameplay/chord-strike.ts",
+            "systems/discovery.ts",
+            "systems/physics/physics-abilities.ts",
+            "systems/physics/physics-core.ts",
+            "systems/physics/physics-updates.ts",
+            "systems/save-system/save-system.ts",
+            "systems/unlocks.ts",
+            "ui/save-menu/save-menu.ts",
+            "ui/save-menu/save-settings.ts",
+            "ui/save-menu/save-slots.ts",
+            "utils/wasm-loader-core.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [
+        "announce"
+      ],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "utils/wasm-batch-types.ts",
+      "exports": [
+        {
+          "name": "SpawnCandidate",
+          "type": "interface",
+          "line": 11,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-batch-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "MaterialAnalysisResult",
+          "type": "interface",
+          "line": 21,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-batch-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "DistanceCullResult",
+          "type": "interface",
+          "line": 34,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-batch-core.ts"
+          ],
+          "size": 0
+        },
+        {
+          "name": "MaterialInfo",
+          "type": "interface",
+          "line": 42,
+          "isUsed": true,
+          "usedIn": [
+            "utils/wasm-batch-core.ts"
+          ],
+          "size": 0
+        }
+      ],
+      "imports": [],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "utils/wasm-batch.ts",
+      "exports": [],
+      "imports": [],
+      "unusedExports": [],
+      "treeShakingScore": 100
+    },
+    {
+      "path": "utils/wasm-loader.ts",
+      "exports": [],
       "imports": [],
       "unusedExports": [],
       "treeShakingScore": 100
@@ -15698,285 +25859,112 @@
       "imports": [],
       "unusedExports": [],
       "treeShakingScore": 100
-    },
-    {
-      "path": "world/state.ts",
-      "exports": [
-        {
-          "name": "animatedFoliage",
-          "type": "const",
-          "line": 5,
-          "isUsed": true,
-          "usedIn": [
-            "main.ts",
-            "systems/physics.ts",
-            "world/generation.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "obstacles",
-          "type": "const",
-          "line": 6,
-          "isUsed": true,
-          "usedIn": [
-            "world/generation.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "foliageMushrooms",
-          "type": "const",
-          "line": 9,
-          "isUsed": true,
-          "usedIn": [
-            "main.ts",
-            "systems/physics.ts",
-            "world/generation.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "foliageTrampolines",
-          "type": "const",
-          "line": 10,
-          "isUsed": true,
-          "usedIn": [
-            "systems/physics.ts",
-            "world/generation.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "foliagePanningPads",
-          "type": "const",
-          "line": 11,
-          "isUsed": true,
-          "usedIn": [
-            "systems/physics.ts",
-            "world/generation.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "foliageClouds",
-          "type": "const",
-          "line": 12,
-          "isUsed": true,
-          "usedIn": [
-            "gameplay/rainbow-blaster.ts",
-            "main.ts",
-            "systems/physics.ts",
-            "systems/weather.ts",
-            "world/generation.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "foliageGeysers",
-          "type": "const",
-          "line": 13,
-          "isUsed": true,
-          "usedIn": [
-            "gameplay/rainbow-blaster.ts",
-            "systems/physics.ts",
-            "world/generation.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "foliageTraps",
-          "type": "const",
-          "line": 14,
-          "isUsed": true,
-          "usedIn": [
-            "gameplay/rainbow-blaster.ts",
-            "systems/physics.ts",
-            "world/generation.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "foliagePortamentoPines",
-          "type": "const",
-          "line": 15,
-          "isUsed": true,
-          "usedIn": [
-            "systems/physics.ts",
-            "world/generation.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "vineSwings",
-          "type": "const",
-          "line": 16,
-          "isUsed": true,
-          "usedIn": [
-            "systems/physics.ts",
-            "world/generation.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "worldGroup",
-          "type": "const",
-          "line": 19,
-          "isUsed": true,
-          "usedIn": [
-            "world/generation.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "foliageGroup",
-          "type": "const",
-          "line": 20,
-          "isUsed": true,
-          "usedIn": [
-            "foliage/arpeggio-batcher.ts",
-            "foliage/berries.ts",
-            "foliage/cloud-batcher.ts",
-            "foliage/dandelion-batcher.ts",
-            "foliage/flower-batcher.ts",
-            "foliage/glowing-flower-batcher.ts",
-            "foliage/lantern-batcher.ts",
-            "foliage/lod.ts",
-            "foliage/mushroom-batcher.ts",
-            "foliage/portamento-batcher.ts",
-            "foliage/simple-flower-batcher.ts",
-            "foliage/tree-batcher.ts",
-            "foliage/waterfall-batcher.ts",
-            "world/generation.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "activeVineSwing",
-          "type": "let",
-          "line": 23,
-          "isUsed": true,
-          "usedIn": [
-            "systems/physics.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "lastVineDetachTime",
-          "type": "let",
-          "line": 24,
-          "isUsed": true,
-          "usedIn": [
-            "systems/physics.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "setActiveVineSwing",
-          "type": "function",
-          "line": 26,
-          "isUsed": true,
-          "usedIn": [
-            "systems/physics.ts"
-          ],
-          "size": 0
-        },
-        {
-          "name": "setLastVineDetachTime",
-          "type": "function",
-          "line": 30,
-          "isUsed": true,
-          "usedIn": [
-            "systems/physics.ts"
-          ],
-          "size": 0
-        }
-      ],
-      "imports": [
-        "VineSwing",
-        "FoliageObject",
-        "THREE"
-      ],
-      "unusedExports": [],
-      "treeShakingScore": 100
     }
   ],
   "recommendations": [
     {
-      "file": "particles/compute-particles.ts",
-      "issue": "22 unused exports",
+      "file": "compute/gpu-foliage-animator.ts",
+      "issue": "11 unused exports",
       "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 46596,
+      "potentialSavings": 28259,
       "priority": "high"
     },
     {
-      "file": "systems/asset-streaming.ts",
-      "issue": "22 unused exports",
+      "file": "systems/accessibility.ts",
+      "issue": "21 unused exports",
       "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 39578,
-      "priority": "high"
-    },
-    {
-      "file": "rendering/culling-system.ts",
-      "issue": "17 unused exports",
-      "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 37587,
-      "priority": "high"
-    },
-    {
-      "file": "systems/analytics.ts",
-      "issue": "18 unused exports",
-      "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 32382,
-      "priority": "high"
-    },
-    {
-      "file": "systems/performance-budget.ts",
-      "issue": "10 unused exports",
-      "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 31370,
-      "priority": "high"
-    },
-    {
-      "file": "ui/loading-screen.ts",
-      "issue": "14 unused exports",
-      "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 24850,
-      "priority": "high"
-    },
-    {
-      "file": "foliage/lod.ts",
-      "issue": "8 unused exports",
-      "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 24280,
+      "potentialSavings": 26796,
       "priority": "high"
     },
     {
       "file": "systems/region-manager.ts",
-      "issue": "13 unused exports",
+      "issue": "14 unused exports",
       "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 23361,
+      "potentialSavings": 25816,
       "priority": "high"
     },
     {
       "file": "particles/gpu_particles.ts",
       "issue": "7 unused exports",
       "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 20965,
+      "potentialSavings": 23373,
+      "priority": "high"
+    },
+    {
+      "file": "compute/gpu-culling-system.ts",
+      "issue": "8 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 22584,
+      "priority": "high"
+    },
+    {
+      "file": "ui/save-menu/save-menu.ts",
+      "issue": "8 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 22232,
+      "priority": "high"
+    },
+    {
+      "file": "foliage/lod.ts",
+      "issue": "7 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 22127,
+      "priority": "high"
+    },
+    {
+      "file": "compute/gpu-particle-system.ts",
+      "issue": "7 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 21700,
       "priority": "high"
     },
     {
       "file": "systems/discovery-persistence.ts",
       "issue": "12 unused exports",
       "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 20592,
+      "potentialSavings": 20904,
       "priority": "high"
     },
     {
-      "file": "systems/accessibility.ts",
-      "issue": "16 unused exports",
+      "file": "ui/loading-screen.ts",
+      "issue": "9 unused exports",
       "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 20416,
+      "potentialSavings": 20520,
+      "priority": "high"
+    },
+    {
+      "file": "foliage/trees.ts",
+      "issue": "18 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 18234,
+      "priority": "high"
+    },
+    {
+      "file": "utils/wasm-animations.ts",
+      "issue": "21 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 17703,
+      "priority": "high"
+    },
+    {
+      "file": "rendering/shader-warmup.ts",
+      "issue": "9 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 16866,
+      "priority": "high"
+    },
+    {
+      "file": "utils/wasm-loader-core.ts",
+      "issue": "39 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 16809,
+      "priority": "high"
+    },
+    {
+      "file": "utils/wasm-physics.ts",
+      "issue": "18 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 16200,
       "priority": "high"
     },
     {
@@ -15987,24 +25975,24 @@
       "priority": "high"
     },
     {
-      "file": "foliage/trees.ts",
-      "issue": "17 unused exports",
+      "file": "utils/wasm-batch-math.ts",
+      "issue": "12 unused exports",
       "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 15878,
-      "priority": "high"
-    },
-    {
-      "file": "rendering/shader-warmup.ts",
-      "issue": "9 unused exports",
-      "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 14859,
+      "potentialSavings": 15204,
       "priority": "high"
     },
     {
       "file": "particles/compute-integration.ts",
       "issue": "15 unused exports",
       "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 13020,
+      "potentialSavings": 13365,
+      "priority": "high"
+    },
+    {
+      "file": "foliage/wind-compute.ts",
+      "issue": "6 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 11088,
       "priority": "high"
     },
     {
@@ -16015,17 +26003,17 @@
       "priority": "high"
     },
     {
-      "file": "foliage/common.ts",
-      "issue": "12 unused exports",
+      "file": "utils/wasm-batch-animation.ts",
+      "issue": "16 unused exports",
       "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 10488,
+      "potentialSavings": 10704,
       "priority": "high"
     },
     {
-      "file": "foliage/berries.ts",
-      "issue": "8 unused exports",
+      "file": "particles/compute-particles.ts",
+      "issue": "6 unused exports",
       "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 10248,
+      "potentialSavings": 10596,
       "priority": "high"
     },
     {
@@ -16036,6 +26024,13 @@
       "priority": "high"
     },
     {
+      "file": "foliage/berries.ts",
+      "issue": "7 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 9681,
+      "priority": "high"
+    },
+    {
       "file": "rendering/webgpu-limits.ts",
       "issue": "11 unused exports",
       "suggestion": "Remove unused exports or split into smaller modules",
@@ -16043,10 +26038,24 @@
       "priority": "high"
     },
     {
+      "file": "utils/bootstrap-loader.ts",
+      "issue": "10 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 8930,
+      "priority": "high"
+    },
+    {
+      "file": "utils/geometry-dedup.ts",
+      "issue": "9 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 8487,
+      "priority": "high"
+    },
+    {
       "file": "systems/music-reactivity.core.ts",
       "issue": "11 unused exports",
       "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 7502,
+      "potentialSavings": 7777,
       "priority": "high"
     },
     {
@@ -16064,24 +26073,45 @@
       "priority": "high"
     },
     {
-      "file": "utils/geometry-dedup.ts",
-      "issue": "6 unused exports",
+      "file": "foliage/material-core.ts",
+      "issue": "9 unused exports",
       "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 5658,
+      "potentialSavings": 6777,
+      "priority": "high"
+    },
+    {
+      "file": "utils/wasm-orchestrator.ts",
+      "issue": "9 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 6363,
       "priority": "high"
     },
     {
       "file": "particles/particle_config.ts",
-      "issue": "12 unused exports",
+      "issue": "11 unused exports",
       "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 5304,
+      "potentialSavings": 4862,
       "priority": "high"
     },
     {
-      "file": "rendering/material_types.ts",
+      "file": "foliage/animation-nodes.ts",
       "issue": "11 unused exports",
       "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 3619,
+      "potentialSavings": 4796,
+      "priority": "high"
+    },
+    {
+      "file": "systems/analytics/types.ts",
+      "issue": "11 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 4323,
+      "priority": "high"
+    },
+    {
+      "file": "debug/stages.ts",
+      "issue": "6 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 4164,
       "priority": "high"
     },
     {
@@ -16092,129 +26122,150 @@
       "priority": "high"
     },
     {
-      "file": "foliage/index.ts",
-      "issue": "48 unused exports",
+      "file": "systems/analytics/index.ts",
+      "issue": "9 unused exports",
       "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 2064,
+      "potentialSavings": 3303,
       "priority": "high"
     },
     {
-      "file": "particles/compute-particles.ts",
-      "issue": "Low tree-shaking score (15%)",
-      "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
-      "potentialSavings": 46596,
-      "priority": "medium"
-    },
-    {
-      "file": "ui/accessibility-menu.ts",
-      "issue": "5 unused exports",
+      "file": "rendering/material_types.ts",
+      "issue": "10 unused exports",
       "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 41025,
-      "priority": "medium"
+      "potentialSavings": 3290,
+      "priority": "high"
     },
     {
-      "file": "systems/asset-streaming.ts",
-      "issue": "Low tree-shaking score (27%)",
-      "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
-      "potentialSavings": 39578,
-      "priority": "medium"
-    },
-    {
-      "file": "rendering/culling-system.ts",
-      "issue": "Low tree-shaking score (6%)",
-      "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
-      "potentialSavings": 37587,
-      "priority": "medium"
-    },
-    {
-      "file": "systems/analytics.ts",
-      "issue": "Low tree-shaking score (18%)",
-      "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
-      "potentialSavings": 32382,
-      "priority": "medium"
-    },
-    {
-      "file": "systems/performance-budget.ts",
-      "issue": "Low tree-shaking score (23%)",
-      "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
-      "potentialSavings": 31370,
-      "priority": "medium"
-    },
-    {
-      "file": "ui/save-menu.ts",
-      "issue": "5 unused exports",
+      "file": "systems/physics/physics-types.ts",
+      "issue": "6 unused exports",
       "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 30630,
+      "potentialSavings": 936,
+      "priority": "high"
+    },
+    {
+      "file": "core/index.ts",
+      "issue": "6 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 162,
+      "priority": "high"
+    },
+    {
+      "file": "compute/gpu-foliage-animator.ts",
+      "issue": "Low tree-shaking score (0%)",
+      "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
+      "potentialSavings": 28259,
       "priority": "medium"
     },
     {
-      "file": "ui/save-menu.ts",
-      "issue": "Low tree-shaking score (38%)",
+      "file": "systems/accessibility.ts",
+      "issue": "Low tree-shaking score (13%)",
       "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
-      "potentialSavings": 30630,
-      "priority": "medium"
-    },
-    {
-      "file": "ui/loading-screen.ts",
-      "issue": "Low tree-shaking score (7%)",
-      "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
-      "potentialSavings": 24850,
-      "priority": "medium"
-    },
-    {
-      "file": "foliage/lod.ts",
-      "issue": "Low tree-shaking score (11%)",
-      "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
-      "potentialSavings": 24280,
+      "potentialSavings": 26796,
       "priority": "medium"
     },
     {
       "file": "systems/region-manager.ts",
-      "issue": "Low tree-shaking score (24%)",
+      "issue": "Low tree-shaking score (22%)",
       "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
-      "potentialSavings": 23361,
+      "potentialSavings": 25816,
       "priority": "medium"
     },
     {
       "file": "ui/analytics-debug.ts",
       "issue": "5 unused exports",
       "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 22420,
+      "potentialSavings": 25015,
       "priority": "medium"
     },
     {
       "file": "ui/analytics-debug.ts",
       "issue": "Low tree-shaking score (17%)",
       "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
-      "potentialSavings": 22420,
+      "potentialSavings": 25015,
       "priority": "medium"
     },
     {
       "file": "particles/gpu_particles.ts",
       "issue": "Low tree-shaking score (0%)",
       "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
-      "potentialSavings": 20965,
+      "potentialSavings": 23373,
+      "priority": "medium"
+    },
+    {
+      "file": "compute/gpu-culling-system.ts",
+      "issue": "Low tree-shaking score (11%)",
+      "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
+      "potentialSavings": 22584,
+      "priority": "medium"
+    },
+    {
+      "file": "ui/save-menu/save-menu.ts",
+      "issue": "Low tree-shaking score (27%)",
+      "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
+      "potentialSavings": 22232,
+      "priority": "medium"
+    },
+    {
+      "file": "foliage/lod.ts",
+      "issue": "Low tree-shaking score (22%)",
+      "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
+      "potentialSavings": 22127,
+      "priority": "medium"
+    },
+    {
+      "file": "compute/gpu-particle-system.ts",
+      "issue": "Low tree-shaking score (22%)",
+      "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
+      "potentialSavings": 21700,
       "priority": "medium"
     },
     {
       "file": "systems/discovery-persistence.ts",
       "issue": "Low tree-shaking score (8%)",
       "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
-      "potentialSavings": 20592,
+      "potentialSavings": 20904,
       "priority": "medium"
     },
     {
-      "file": "systems/accessibility.ts",
-      "issue": "Low tree-shaking score (33%)",
+      "file": "ui/loading-screen.ts",
+      "issue": "Low tree-shaking score (47%)",
       "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
-      "potentialSavings": 20416,
+      "potentialSavings": 20520,
       "priority": "medium"
     },
     {
-      "file": "systems/physics.ts",
-      "issue": "4 unused exports",
+      "file": "foliage/trees.ts",
+      "issue": "Low tree-shaking score (31%)",
+      "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
+      "potentialSavings": 18234,
+      "priority": "medium"
+    },
+    {
+      "file": "utils/wasm-animations.ts",
+      "issue": "Low tree-shaking score (5%)",
+      "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
+      "potentialSavings": 17703,
+      "priority": "medium"
+    },
+    {
+      "file": "rendering/shader-warmup.ts",
+      "issue": "Low tree-shaking score (10%)",
+      "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
+      "potentialSavings": 16866,
+      "priority": "medium"
+    },
+    {
+      "file": "systems/music-reactivity.ts",
+      "issue": "3 unused exports",
       "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 20040,
+      "potentialSavings": 16257,
+      "priority": "medium"
+    },
+    {
+      "file": "utils/wasm-physics.ts",
+      "issue": "Low tree-shaking score (45%)",
+      "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
+      "potentialSavings": 16200,
       "priority": "medium"
     },
     {
@@ -16225,59 +26276,52 @@
       "priority": "medium"
     },
     {
-      "file": "foliage/trees.ts",
-      "issue": "Low tree-shaking score (29%)",
-      "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
-      "potentialSavings": 15878,
-      "priority": "medium"
-    },
-    {
-      "file": "rendering/shader-warmup.ts",
-      "issue": "Low tree-shaking score (10%)",
-      "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
-      "potentialSavings": 14859,
-      "priority": "medium"
-    },
-    {
       "file": "world/generation.ts",
-      "issue": "3 unused exports",
+      "issue": "4 unused exports",
       "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 14808,
+      "potentialSavings": 15816,
       "priority": "medium"
     },
     {
-      "file": "systems/save-system.ts",
-      "issue": "5 unused exports",
-      "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 14420,
-      "priority": "medium"
-    },
-    {
-      "file": "utils/startup-profiler.ts",
-      "issue": "5 unused exports",
-      "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 14220,
+      "file": "utils/wasm-batch-math.ts",
+      "issue": "Low tree-shaking score (0%)",
+      "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
+      "potentialSavings": 15204,
       "priority": "medium"
     },
     {
       "file": "particles/compute-integration.ts",
-      "issue": "Low tree-shaking score (0%)",
-      "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
-      "potentialSavings": 13020,
-      "priority": "medium"
-    },
-    {
-      "file": "foliage/wind-compute.ts",
-      "issue": "5 unused exports",
-      "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 11585,
-      "priority": "medium"
-    },
-    {
-      "file": "foliage/wind-compute.ts",
       "issue": "Low tree-shaking score (29%)",
       "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
-      "potentialSavings": 11585,
+      "potentialSavings": 13365,
+      "priority": "medium"
+    },
+    {
+      "file": "core/game-loop.ts",
+      "issue": "3 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 13245,
+      "priority": "medium"
+    },
+    {
+      "file": "systems/asset-streaming/asset-streaming-scheduler.ts",
+      "issue": "3 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 12114,
+      "priority": "medium"
+    },
+    {
+      "file": "rendering/culling-system-gpu.ts",
+      "issue": "3 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 11391,
+      "priority": "medium"
+    },
+    {
+      "file": "utils/startup-profiler.ts",
+      "issue": "4 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 11212,
       "priority": "medium"
     },
     {
@@ -16295,10 +26339,24 @@
       "priority": "medium"
     },
     {
+      "file": "foliage/wind-compute.ts",
+      "issue": "Low tree-shaking score (25%)",
+      "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
+      "potentialSavings": 11088,
+      "priority": "medium"
+    },
+    {
       "file": "rendering/materials.ts",
       "issue": "Low tree-shaking score (21%)",
       "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
       "potentialSavings": 10978,
+      "priority": "medium"
+    },
+    {
+      "file": "utils/wasm-batch-animation.ts",
+      "issue": "Low tree-shaking score (27%)",
+      "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
+      "potentialSavings": 10704,
       "priority": "medium"
     },
     {
@@ -16316,17 +26374,38 @@
       "priority": "medium"
     },
     {
+      "file": "utils/bootstrap-loader.ts",
+      "issue": "Low tree-shaking score (0%)",
+      "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
+      "potentialSavings": 8930,
+      "priority": "medium"
+    },
+    {
+      "file": "utils/geometry-dedup.ts",
+      "issue": "Low tree-shaking score (47%)",
+      "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
+      "potentialSavings": 8487,
+      "priority": "medium"
+    },
+    {
+      "file": "compute/mesh-deformation-gpu.ts",
+      "issue": "4 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 8480,
+      "priority": "medium"
+    },
+    {
       "file": "foliage/flowers.ts",
       "issue": "3 unused exports",
       "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 7620,
+      "potentialSavings": 8133,
       "priority": "medium"
     },
     {
       "file": "systems/music-reactivity.core.ts",
       "issue": "Low tree-shaking score (0%)",
       "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
-      "potentialSavings": 7502,
+      "potentialSavings": 7777,
       "priority": "medium"
     },
     {
@@ -16344,10 +26423,38 @@
       "priority": "medium"
     },
     {
+      "file": "core/input/playlist-manager.ts",
+      "issue": "4 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 6848,
+      "priority": "medium"
+    },
+    {
       "file": "foliage/musical_flora.ts",
       "issue": "5 unused exports",
       "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 6590,
+      "potentialSavings": 6745,
+      "priority": "medium"
+    },
+    {
+      "file": "foliage/environment.ts",
+      "issue": "4 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 6708,
+      "priority": "medium"
+    },
+    {
+      "file": "foliage/environment.ts",
+      "issue": "Low tree-shaking score (33%)",
+      "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
+      "potentialSavings": 6708,
+      "priority": "medium"
+    },
+    {
+      "file": "utils/wasm-orchestrator.ts",
+      "issue": "Low tree-shaking score (36%)",
+      "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
+      "potentialSavings": 6363,
       "priority": "medium"
     },
     {
@@ -16358,87 +26465,136 @@
       "priority": "medium"
     },
     {
-      "file": "foliage/environment.ts",
-      "issue": "4 unused exports",
+      "file": "foliage/post-processing.ts",
+      "issue": "5 unused exports",
       "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 5780,
+      "potentialSavings": 5905,
       "priority": "medium"
     },
     {
-      "file": "foliage/environment.ts",
-      "issue": "Low tree-shaking score (33%)",
+      "file": "foliage/post-processing.ts",
+      "issue": "Low tree-shaking score (17%)",
       "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
-      "potentialSavings": 5780,
+      "potentialSavings": 5905,
       "priority": "medium"
     },
     {
-      "file": "foliage/mushrooms.ts",
-      "issue": "4 unused exports",
-      "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 5364,
-      "priority": "medium"
-    },
-    {
-      "file": "foliage/mushrooms.ts",
-      "issue": "Low tree-shaking score (33%)",
-      "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
-      "potentialSavings": 5364,
-      "priority": "medium"
-    },
-    {
-      "file": "particles/particle_config.ts",
-      "issue": "Low tree-shaking score (8%)",
-      "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
-      "potentialSavings": 5304,
-      "priority": "medium"
-    },
-    {
-      "file": "systems/discovery.ts",
+      "file": "compute/gpu-compute-shaders.ts",
       "issue": "3 unused exports",
       "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 4497,
+      "potentialSavings": 5865,
       "priority": "medium"
     },
     {
-      "file": "core/cycle.ts",
+      "file": "foliage/mushrooms.ts",
       "issue": "4 unused exports",
       "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 4448,
+      "potentialSavings": 5616,
       "priority": "medium"
     },
     {
-      "file": "core/cycle.ts",
+      "file": "foliage/mushrooms.ts",
       "issue": "Low tree-shaking score (33%)",
       "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
-      "potentialSavings": 4448,
+      "potentialSavings": 5616,
       "priority": "medium"
     },
     {
       "file": "foliage/moon.ts",
       "issue": "3 unused exports",
       "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 4416,
+      "potentialSavings": 5448,
+      "priority": "medium"
+    },
+    {
+      "file": "systems/discovery.ts",
+      "issue": "3 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 5442,
+      "priority": "medium"
+    },
+    {
+      "file": "ui/save-menu/save-settings.ts",
+      "issue": "4 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 5280,
+      "priority": "medium"
+    },
+    {
+      "file": "utils/wasm-batch-particles.ts",
+      "issue": "3 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 5097,
+      "priority": "medium"
+    },
+    {
+      "file": "systems/loading-manager.ts",
+      "issue": "4 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 4940,
+      "priority": "medium"
+    },
+    {
+      "file": "systems/loading-manager.ts",
+      "issue": "Low tree-shaking score (43%)",
+      "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
+      "potentialSavings": 4940,
+      "priority": "medium"
+    },
+    {
+      "file": "particles/particle_config.ts",
+      "issue": "Low tree-shaking score (15%)",
+      "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
+      "potentialSavings": 4862,
       "priority": "medium"
     },
     {
       "file": "systems/unlocks.ts",
       "issue": "3 unused exports",
       "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 4086,
+      "potentialSavings": 4824,
       "priority": "medium"
     },
     {
-      "file": "rendering/material_types.ts",
-      "issue": "Low tree-shaking score (8%)",
+      "file": "foliage/animation-nodes.ts",
+      "issue": "Low tree-shaking score (15%)",
       "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
-      "potentialSavings": 3619,
+      "potentialSavings": 4796,
+      "priority": "medium"
+    },
+    {
+      "file": "core/hud.ts",
+      "issue": "5 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 4625,
+      "priority": "medium"
+    },
+    {
+      "file": "core/cycle.ts",
+      "issue": "4 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 4240,
+      "priority": "medium"
+    },
+    {
+      "file": "core/cycle.ts",
+      "issue": "Low tree-shaking score (43%)",
+      "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
+      "potentialSavings": 4240,
+      "priority": "medium"
+    },
+    {
+      "file": "utils/wasm-batch-core.ts",
+      "issue": "4 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 3848,
       "priority": "medium"
     },
     {
       "file": "systems/physics.core.ts",
       "issue": "5 unused exports",
       "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 3445,
+      "potentialSavings": 3745,
       "priority": "medium"
     },
     {
@@ -16449,17 +26605,31 @@
       "priority": "medium"
     },
     {
-      "file": "foliage/post-processing.ts",
-      "issue": "3 unused exports",
-      "suggestion": "Remove unused exports or split into smaller modules",
-      "potentialSavings": 2238,
+      "file": "systems/analytics/index.ts",
+      "issue": "Low tree-shaking score (31%)",
+      "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
+      "potentialSavings": 3303,
       "priority": "medium"
     },
     {
-      "file": "foliage/index.ts",
-      "issue": "Low tree-shaking score (4%)",
+      "file": "rendering/material_types.ts",
+      "issue": "Low tree-shaking score (17%)",
       "suggestion": "Review export structure. Consider using explicit exports instead of wildcards.",
-      "potentialSavings": 2064,
+      "potentialSavings": 3290,
+      "priority": "medium"
+    },
+    {
+      "file": "core/input/audio-controls.ts",
+      "issue": "3 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 2820,
+      "priority": "medium"
+    },
+    {
+      "file": "rendering/culling/culling-types.ts",
+      "issue": "5 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 2680,
       "priority": "medium"
     },
     {
@@ -16477,28 +26647,40 @@
       "priority": "medium"
     },
     {
+      "file": "core/deferred-init.ts",
+      "issue": "3 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 1887,
+      "priority": "medium"
+    },
+    {
       "file": "utils/shared-buffer-example.ts",
       "issue": "4 unused exports",
       "suggestion": "Remove unused exports or split into smaller modules",
       "potentialSavings": 936,
       "priority": "medium"
+    },
+    {
+      "file": "foliage/index.ts",
+      "issue": "5 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 930,
+      "priority": "medium"
+    },
+    {
+      "file": "systems/save-system/save-types.ts",
+      "issue": "4 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 704,
+      "priority": "medium"
+    },
+    {
+      "file": "main.ts",
+      "issue": "3 unused exports",
+      "suggestion": "Remove unused exports or split into smaller modules",
+      "potentialSavings": 249,
+      "priority": "medium"
     }
   ],
-  "commonTsAudit": {
-    "totalExports": 51,
-    "unusedExports": 12,
-    "unusedFunctions": [
-      "generateNoiseTexture",
-      "getCachedProceduralMaterial",
-      "createTexturedClay",
-      "createSugaredMaterial"
-    ],
-    "sideEffects": true,
-    "recommendations": [
-      "Consider splitting common.ts into smaller modules. 12 unused exports detected.",
-      "common.ts may have side effects. Add \"sideEffects\": false to package.json for better tree-shaking.",
-      "Remove unused functions: generateNoiseTexture, getCachedProceduralMaterial, createTexturedClay, createSugaredMaterial",
-      "Using Three.js imports. Ensure you're importing only needed modules for better tree-shaking."
-    ]
-  }
+  "commonTsAudit": null
 }

--- a/tools/build-optimizer/stats/tree-shaking-report.md
+++ b/tools/build-optimizer/stats/tree-shaking-report.md
@@ -1,56 +1,34 @@
 # 🌳 Tree Shaking Audit Report
 
-**Overall Tree-Shaking Score: 37%**
+**Overall Tree-Shaking Score: 52%**
 
 | Metric | Value |
 |--------|-------|
-| Total Files | 131 |
-| Total Exports | 912 |
-| Unused Exports | 576 (63.2%) |
-| Potential Savings | 919.76 KB |
-
-## 📋 common.ts Analysis
-
-| Metric | Value |
-|--------|-------|
-| Total Exports | 51 |
-| Unused Exports | 12 |
-| Side Effects | ⚠️ Yes |
-
-### Unused Functions in common.ts
-
-- `generateNoiseTexture`
-- `getCachedProceduralMaterial`
-- `createTexturedClay`
-- `createSugaredMaterial`
-
-### Recommendations
-
-- Consider splitting common.ts into smaller modules. 12 unused exports detected.
-- common.ts may have side effects. Add "sideEffects": false to package.json for better tree-shaking.
-- Remove unused functions: generateNoiseTexture, getCachedProceduralMaterial, createTexturedClay, createSugaredMaterial
-- Using Three.js imports. Ensure you're importing only needed modules for better tree-shaking.
+| Total Files | 226 |
+| Total Exports | 1559 |
+| Unused Exports | 747 (47.9%) |
+| Potential Savings | 1.05 MB |
 
 ## 📁 Files with Unused Exports
 
-### foliage/index.ts
+### utils/wasm-loader-core.ts
 
-- **Tree-Shaking Score:** 4%
-- **Unused Exports:** 48/50
+- **Tree-Shaking Score:** 58%
+- **Unused Exports:** 39/93
 
 | Export | Type | Line |
 |--------|------|------|
-| `./common.ts` | const | 3 |
-| `./berries.ts` | const | 4 |
-| `./grass.ts` | const | 5 |
-| `./mushrooms.ts` | const | 6 |
-| `./flowers.ts` | const | 7 |
-| `./trees.ts` | const | 8 |
-| `./clouds.ts` | const | 9 |
-| `./waterfalls.ts` | const | 10 |
-| `./cave.ts` | const | 11 |
-| `./environment.ts` | const | 12 |
-| ... and 38 more | | |
+| `sharedF32` | let | 43 |
+| `wasmUpdateFoliageBatch` | let | 50 |
+| `wasmDampVelocity` | let | 67 |
+| `wasmBatchDistanceCalc` | let | 68 |
+| `wasmBatchFrustumTest` | let | 69 |
+| `wasmBatchLODSelect` | let | 70 |
+| `cppBatchShiverSimd` | let | 107 |
+| `cppBatchSpringSimd` | let | 108 |
+| `cppBatchFloatSimd` | let | 109 |
+| `cppBatchCloudBobSimd` | let | 110 |
+| ... and 29 more | | |
 
 ### workers/worker-types.ts
 
@@ -78,10 +56,10 @@
 
 | Export | Type | Line |
 |--------|------|------|
-| `SpawnCandidate` | type | 3 |
 | `AnimationType` | const | 5 |
 | `lerp` | function | 18 |
 | `lerpColor` | function | 19 |
+| `uploadAnimationData` | function | 27 |
 | `batchDistanceCull` | function | 31 |
 | `calcBounceY` | function | 43 |
 | `calcSwayRotZ` | function | 44 |
@@ -90,43 +68,43 @@
 | `calcAccordionStretch` | function | 50 |
 | ... and 13 more | | |
 
-### particles/compute-particles.ts
+### systems/accessibility.ts
 
-- **Tree-Shaking Score:** 15%
-- **Unused Exports:** 22/26
-
-| Export | Type | Line |
-|--------|------|------|
-| `ComputeParticleType` | type | 52 |
-| `ComputeParticleConfig` | interface | 54 |
-| `ParticleBuffers` | interface | 71 |
-| `ParticleAudioData` | interface | 80 |
-| `FireflyConfig` | interface | 1379 |
-| `PollenConfig` | interface | 1384 |
-| `BerryConfig` | interface | 1389 |
-| `RainConfig` | interface | 1394 |
-| `SparkConfig` | interface | 1399 |
-| `createComputeBerries` | function | 1441 |
-| ... and 12 more | | |
-
-### systems/asset-streaming.ts
-
-- **Tree-Shaking Score:** 27%
-- **Unused Exports:** 22/30
+- **Tree-Shaking Score:** 13%
+- **Unused Exports:** 21/24
 
 | Export | Type | Line |
 |--------|------|------|
-| `AssetType` | enum | 37 |
-| `TextureFormat` | enum | 48 |
-| `LoadingState` | enum | 58 |
-| `MemoryPressure` | enum | 77 |
-| `AssetMetadata` | interface | 86 |
-| `AssetManifest` | interface | 103 |
-| `LoadedAsset` | interface | 112 |
-| `LoadingProgress` | interface | 126 |
-| `NetworkStats` | interface | 137 |
-| `StreamingConfig` | interface | 147 |
-| ... and 12 more | | |
+| `ColorBlindType` | type | 19 |
+| `UIScale` | type | 20 |
+| `VerbosityLevel` | type | 21 |
+| `CrosshairStyle` | type | 22 |
+| `Keybinding` | interface | 24 |
+| `InputSettings` | interface | 32 |
+| `VisualSettings` | interface | 43 |
+| `CognitiveSettings` | interface | 59 |
+| `AuditorySettings` | interface | 70 |
+| `ScreenReaderSettings` | interface | 83 |
+| ... and 11 more | | |
+
+### utils/wasm-animations.ts
+
+- **Tree-Shaking Score:** 5%
+- **Unused Exports:** 21/22
+
+| Export | Type | Line |
+|--------|------|------|
+| `WobbleResult` | interface | 27 |
+| `AccordionResult` | interface | 35 |
+| `FiberResult` | interface | 43 |
+| `ShiverResult` | interface | 51 |
+| `SpiralResult` | interface | 59 |
+| `PrismResult` | interface | 68 |
+| `ArpeggioResult` | interface | 78 |
+| `ParticleResult` | interface | 86 |
+| `calcBounceY` | function | 118 |
+| `calcSwayRotZ` | function | 139 |
+| ... and 11 more | | |
 
 ### ui/announcer.ts
 
@@ -147,29 +125,10 @@
 | `announcePolite` | function | 543 |
 | ... and 10 more | | |
 
-### systems/analytics.ts
-
-- **Tree-Shaking Score:** 18%
-- **Unused Exports:** 18/22
-
-| Export | Type | Line |
-|--------|------|------|
-| `AnalyticsConfig` | interface | 38 |
-| `EventType` | type | 62 |
-| `AnalyticsEvent` | interface | 77 |
-| `SessionData` | interface | 91 |
-| `FPSHistogram` | interface | 121 |
-| `FrameTimePercentiles` | interface | 133 |
-| `LoadingPhaseTiming` | interface | 143 |
-| `MemorySnapshot` | interface | 153 |
-| `GPUTiming` | interface | 165 |
-| `PerformanceMetrics` | interface | 175 |
-| ... and 8 more | | |
-
 ### foliage/trees.ts
 
-- **Tree-Shaking Score:** 29%
-- **Unused Exports:** 17/24
+- **Tree-Shaking Score:** 31%
+- **Unused Exports:** 18/26
 
 | Export | Type | Line |
 |--------|------|------|
@@ -183,88 +142,69 @@
 | `AccordionPalmOptions` | interface | 40 |
 | `FiberOpticWillowOptions` | interface | 44 |
 | `SwingableVineOptions` | interface | 48 |
-| ... and 7 more | | |
+| ... and 8 more | | |
 
-### rendering/culling-system.ts
+### utils/wasm-physics.ts
 
-- **Tree-Shaking Score:** 6%
-- **Unused Exports:** 17/18
-
-| Export | Type | Line |
-|--------|------|------|
-| `CullingGroup` | enum | 25 |
-| `EntityType` | enum | 35 |
-| `LODLevel` | enum | 49 |
-| `QualityTier` | enum | 57 |
-| `CullableObject` | interface | 65 |
-| `CullingConfig` | interface | 83 |
-| `CullingStats` | interface | 109 |
-| `DEFAULT_CULL_DISTANCES` | const | 135 |
-| `LOD_THRESHOLDS` | const | 149 |
-| `QUALITY_MULTIPLIERS` | const | 157 |
-| ... and 7 more | | |
-
-### systems/accessibility.ts
-
-- **Tree-Shaking Score:** 33%
-- **Unused Exports:** 16/24
+- **Tree-Shaking Score:** 45%
+- **Unused Exports:** 18/33
 
 | Export | Type | Line |
 |--------|------|------|
-| `Keybinding` | interface | 24 |
-| `InputSettings` | interface | 32 |
-| `VisualSettings` | interface | 43 |
-| `CognitiveSettings` | interface | 59 |
-| `AuditorySettings` | interface | 70 |
-| `ScreenReaderSettings` | interface | 83 |
-| `AccessibilitySettings` | interface | 91 |
-| `AccessibilityPreset` | interface | 99 |
-| `defaultSettings` | const | 127 |
-| `colorBlindMatrices` | const | 189 |
+| `PlayerStateResult` | interface | 56 |
+| `initObstacleUploadBridge` | function | 79 |
+| `checkCollision` | function | 377 |
+| `valueNoise2D` | function | 488 |
+| `fbm` | function | 502 |
+| `fastInvSqrt` | function | 519 |
+| `fastDistance` | function | 535 |
+| `hash` | function | 548 |
+| `getGroundHeightBatch` | function | 571 |
+| `batchGroundHeight` | function | 637 |
+| ... and 8 more | | |
+
+### utils/wasm-batch-animation.ts
+
+- **Tree-Shaking Score:** 27%
+- **Unused Exports:** 16/22
+
+| Export | Type | Line |
+|--------|------|------|
+| `batchShiver_c` | function | 58 |
+| `batchSpring_c` | function | 71 |
+| `batchFloat_c` | function | 84 |
+| `batchCloudBob_c` | function | 97 |
+| `deformWave_c` | function | 114 |
+| `deformJiggle_c` | function | 127 |
+| `deformWobble_c` | function | 140 |
+| `batchUpdateLODMatrices_c` | function | 162 |
+| `batchScaleMatrices_c` | function | 186 |
+| `batchFadeColors_c` | function | 197 |
 | ... and 6 more | | |
 
 ### particles/compute-integration.ts
 
-- **Tree-Shaking Score:** 0%
-- **Unused Exports:** 15/15
+- **Tree-Shaking Score:** 29%
+- **Unused Exports:** 15/21
 
 | Export | Type | Line |
 |--------|------|------|
 | `getParticleMetrics` | function | 28 |
 | `getAllParticleMetrics` | function | 32 |
 | `IntegratedFireflyOptions` | interface | 40 |
-| `createIntegratedFireflies` | function | 50 |
-| `IntegratedPollenOptions` | interface | 102 |
-| `createIntegratedPollen` | function | 113 |
-| `registerIntegratedSystem` | function | 175 |
-| `updateAllIntegratedSystems` | function | 201 |
-| `disposeIntegratedSystem` | function | 212 |
-| `disposeAllIntegratedSystems` | function | 223 |
+| `IntegratedPollenOptions` | interface | 103 |
+| `IntegratedSparksOptions` | interface | 164 |
+| `IntegratedBerriesOptions` | interface | 171 |
+| `IntegratedRainOptions` | interface | 178 |
+| `createIntegratedBerries` | function | 247 |
+| `disposeIntegratedSystem` | function | 393 |
+| `disposeAllIntegratedSystems` | function | 404 |
 | ... and 5 more | | |
-
-### ui/loading-screen.ts
-
-- **Tree-Shaking Score:** 7%
-- **Unused Exports:** 14/15
-
-| Export | Type | Line |
-|--------|------|------|
-| `LoadingPhase` | interface | 20 |
-| `LoadingProgress` | interface | 30 |
-| `LoadingScreenOptions` | interface | 40 |
-| `DEFAULT_LOADING_PHASES` | const | 52 |
-| `LoadingScreen` | class | 116 |
-| `initLoadingScreen` | function | 701 |
-| `getLoadingScreen` | function | 715 |
-| `showLoadingScreen` | function | 722 |
-| `hideLoadingScreen` | function | 732 |
-| `updateProgress` | function | 739 |
-| ... and 4 more | | |
 
 ### systems/region-manager.ts
 
-- **Tree-Shaking Score:** 24%
-- **Unused Exports:** 13/17
+- **Tree-Shaking Score:** 22%
+- **Unused Exports:** 14/18
 
 | Export | Type | Line |
 |--------|------|------|
@@ -276,9 +216,9 @@
 | `SpatialQueryResult` | interface | 96 |
 | `DEFAULT_REGION_CONFIG` | const | 106 |
 | `getCellKey` | function | 121 |
-| `parseCellKey` | function | 126 |
-| `worldToCell` | function | 132 |
-| ... and 3 more | | |
+| `parseCellKey` | function | 132 |
+| `worldToCell` | function | 140 |
+| ... and 4 more | | |
 
 ### systems/weather.core.ts
 
@@ -299,44 +239,6 @@
 | `calculateFogDensity` | function | 196 |
 | ... and 3 more | | |
 
-### foliage/common.ts
-
-- **Tree-Shaking Score:** 76%
-- **Unused Exports:** 12/51
-
-| Export | Type | Line |
-|--------|------|------|
-| `eyeGeo` | const | 50 |
-| `pupilGeo` | const | 51 |
-| `_scratchVec1` | const | 54 |
-| `_scratchVec2` | const | 55 |
-| `_scratchVec3` | const | 56 |
-| `reactiveObjects` | const | 59 |
-| `generateNoiseTexture` | function | 85 |
-| `getCachedProceduralMaterial` | function | 104 |
-| `addRimLight` | const | 238 |
-| `calculateWindSwayLegacy` | const | 362 |
-| ... and 2 more | | |
-
-### particles/particle_config.ts
-
-- **Tree-Shaking Score:** 8%
-- **Unused Exports:** 12/13
-
-| Export | Type | Line |
-|--------|------|------|
-| `ParticleSystemTypeValue` | type | 20 |
-| `ParticleBounds` | interface | 25 |
-| `ShimmerParticleConfig` | interface | 34 |
-| `BubbleStreamConfig` | interface | 52 |
-| `PollenCloudConfig` | interface | 68 |
-| `LeafConfettiConfig` | interface | 84 |
-| `PulseRingConfig` | interface | 100 |
-| `ComputeParticleConfig` | interface | 114 |
-| `ParticleAudioState` | interface | 130 |
-| `IParticleSystem` | interface | 160 |
-| ... and 2 more | | |
-
 ### systems/discovery-persistence.ts
 
 - **Tree-Shaking Score:** 8%
@@ -349,30 +251,87 @@
 | `ImportResult` | interface | 62 |
 | `DiscoveryStats` | interface | 72 |
 | `DiscoveryPersistence` | class | 95 |
-| `exportDiscoveries` | function | 662 |
-| `importDiscoveries` | function | 671 |
-| `clearLocalDiscoveries` | function | 678 |
-| `getDiscoveryStats` | function | 685 |
-| `isPersistenceAvailable` | function | 692 |
+| `exportDiscoveries` | function | 676 |
+| `importDiscoveries` | function | 685 |
+| `clearLocalDiscoveries` | function | 692 |
+| `getDiscoveryStats` | function | 699 |
+| `isPersistenceAvailable` | function | 706 |
 | ... and 2 more | | |
 
-### rendering/material_types.ts
+### utils/wasm-batch-math.ts
 
-- **Tree-Shaking Score:** 8%
-- **Unused Exports:** 11/12
+- **Tree-Shaking Score:** 0%
+- **Unused Exports:** 12/12
 
 | Export | Type | Line |
 |--------|------|------|
-| `MaterialTypeValue` | type | 24 |
-| `CandyMaterialConfig` | interface | 29 |
-| `GlowingMaterialConfig` | interface | 47 |
-| `PetalMaterialConfig` | interface | 59 |
-| `AudioReactiveMaterialConfig` | interface | 69 |
-| `GroundMaterialConfig` | interface | 81 |
-| `AudioState` | interface | 89 |
-| `IAudioReactiveMaterial` | interface | 103 |
-| `CandyMaterial` | interface | 111 |
-| `AudioUniforms` | interface | 131 |
+| `batchHslToRgb` | function | 80 |
+| `batchSphereCull` | function | 132 |
+| `batchLerp` | function | 167 |
+| `batchValueNoiseSimd4` | function | 195 |
+| `batchFbmSimd4` | function | 234 |
+| `batchGroundHeightSimd` | function | 271 |
+| `batchValueNoiseOmp` | function | 313 |
+| `batchFbmOmp` | function | 352 |
+| `batchDistSq3DOmp` | function | 394 |
+| `fastSin` | function | 448 |
+| ... and 2 more | | |
+
+### compute/gpu-foliage-animator.ts
+
+- **Tree-Shaking Score:** 0%
+- **Unused Exports:** 11/11
+
+| Export | Type | Line |
+|--------|------|------|
+| `FoliageInstanceData` | interface | 29 |
+| `FoliageAudioState` | interface | 47 |
+| `AnimationType` | enum | 62 |
+| `FoliageAnimationOutput` | interface | 81 |
+| `FOLIAGE_ANIMATION_WGSL` | const | 117 |
+| `GPUFoliageAnimator` | class | 361 |
+| `updateInstancedMeshFromAnimator` | function | 687 |
+| `createGPUFoliageAnimator` | function | 740 |
+| `createFoliageInstanceData` | function | 758 |
+| `FoliageAnimatorCapabilities` | interface | 794 |
+| ... and 1 more | | |
+
+### foliage/animation-nodes.ts
+
+- **Tree-Shaking Score:** 15%
+- **Unused Exports:** 11/13
+
+| Export | Type | Line |
+|--------|------|------|
+| `gentleSwayNode` | const | 26 |
+| `bounceNode` | const | 34 |
+| `shiverNode` | const | 41 |
+| `springNode` | const | 49 |
+| `vineSwayNode` | const | 57 |
+| `hopNode` | const | 65 |
+| `wobbleNode` | const | 72 |
+| `accordionNode` | const | 79 |
+| `spiralWaveNode` | const | 86 |
+| `fiberWhipNode` | const | 94 |
+| ... and 1 more | | |
+
+### particles/particle_config.ts
+
+- **Tree-Shaking Score:** 15%
+- **Unused Exports:** 11/13
+
+| Export | Type | Line |
+|--------|------|------|
+| `ParticleSystemTypeValue` | type | 20 |
+| `ParticleBounds` | interface | 25 |
+| `ShimmerParticleConfig` | interface | 34 |
+| `BubbleStreamConfig` | interface | 52 |
+| `PollenCloudConfig` | interface | 68 |
+| `LeafConfettiConfig` | interface | 84 |
+| `PulseRingConfig` | interface | 100 |
+| `ParticleAudioState` | interface | 130 |
+| `IParticleSystem` | interface | 160 |
+| `ParticleSystemFactory` | type | 183 |
 | ... and 1 more | | |
 
 ### rendering/materials.ts
@@ -413,111 +372,130 @@
 | `estimateVertexBufferUsage` | function | 290 |
 | ... and 1 more | | |
 
+### systems/analytics/types.ts
+
+- **Tree-Shaking Score:** 52%
+- **Unused Exports:** 11/23
+
+| Export | Type | Line |
+|--------|------|------|
+| `AnalyticsConfig` | interface | 14 |
+| `EventType` | type | 38 |
+| `AnalyticsEvent` | interface | 53 |
+| `SessionData` | interface | 67 |
+| `FPSHistogram` | interface | 97 |
+| `FrameTimePercentiles` | interface | 109 |
+| `LoadingPhaseTiming` | interface | 119 |
+| `MemorySnapshot` | interface | 129 |
+| `GPUTiming` | interface | 141 |
+| `AnalyticsExport` | interface | 165 |
+| ... and 1 more | | |
+
 ## 💡 Recommendations
 
 ### 🔴 High Priority
 
-**particles/compute-particles.ts**
-- Issue: 22 unused exports
+**compute/gpu-foliage-animator.ts**
+- Issue: 11 unused exports
 - Suggestion: Remove unused exports or split into smaller modules
-- Potential Savings: 45.5 KB
+- Potential Savings: 27.6 KB
 
-**systems/asset-streaming.ts**
-- Issue: 22 unused exports
+**systems/accessibility.ts**
+- Issue: 21 unused exports
 - Suggestion: Remove unused exports or split into smaller modules
-- Potential Savings: 38.65 KB
-
-**rendering/culling-system.ts**
-- Issue: 17 unused exports
-- Suggestion: Remove unused exports or split into smaller modules
-- Potential Savings: 36.71 KB
-
-**systems/analytics.ts**
-- Issue: 18 unused exports
-- Suggestion: Remove unused exports or split into smaller modules
-- Potential Savings: 31.62 KB
-
-**systems/performance-budget.ts**
-- Issue: 10 unused exports
-- Suggestion: Remove unused exports or split into smaller modules
-- Potential Savings: 30.63 KB
-
-**ui/loading-screen.ts**
-- Issue: 14 unused exports
-- Suggestion: Remove unused exports or split into smaller modules
-- Potential Savings: 24.27 KB
-
-**foliage/lod.ts**
-- Issue: 8 unused exports
-- Suggestion: Remove unused exports or split into smaller modules
-- Potential Savings: 23.71 KB
+- Potential Savings: 26.17 KB
 
 **systems/region-manager.ts**
-- Issue: 13 unused exports
+- Issue: 14 unused exports
 - Suggestion: Remove unused exports or split into smaller modules
-- Potential Savings: 22.81 KB
+- Potential Savings: 25.21 KB
 
 **particles/gpu_particles.ts**
 - Issue: 7 unused exports
 - Suggestion: Remove unused exports or split into smaller modules
-- Potential Savings: 20.47 KB
+- Potential Savings: 22.83 KB
+
+**compute/gpu-culling-system.ts**
+- Issue: 8 unused exports
+- Suggestion: Remove unused exports or split into smaller modules
+- Potential Savings: 22.05 KB
+
+**ui/save-menu/save-menu.ts**
+- Issue: 8 unused exports
+- Suggestion: Remove unused exports or split into smaller modules
+- Potential Savings: 21.71 KB
+
+**foliage/lod.ts**
+- Issue: 7 unused exports
+- Suggestion: Remove unused exports or split into smaller modules
+- Potential Savings: 21.61 KB
+
+**compute/gpu-particle-system.ts**
+- Issue: 7 unused exports
+- Suggestion: Remove unused exports or split into smaller modules
+- Potential Savings: 21.19 KB
 
 **systems/discovery-persistence.ts**
 - Issue: 12 unused exports
 - Suggestion: Remove unused exports or split into smaller modules
-- Potential Savings: 20.11 KB
+- Potential Savings: 20.41 KB
+
+**ui/loading-screen.ts**
+- Issue: 9 unused exports
+- Suggestion: Remove unused exports or split into smaller modules
+- Potential Savings: 20.04 KB
 
 ### 🟡 Medium Priority
 
-**particles/compute-particles.ts**
-- Issue: Low tree-shaking score (15%)
+**compute/gpu-foliage-animator.ts**
+- Issue: Low tree-shaking score (0%)
 - Suggestion: Review export structure. Consider using explicit exports instead of wildcards.
-- Potential Savings: 45.5 KB
+- Potential Savings: 27.6 KB
 
-**ui/accessibility-menu.ts**
+**systems/accessibility.ts**
+- Issue: Low tree-shaking score (13%)
+- Suggestion: Review export structure. Consider using explicit exports instead of wildcards.
+- Potential Savings: 26.17 KB
+
+**systems/region-manager.ts**
+- Issue: Low tree-shaking score (22%)
+- Suggestion: Review export structure. Consider using explicit exports instead of wildcards.
+- Potential Savings: 25.21 KB
+
+**ui/analytics-debug.ts**
 - Issue: 5 unused exports
 - Suggestion: Remove unused exports or split into smaller modules
-- Potential Savings: 40.06 KB
+- Potential Savings: 24.43 KB
 
-**systems/asset-streaming.ts**
-- Issue: Low tree-shaking score (27%)
+**ui/analytics-debug.ts**
+- Issue: Low tree-shaking score (17%)
 - Suggestion: Review export structure. Consider using explicit exports instead of wildcards.
-- Potential Savings: 38.65 KB
+- Potential Savings: 24.43 KB
 
-**rendering/culling-system.ts**
-- Issue: Low tree-shaking score (6%)
+**particles/gpu_particles.ts**
+- Issue: Low tree-shaking score (0%)
 - Suggestion: Review export structure. Consider using explicit exports instead of wildcards.
-- Potential Savings: 36.71 KB
+- Potential Savings: 22.83 KB
 
-**systems/analytics.ts**
-- Issue: Low tree-shaking score (18%)
-- Suggestion: Review export structure. Consider using explicit exports instead of wildcards.
-- Potential Savings: 31.62 KB
-
-**systems/performance-budget.ts**
-- Issue: Low tree-shaking score (23%)
-- Suggestion: Review export structure. Consider using explicit exports instead of wildcards.
-- Potential Savings: 30.63 KB
-
-**ui/save-menu.ts**
-- Issue: 5 unused exports
-- Suggestion: Remove unused exports or split into smaller modules
-- Potential Savings: 29.91 KB
-
-**ui/save-menu.ts**
-- Issue: Low tree-shaking score (38%)
-- Suggestion: Review export structure. Consider using explicit exports instead of wildcards.
-- Potential Savings: 29.91 KB
-
-**ui/loading-screen.ts**
-- Issue: Low tree-shaking score (7%)
-- Suggestion: Review export structure. Consider using explicit exports instead of wildcards.
-- Potential Savings: 24.27 KB
-
-**foliage/lod.ts**
+**compute/gpu-culling-system.ts**
 - Issue: Low tree-shaking score (11%)
 - Suggestion: Review export structure. Consider using explicit exports instead of wildcards.
-- Potential Savings: 23.71 KB
+- Potential Savings: 22.05 KB
+
+**ui/save-menu/save-menu.ts**
+- Issue: Low tree-shaking score (27%)
+- Suggestion: Review export structure. Consider using explicit exports instead of wildcards.
+- Potential Savings: 21.71 KB
+
+**foliage/lod.ts**
+- Issue: Low tree-shaking score (22%)
+- Suggestion: Review export structure. Consider using explicit exports instead of wildcards.
+- Potential Savings: 21.61 KB
+
+**compute/gpu-particle-system.ts**
+- Issue: Low tree-shaking score (22%)
+- Suggestion: Review export structure. Consider using explicit exports instead of wildcards.
+- Potential Savings: 21.19 KB
 
 ## 📚 Tree-Shaking Best Practices
 

--- a/weekly_plan.md
+++ b/weekly_plan.md
@@ -1,8 +1,8 @@
 # candy_world — Weekly Plan
 
 ## Today's focus
-**2026-05-12 — New Idea: Twilight Glow Completion & Expansion.**
-`uTwilight` is live in trees and mushrooms but missing from 5+ foliage types (flowers, dandelions, wisteria, lotus, lanterns). `CONFIG.glow.glowColorMap` has 2 entries; PLAN_PLANTS_TWILIGHT_GLOW specifies the full map. kimi-cli completes species coverage. Outcome goal: all major foliage batchers react to uTwilight, glowColorMap has entries for every species, glow is visually consistent across the world at dusk.
+**2026-05-19 — User Idea: Per-channel MOD note-color propagation from sky to foliage.**
+When a tracker note fires on the sky/moon channel, the note's hue (already in `BiomeUniforms.skyMoon.moonNoteColor`) cascades downward to nearby foliage emissive uniforms, creating a visible color wave from sky to ground synchronized to the beat. kimi-cli implements the wave state, beat trigger, and per-frame propagation update. Touches `music-reactivity.ts`, `foliage-reactivity.ts`, `biome-uniforms.ts`, `music-bindings.json`. Full day.
 
 ## Ideas
 <!--
@@ -12,15 +12,14 @@ Format: - [ ] Short description (optional: more context on next line indented)
 Routine will mark picked items as "[in progress — YYYY-MM-DD]".
 -->
 - [ ] **Three.js ColorSpace enum regression** — In `src/core/init.js` we fall back to string literals (`'display-p3'`, `'srgb'`) for `outputColorSpace` because `THREE.DisplayP3ColorSpace` / `THREE.SRGBColorSpace` produced TS/build warnings with the current `three` version. When updating Three.js, revert to the proper enum. Opportunistic — activate when upgrading Three.js version, not a standalone sprint.
-- [ ] **Per-channel MOD note-color propagation from sky to foliage** — Extend the music-bindings system so each biome's note-color hue (established by Moon Dance, PR #764) propagates downward to nearby foliage emissive uniforms, creating a visible color wave from sky to ground per beat. Touches `foliage-reactivity.ts`, `music-reactivity.ts`, `music-bindings.json`. Full day.
-- [x] **Portamento-batcher + wisteria-cluster audio reactivity wiring** — `portamento-batcher.ts` imports `uTwilight` but is not wired to music-reactivity or music-bindings.json. Same for `wisteria-cluster.ts`. Add ADSR-driven scale/emission and per-channel hue mapping, matching the pattern established in tree-batcher and mushroom-batcher. Full day.
+- [in progress — 2026-05-19] **Per-channel MOD note-color propagation from sky to foliage** — Extend the music-bindings system so each biome's note-color hue (established by Moon Dance, PR #764) propagates downward to nearby foliage emissive uniforms, creating a visible color wave from sky to ground per beat. Touches `foliage-reactivity.ts`, `music-reactivity.ts`, `music-bindings.json`. Full day.
 
 ## Backlog
 <!--
 Unfinished items, known bugs, deferred ideas.
 Routine maintains this automatically — you can add items too.
 -->
-- [ ] Plants Twilight Glow — Implement configurable twilight glowing for existing foliage types based on docs/archive/PLAN_PLANTS_TWILIGHT_GLOW.md.
+- [ ] **[bug] portamento-batcher uTwilight stub** — `src/foliage/portamento-batcher.ts` imports `uTwilight` from `sky.ts` (line 16) but never uses it in a shader node. `CONFIG.glow.glowColorMap['portamento']` is read (line 149) but `uTwilight` multiplier is missing from the emissive graph. Fix by adding `.mul(uTwilight)` to the glow color node, matching the pattern in `simple-flower-batcher.ts:161`.
 - [ ] Accessibility note: `Announcer` in `src/ui/announcer.ts` dynamically injects `aria-live` regions rather than relying on static HTML — future ARIA work should use the dynamic path, not add static tags.
 - [ ] **[ui bug — #702]** Auto-scroll on live site forces page to bottom on load, blocking top-row links. Separate: no links to external apps are clickable. Labeled "jules" on GitHub. Likely a `scroll-behavior` or `focus` side-effect from loading-screen dismissal.
 - [ ] Three.js ColorSpace enum — opportunistic, activate when upgrading Three.js version (not a standalone sprint).
@@ -30,6 +29,10 @@ Routine maintains this automatically — you can add items too.
 Completed items, routine archives here with date.
 Prune occasionally when this gets long.
 -->
+- [x] **2026-05-19** Twilight Glow Completion — `glowColorMap` expanded to 9 species (mushroom, tree, flower, dandelion, wisteria, lotus, lantern, portamento, global). `uTwilight` wired into all major foliage batchers. Portamento-batcher stub (import-only) flagged to backlog for follow-up.
+- [x] **2026-05-19** Startup error fixes — dev.sh emsdk guard, game-loop weather state bug, import corrections, flower-batcher/lantern-batcher fixes (PR #833).
+- [x] **2026-05-13** Portamento-batcher + wisteria-cluster audio reactivity wiring — `BiomeUniforms.arpeggioGrove.noteColor` and `BiomeUniforms.crystallineNebula.noteColor` multiplied into emissive nodes for tree-batcher, mushroom-batcher, portamento-batcher, wisteria-cluster (PR #825).
+- [x] **2026-05-19** Zero-allocation WASM boundary + audio reactivity (PR #830). Cloud-batcher `updateMatrixWorld` bypass (PR #829). UI: Save Menu focus trap, active toggle styling, upload tactile feedback (PRs #828, #824, #822, #831).
 - [x] **2026-05-13** Loading Architecture Fixes — Batched WASM heightmap calls, deferred world content via initWorldCritical/initWorldContent split, recalibrated progress bar, and fixed enterWorld race condition.
 - [x] **2026-05-12** Planning Debt — archive completed plan files — 34 root `.md` docs archived to `docs/archive/` (commits 4e375df, c1d93cb). Root down to 8 live docs.
 - [x] **2026-05-12** Moon Dance sky reactivity — note-colour-driven hue reactivity for sky and moon glow (PR #764).
@@ -50,7 +53,7 @@ Prune occasionally when this gets long.
 
 ## Last run
 <!-- Routine writes summary here each run. Overwrites previous. -->
-Date: 2026-05-12
-Mode: New Idea — Twilight Glow Completion & Expansion
-Focus: Wire `uTwilight` and `CONFIG.glow.glowColorMap` into all remaining foliage batchers (flowers, dandelions, wisteria, lotus, lanterns). Trees and mushrooms already done; 5+ types still missing species-specific glow. kimi-cli runs per-type sweep. Two new Ideas appended (note-color propagation, portamento/wisteria music wiring).
+Date: 2026-05-19
+Mode: User Idea — Per-channel MOD note-color propagation from sky to foliage
+Focus: Beat-driven color wave from `BiomeUniforms.skyMoon.moonNoteColor` down to per-species foliage emissive uniforms. Introduces wave state (timestamp + color at beat), per-frame propagation lerp, and `music-bindings.json` config for which biomes receive the cascade. Portamento-batcher uTwilight stub moved to backlog. Twilight Glow marked Done.
 Outcome: TBD


### PR DESCRIPTION
Weekly planning routine output for 2026-05-19.

## Changes
- Moved Twilight Glow Completion to Done (substantially complete via PRs across the week)
- Flagged portamento-batcher `uTwilight` import-only stub to Backlog
- Marked PR #833 startup fixes as Done
- Set today's focus: per-channel MOD note-color wave propagation from sky to foliage
- Marked per-channel propagation idea as `[in progress — 2026-05-19]`

https://claude.ai/code/session_01AMvTK5hmMu6dxwp7e4skoy

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMvTK5hmMu6dxwp7e4skoy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compression benchmark reporting with algorithm comparisons and estimated load-time analysis.
  * Added server configuration examples for Nginx, Apache, Netlify, and Vercel.

* **Documentation**
  * Updated bundle analysis metrics and visualization.
  * Refreshed tree-shaking analysis report with improved metrics.

* **Chores**
  * Updated internal planning documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/candy_world/pull/834?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->