### PR TITLE
⚡ Bolt: [Portamento Batcher Attribute Optimization]

### DIFF
--- a/src/foliage/portamento-batcher.ts
+++ b/src/foliage/portamento-batcher.ts
@@ -272,7 +272,8 @@ export class PortamentoPineBatcher {
         // If significant change, update attribute
         const last = pine.userData._lastUploadedBend || 0;
         if (Math.abs(state.currentBend - last) > 0.001) {
-             this.bendAttribute!.setX(i, state.currentBend);
+             // ⚡ OPTIMIZATION: Bypassed THREE.BufferAttribute.setX overhead by writing directly to typed array
+             this.bendAttribute!.array[i] = state.currentBend;
              pine.userData._lastUploadedBend = state.currentBend;
              needsUpdate = true;
         }


### PR DESCRIPTION
Bottleneck: "Was using THREE.BufferAttribute.setX in a hot loop, causing function call overhead and proxy access per instance on every frame."
Fix: "Bypassed setX() to write directly to the underlying Float32Array (`this.bendAttribute!.array[i] = state.currentBend;`)."
Impact: "Eliminated function overhead for per-instance ADSR updates, preventing GC spikes and lowering CPU cost during music reactivity updates."

---
*PR created automatically by Jules for task [4108160250208582647](https://jules.google.com/task/4108160250208582647) started by @ford442*