### PR TITLE
fix(foliage): stop foliage from sampling wind StorageTexture (WGSL crash)

### DIFF
--- a/src/foliage/material-core.ts
+++ b/src/foliage/material-core.ts
@@ -284,42 +284,23 @@ export const applyPlayerInteraction = (basePosNode: any) => {
  * Samples wind vector from texture based on world position + time
  */
 export const calculateWindSway = Fn(([posNode]) => {
-    // Get wind texture data for TSL sampling inside the function to avoid execution order issues
-    const windTextureData = getWindTextureData();
+    // NOTE: Texture-sampled wind is disabled. Three.js TSL's WGSLNodeBuilder
+    // generates `textureLoad(tex, vec2u)` (no mip-level arg) for any
+    // texture flagged isStorageTexture === true, even when read as a
+    // sampled texture_2d<f32>. This produces an invalid WGSL vertex shader
+    // and crashes every foliage material on load. Until three.js is fixed,
+    // fall back to a procedural sway equivalent to calculateWindSwayLegacy.
+    const windTime = uTime.mul(uWindSpeed.add(0.5));
+    const swayPhase = positionWorld.x.mul(0.5).add(positionWorld.z.mul(0.5)).add(windTime);
+    const swayAmount = sin(swayPhase).mul(0.1).mul(uWindSpeed.add(0.2));
 
-    // Create UV coordinates from world position with tiling
-    // Scale matches the world-space tiling of the wind texture
-    const worldScale = float(0.1); // Matches getWindTextureData().sampleScale
-    const timeOffset = uTime.mul(0.1); // Animated wind flow
-    
-    // UV coordinates: world XZ mapped to texture with animation
-    const windUV = vec2(
-        positionWorld.x.mul(worldScale).add(timeOffset),
-        positionWorld.z.mul(worldScale).add(timeOffset.mul(0.5)) // Different speed for Y axis
-    );
-    
-    // Sample wind vector from baked texture (RG channels = XZ wind)
-    const windSample = texture(windTextureData.texture, windUV);
-    const windX = windSample.r;
-    const windZ = windSample.g;
-    const gustIntensity = windSample.b; // Gust intensity for variation
-    
-    // Height factor: more sway at the top (cantilever effect)
     const heightFactor = posNode.y.max(0.0);
-    const heightBend = heightFactor.pow(2.0); // Squared for natural bend curve
-    
-    // Apply global wind speed uniform for dynamic control
-    const speedMultiplier = uWindSpeed.add(0.2).mul(0.1);
-    
-    // Apply gust intensity for dynamic variation
-    const gustMultiplier = float(1.0).add(gustIntensity.mul(0.5));
-    
-    // Calculate final bend offset
-    // Uses direction uniform for global wind direction control
+    const heightBend = heightFactor.pow(2.0);
+
     const windBend = vec3(
-        windX.mul(uWindDirection.x).mul(heightBend).mul(speedMultiplier).mul(gustMultiplier),
+        uWindDirection.x.mul(swayAmount).mul(heightBend),
         float(0.0),
-        windZ.mul(uWindDirection.z).mul(heightBend).mul(speedMultiplier).mul(gustMultiplier)
+        uWindDirection.z.mul(swayAmount).mul(heightBend)
     );
 
     return windBend;


### PR DESCRIPTION
## Summary

Probed the live build at https://test.1ink.us/candy-world/index.html in a headless Chromium with WebGPU. World generation now runs to completion (the prior "always-skipped stages" fix is working), but every foliage vertex shader was failing with `Invalid ShaderModule "vertex"` from a WGSL parse error, and eventually the WebGPU device was destroyed:

```
no matching call to 'textureLoad(texture_2d<f32>, vec2<u32>)'
  textureLoad( nodeUniform5, vec2u( tsl_coord_repeatS_repeatT( vec2<f32>(
    ( ( varyings.v_positionWorld.x * 0.1 ) + nodeVar25 ),
    ( ( varyings.v_positionWorld.z * 0.1 ) + ( nodeVar25 * 0.5 ) ) ) ) * vec2f( nodeVar27 ) ) );
```

That is `calculateWindSway` in `src/foliage/material-core.ts` sampling the wind texture from `wind-compute.ts`.

## Root cause

In `node_modules/three/src/renderers/webgpu/nodes/WGSLNodeBuilder.js:358`, `generateTextureLoad` short-circuits whenever `texture.isStorageTexture === true` and emits `textureLoad(prop, uv)` with no mip-level argument. But when the same storage texture is *read* (rather than written) in a different shader, the binding is generated as a plain `texture_2d<f32>` — which requires the level argument. Result: WGSL fails to parse, every foliage shader is invalid, GPU goes down.

The previous attempt (commit 95f0fc5, switching the wind texture to `HalfFloatType`) didn't help — the bug triggers on `isStorageTexture`, not on texel format.

## Fix

Route `calculateWindSway` through the procedural sway used by `calculateWindSwayLegacy`. The wind compute system stays in place (other consumers can still use it), but foliage materials no longer sample the storage texture, so the broken WGSL path is avoided.

## Test plan

- [x] Verified locally with a headless Chromium probe against the deployed build — without the fix: `Invalid ShaderModule "vertex"` spam, then `WebGPU Device Lost: destroyed`.
- [ ] Re-deploy and re-probe to confirm no WGSL errors, scene reaches steady state, foliage still sways.
- [ ] Visual regression check on grass/trees/flowers (sway is now uniform-driven, not texture-driven; should look very similar to the legacy mode).

https://claude.ai/code/session_01Mhx4Wj7xxnDnwu7pHiffaX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mhx4Wj7xxnDnwu7pHiffaX)_