### PR TITLE
🎨 Palette: [Accessibility] Synchronize focus trap timing with CSS transitions

### DIFF
--- a/src/core/game-loop.ts
+++ b/src/core/game-loop.ts
@@ -586,6 +586,7 @@ export function animate() {
                     () => updateAllIntegratedSystems(rendererRef, delta, player.position, _scratchParticleAudioData),
                     'updateAllIntegratedSystems'
                 );
+            });
 
         if (fluidFog && audioState) {
             fluidSystem.update(delta, audioState);

--- a/src/core/input/playlist-manager.ts
+++ b/src/core/input/playlist-manager.ts
@@ -445,27 +445,25 @@ export function togglePlaylist(): void {
             setTimeout(() => {
                 if (isPlaylistOpen && playlistOverlay) {
                     releaseJukeboxFocus = trapFocusInside(playlistOverlay);
+
+                    // UX: Auto-focus the currently playing track for immediate context
+                    if (!audioSystemRef || !playlistList) return;
+                    const currentIdx = audioSystemRef.getCurrentIndex();
+                    const playlistBtns = playlistList.querySelectorAll('.playlist-btn');
+
+                    if (currentIdx >= 0 && playlistBtns[currentIdx]) {
+                        const activeBtn = playlistBtns[currentIdx] as HTMLElement;
+                        activeBtn.focus();
+                        // Ensure the active song is visible in the scrollable list
+                        activeBtn.scrollIntoView({ block: 'center', behavior: 'smooth' });
+                    } else if (closePlaylistBtn) {
+                        closePlaylistBtn.focus();
+                    }
                 }
             }, 300);
         }
         if (playlistBackdrop) playlistBackdrop.style.display = 'block';
         renderPlaylist();
-        
-        // UX: Auto-focus the currently playing track for immediate context
-        requestAnimationFrame(() => {
-            if (!audioSystemRef || !playlistList) return;
-            const currentIdx = audioSystemRef.getCurrentIndex();
-            const playlistBtns = playlistList.querySelectorAll('.playlist-btn');
-
-            if (currentIdx >= 0 && playlistBtns[currentIdx]) {
-                const activeBtn = playlistBtns[currentIdx] as HTMLElement;
-                activeBtn.focus();
-                // Ensure the active song is visible in the scrollable list
-                activeBtn.scrollIntoView({ block: 'center', behavior: 'smooth' });
-            } else if (closePlaylistBtn) {
-                closePlaylistBtn.focus();
-            }
-        });
     } else {
         // CLOSING
         if (releaseJukeboxFocus) {

--- a/src/systems/discovery.ts
+++ b/src/systems/discovery.ts
@@ -223,7 +223,7 @@ class DiscoverySystem {
                 // Focus close button for accessibility
                 closeBtn.focus();
             }
-        }, 100);
+        }, 300);
     }
 
     /**


### PR DESCRIPTION
🎨 Palette: [Accessibility] Synchronize focus trap timing with CSS transitions

Moves the auto-focus logic into the existing `setTimeout` block in `playlist-manager.ts` and correctly syncs the transition time from 100ms to 300ms in `discovery.ts` to properly trap focus alongside the CSS visual transition. Includes a pre-existing syntax fix in `game-loop.ts` so the build stays green.

---
*PR created automatically by Jules for task [1497038360038323310](https://jules.google.com/task/1497038360038323310) started by @ford442*