### PR TITLE
Fix game-loop syntax error and WASM discovery memory out-of-bounds crash

### DIFF
--- a/src/core/game-loop.ts
+++ b/src/core/game-loop.ts
@@ -604,7 +604,6 @@ export function animate() {
             }
         }
     });
-    });
 
     if (firefliesRef) {
         firefliesRef.visible = isDeepNight;


### PR DESCRIPTION
## Summary
- Fixed duplicate `});` syntax error in `src/core/game-loop.ts` that caused Vite build failure
- Fixed WASM `RuntimeError: memory access out of bounds` crash during discovery system initialization

## Root Cause (WASM crash)
`assembly/discovery.ts` placed its data at absolute offsets of 350KB–463KB, but the WASM module only allocates 4 pages (256KB) of initial memory. On page load, `new OptimizedDiscoverySystem()` immediately calls `initDiscoverySystem()` which `store`s to those out-of-bounds addresses and crashes.

## Changes
- **`assembly/discovery.ts`**: Moved `DISCOVERY_BUFFER_OFFSET` from 350KB to 167KB (right after the static physics layout), reducing required memory to 5 pages (~276KB used)
- **`package.json`**: Bumped `--initialMemory` from 4 to 5 pages so future WASM builds have sufficient memory
- **`src/systems/discovery-optimized.ts`**: Added a runtime memory-size guard before calling `initDiscoverySystem()` — detects already-compiled 4-page WASM binaries and falls back to JS instead of crashing

## Test plan
- [ ] `npm run test:wasm` — WASM physics bounds test should pass
- [ ] `npm run build:wasm && npm run build` — full build with 5-page initial memory
- [ ] Launch in browser and confirm no `RuntimeError: memory access out of bounds` in console
- [ ] Discovery system should log either "WASM spatial grid initialized" (new binary) or "WASM memory too small... using JS fallback" (old binary) — not crash

https://claude.ai/code/session_01KUSSbHhLJrGjb1R1ebnBnH