### PR TITLE
♿ Aria: [Accessibility improvement for Jukebox]

### DIFF
--- a/index.html
+++ b/index.html
@@ -700,7 +700,7 @@
     <div id="playlist-overlay" role="dialog" aria-modal="true" aria-labelledby="playlist-title" tabindex="-1">
         <button id="playlistCloseX" class="close-icon-btn" aria-label="Close Jukebox" title="Close Jukebox (Esc)"><span aria-hidden="true">×</span></button>
         <h2 id="playlist-title"><span aria-hidden="true">🎵</span> Jukebox</h2>
-        <ul id="playlist-list" aria-label="Current playlist">
+        <ul id="playlist-list" aria-label="Current playlist" aria-live="polite">
         </ul>
         
         <div class="playlist-controls">


### PR DESCRIPTION
💡 What: Added `aria-live="polite"` to the `#playlist-list` element in `index.html`.
🎯 Why: This ensures that when the Jukebox empty state is displayed or songs are dynamically updated, the changes are gracefully announced to users using screen readers without interrupting their current tasks.
♿ Accessibility: Uses the `aria-live` polite region to manage dynamic content updates in the playlist.

---
*PR created automatically by Jules for task [8961058396014232429](https://jules.google.com/task/8961058396014232429) started by @ford442*