### PR TITLE
Fix WASM memory out-of-bounds crash in discovery system initialization

### DIFF
--- a/assembly/discovery.ts
+++ b/assembly/discovery.ts
@@ -49,12 +49,18 @@ const FLAG_DISCOVERABLE: i32 = 2;
 // MEMORY LAYOUT
 // =============================================================================
 
-/** Discovery data buffer offset */
-const DISCOVERY_BUFFER_OFFSET: i32 = 350000; // 350KB
+// Memory layout (relative to WASM linear memory start):
+//   constants.ts static layout ends at ~166944 (DYNAMIC_RADII_OFFSET + MAX_DYNAMIC_PLANTS*4)
+//   Discovery buffer: 167168 + 3000*32 = 263168
+//   Discovery grid heads: 263168 + 16*16*4 = 264192
+//   Discovery grid next: 264192 + 3000*4 = 276192  →  ceil(276192/65536) = 5 pages required
+
+/** Discovery data buffer offset — starts right after the static constants.ts layout */
+const DISCOVERY_BUFFER_OFFSET: i32 = 167168; // ~163KB, aligned to 256-byte boundary
 
 /** Spatial grid for discovery objects (maps grid cell -> object indices) */
-const DISCOVERY_GRID_HEADS_OFFSET: i32 = 450000; // 450KB
-const DISCOVERY_GRID_NEXT_OFFSET: i32 = 451024; // 451KB (1KB for heads + next pointers)
+const DISCOVERY_GRID_HEADS_OFFSET: i32 = 263168; // after discovery buffer
+const DISCOVERY_GRID_NEXT_OFFSET: i32 = 264192; // after grid heads (16*16*4 = 1024 bytes)
 
 // =============================================================================
 // SPATIAL GRID FUNCTIONS

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "bash dev.sh",
     "preview": "vite preview",
-    "build:wasm": "asc assembly/index.ts --outFile src/wasm/candy_physics.wasm --textFile src/wasm/candy_physics.wat --sourceMap --shrinkLevel 0 --optimize --converge --optimizeLevel 3 --enable simd --enable bulk-memory --initialMemory 4 --maximumMemory 256 --target wasm-gc --enable reference-types --enable gc --exportRuntime --bindings esm",
+    "build:wasm": "asc assembly/index.ts --outFile src/wasm/candy_physics.wasm --textFile src/wasm/candy_physics.wat --sourceMap --shrinkLevel 0 --optimize --converge --optimizeLevel 3 --enable simd --enable bulk-memory --initialMemory 5 --maximumMemory 256 --target wasm-gc --enable reference-types --enable gc --exportRuntime --bindings esm",
     "build:emcc": "bash emscripten/build.sh",
     "optimize": "cd tools/build-optimizer && npm run optimize",
     "optimize:assets": "cd tools/build-optimizer && npm run optimize:assets",

--- a/src/systems/discovery-optimized.ts
+++ b/src/systems/discovery-optimized.ts
@@ -98,9 +98,24 @@ export class OptimizedDiscoverySystem {
         this.wasmGetUndiscoveredCount = (instance.exports as any).getUndiscoveredCount;
 
         if (this.wasmInitDiscovery) {
-            this.wasmInitDiscovery();
-            this.wasmInitialized = true;
-            console.log('[OptimizedDiscovery] WASM spatial grid initialized');
+            // The discovery system writes to addresses up to ~276KB. Guard against
+            // running on a WASM build whose initialMemory is too small (old 4-page
+            // binaries only have 256KB), which would throw RuntimeError immediately.
+            const mem = (instance.exports as any).memory as WebAssembly.Memory;
+            const DISCOVERY_REQUIRED_BYTES = 280000;
+            if (mem && mem.buffer.byteLength < DISCOVERY_REQUIRED_BYTES) {
+                console.warn('[OptimizedDiscovery] WASM memory too small for discovery system, using JS fallback');
+                this.wasmInitDiscovery = null;
+                return;
+            }
+            try {
+                this.wasmInitDiscovery();
+                this.wasmInitialized = true;
+                console.log('[OptimizedDiscovery] WASM spatial grid initialized');
+            } catch (e) {
+                console.warn('[OptimizedDiscovery] WASM initDiscoverySystem failed, using JS fallback:', e);
+                this.wasmInitDiscovery = null;
+            }
         }
     }
 


### PR DESCRIPTION
The discovery system's AssemblyScript code used absolute memory offsets of 350KB–463KB, which exceeded the WASM module's 4-page (256KB) initial memory. On load, `initDiscoverySystem()` immediately faulted with RuntimeError.

Three-part fix:
- Move discovery offsets in assembly/discovery.ts to start at 167168 (just after the static constants.ts layout at ~167KB), requiring only 5 pages (~320KB) instead of 7+.
- Bump --initialMemory from 4 to 5 pages in the build:wasm script so future WASM builds have sufficient memory for the new layout.
- Guard the initDiscoverySystem() call in discovery-optimized.ts to detect under-sized WASM binaries at runtime and fall back to JS, preventing crashes with already-compiled .wasm files.

https://claude.ai/code/session_01KUSSbHhLJrGjb1R1ebnBnH