### PR TITLE
⚡ Bolt: Optimize getUnifiedGroundHeight math bottlenecks

### DIFF
--- a/src/workers/physics-worker.ts
+++ b/src/workers/physics-worker.ts
@@ -118,9 +118,13 @@ function getUnifiedGroundHeight(x: number, z: number): number {
     if (LAKE_ISLAND.enabled) {
       const dx = x - LAKE_ISLAND.centerX;
       const dz = z - LAKE_ISLAND.centerZ;
-      const distFromIslandCenter = Math.sqrt(dx * dx + dz * dz);
       
-      if (distFromIslandCenter < LAKE_ISLAND.radius) {
+      // ⚡ OPTIMIZATION: Deferred Math.sqrt() by using squared distance for early-out bounds check.
+      const distFromIslandCenterSq = dx * dx + dz * dz;
+      const islandRadiusSq = LAKE_ISLAND.radius * LAKE_ISLAND.radius;
+
+      if (distFromIslandCenterSq < islandRadiusSq) {
+        const distFromIslandCenter = Math.sqrt(distFromIslandCenterSq);
         const normalizedDist = distFromIslandCenter / LAKE_ISLAND.radius;
         const islandHeight = LAKE_ISLAND.peakHeight * Math.cos(normalizedDist * Math.PI / 2);
         const edgeDist = LAKE_ISLAND.radius - distFromIslandCenter;

--- a/src/world/generation.ts
+++ b/src/world/generation.ts
@@ -138,9 +138,13 @@ function getUnifiedGroundHeight(x: number, z: number): number {
         if (LAKE_ISLAND.enabled) {
             const dx = x - LAKE_ISLAND.centerX;
             const dz = z - LAKE_ISLAND.centerZ;
-            const distFromIslandCenter = Math.sqrt(dx * dx + dz * dz);
             
-            if (distFromIslandCenter < LAKE_ISLAND.radius) {
+            // ⚡ OPTIMIZATION: Deferred Math.sqrt() by using squared distance for early-out bounds check.
+            const distFromIslandCenterSq = dx * dx + dz * dz;
+            const islandRadiusSq = LAKE_ISLAND.radius * LAKE_ISLAND.radius;
+
+            if (distFromIslandCenterSq < islandRadiusSq) {
+                const distFromIslandCenter = Math.sqrt(distFromIslandCenterSq);
                 // On the island - calculate height above water
                 const normalizedDist = distFromIslandCenter / LAKE_ISLAND.radius;
                 


### PR DESCRIPTION
⚡ Bolt: Optimize getUnifiedGroundHeight math bottlenecks

Bottleneck: Was executing `Math.sqrt()` per-pixel or per-physics-query blindly inside `getUnifiedGroundHeight` calculations.

Fix: Converted the initial check for lake island boundaries to use squared distance to defer `Math.sqrt()` calculations only when safely inside the island radius. Applied to both `src/world/generation.ts` and `src/workers/physics-worker.ts`.

Impact: Eliminated CPU math bottlenecks associated with Math.sqrt in the hot loops that execute thousands of times per second.

---
*PR created automatically by Jules for task [11600202697775637856](https://jules.google.com/task/11600202697775637856) started by @ford442*