### PR TITLE
♿ Aria: [UX improvement] Add clear audio-visual readiness feedback to Start button

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,6 +77,27 @@
             /* 🎨 Palette: Improve text contrast */
             text-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
         }
+
+        /* ♿ Aria & 🎨 Palette: Visual pop when button becomes ready */
+        .cta-button[aria-disabled="false"]:not(:disabled) {
+            animation: cta-pulse-ready 0.6s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards;
+        }
+
+        @keyframes cta-pulse-ready {
+            0% {
+                transform: scale(0.9);
+                box-shadow: 0 0 0 rgba(255, 107, 107, 0);
+            }
+            50% {
+                transform: scale(1.08);
+                box-shadow: 0 0 25px rgba(255, 107, 107, 0.8);
+            }
+            100% {
+                transform: scale(1);
+                box-shadow: 0 5px 15px rgba(255, 107, 107, 0.4);
+            }
+        }
+
         .cta-button:hover,
         .cta-button:focus {
             transform: scale(1.05);

--- a/src/core/main.ts
+++ b/src/core/main.ts
@@ -459,6 +459,11 @@ if (startButton) {
     startButton.removeAttribute('title');
     startButton.innerHTML = 'Enter Core World <span aria-hidden="true">🍭</span> <span class="key-badge" aria-hidden="true">Enter</span>';
 
+    // ♿ Aria: Announce to screen readers that the world is ready
+    import('../ui/announcer.ts').then(({ announce }) => {
+        announce('World loaded. Press Enter to enter the world.', 'assertive');
+    }).catch(err => console.warn('Failed to load announcer:', err));
+
     let coreOnlyMode = true;
     const btnCoreOnly = document.getElementById('btn-core-only') as HTMLButtonElement | null;
     const btnFullGame = document.getElementById('btn-full-game') as HTMLButtonElement | null;
@@ -664,6 +669,11 @@ if (startButton) {
             startButton.setAttribute('aria-disabled', 'false');
             startButton.setAttribute('aria-busy', 'false');
             startButton.removeAttribute('title');
+
+            // ♿ Aria: Announce if they somehow return back or if it completes
+            import('../ui/announcer.ts').then(({ announce }) => {
+                announce('World loaded. Press Enter to enter the world.', 'assertive');
+            }).catch(err => console.warn('Failed to load announcer:', err));
         }
     }
 


### PR DESCRIPTION
## Summary
This adds much-needed micro-UX feedback to the `#startButton` when the game has finished generating the world and is ready to be entered.

## Details
- `src/core/main.ts`: Detects when `startButton.disabled = false;` is set on the final loading state and dynamically imports `announce()` to immediately broadcast "World loaded. Press Enter to enter the world." to screen readers.
- `index.html`: Defines an inline `@keyframes cta-pulse-ready` animation that triggers on `.cta-button[aria-disabled="false"]:not(:disabled)`. This creates a satisfying, juicy pop when the button transitions from a loading state to a ready state, improving game feel.

---
*PR created automatically by Jules for task [6615103680045061927](https://jules.google.com/task/6615103680045061927) started by @ford442*