### PR TITLE
⚡ Bolt: [Flower Batcher] Bypass .setX proxy overhead in hot loop

### DIFF
--- a/src/foliage/flower-batcher.ts
+++ b/src/foliage/flower-batcher.ts
@@ -418,11 +418,13 @@ export class FlowerBatcher {
             const attr = mesh.geometry.attributes.aPoseState as THREE.InstancedBufferAttribute;
             if (!attr) continue;
             
+            // ⚡ OPTIMIZATION: Bypassed THREE.BufferAttribute.setX overhead by writing directly to typed array
+            const array = attr.array as Float32Array;
             for (let i = 0; i < mesh.count; i++) {
                 // _poseMachine covers up to MAX_PETALS, which is MAX_FLOWERS * 8
                 // Ensure we don't read out of bounds. Stamens can have up to MAX_FLOWERS * 3 instances.
                 // Stems and Centers have up to MAX_FLOWERS instances.
-                attr.setX(i, this._poseMachine.getPose(i));
+                array[i * attr.itemSize] = this._poseMachine.getPose(i);
             }
             attr.needsUpdate = true;
         }


### PR DESCRIPTION
Optimized the hot loop in `src/foliage/flower-batcher.ts` to directly access the typed array instead of using `BufferAttribute.setX()` to prevent execution proxy overheads.

---
*PR created automatically by Jules for task [11821591605768390317](https://jules.google.com/task/11821591605768390317) started by @ford442*