### PR TITLE
♿ Aria: [UX improvement] Fix screen reader double announcements for toasts

### DIFF
--- a/index.html
+++ b/index.html
@@ -596,7 +596,7 @@
 </head>
 
 <body>
-    <div id="now-playing-toast" role="status" aria-live="polite">
+    <div id="now-playing-toast" aria-hidden="true">
         <span class="icon" aria-hidden="true">🎵</span>
         <span id="now-playing-text">Now Playing...</span>
     </div>
@@ -611,7 +611,7 @@
 <div id="instructions" role="dialog" aria-modal="true" aria-labelledby="instructions-title">
         <div class="instructions-content">
         <h1 id="instructions-title"><span aria-hidden="true">🍭</span> Candy World</h1>
-        <div id="nowPlayingContainer" class="now-playing-info" aria-live="polite" style="display: none;">
+        <div id="nowPlayingContainer" class="now-playing-info" aria-hidden="true" style="display: none;">
             <span class="music-note" aria-hidden="true">🎵</span> <span id="nowPlayingText"></span>
         </div>
         <button id="startButton" class="cta-button" disabled aria-live="polite" aria-busy="true" title="Please wait while game assets load...">

--- a/plan.md
+++ b/plan.md
@@ -47,3 +47,7 @@ Next Step: Continue large file refactoring from `REFACTORING_PLAN_REMAINING.md` 
 
 Status: Implemented ✅
 * Implementation Details: Improved FCP (First Contentful Paint) for the `LoadingScreen` by moving heavy, synchronous DOM generation from `src/ui/loading-screen-ui.ts` into static HTML shells inside `index.html`. This ensures the overlay and loading indicator render immediately without JS-driven layout thrashing.
+
+Status: Implemented ✅
+* Implementation Details: Fixed screen reader double-announcements by removing `aria-live` and adding `aria-hidden="true"` to visual toast UI elements in `index.html`. Removed `aria-live` from the jukebox empty state element in `src/core/input/playlist-manager.ts` to prevent unnecessary automatic announcements, aligning with typical empty-state ARIA guidelines.
+Next Step: Ask the user for the next task.

--- a/src/core/input/playlist-manager.ts
+++ b/src/core/input/playlist-manager.ts
@@ -366,7 +366,6 @@ export function renderPlaylist(): void {
         const li = document.createElement('li');
         li.className = 'jukebox-empty-state';
         li.style.listStyle = 'none';
-        li.setAttribute('aria-live', 'polite');
 
         const iconContainer = document.createElement('div');
         iconContainer.className = 'jukebox-empty-icon-container';


### PR DESCRIPTION
💡 What:
- Replaced `aria-live` and `role="status"` with `aria-hidden="true"` on the `#now-playing-toast` and `#nowPlayingContainer` UI elements.
- Removed `aria-live` from the `.jukebox-empty-state` list item in the jukebox overlay.

🎯 Why:
- Prevents screen readers from double-announcing dynamic content (like song changes), relying instead entirely on the centralized `announce()` utility function for accessibility notifications.
- Prevents the jukebox empty state from being announced unnecessarily simply when rendering the overlay.

♿ Accessibility:
- Uses `aria-hidden="true"` to explicitly hide visual-only toasts from the accessibility tree, delegating speech to the global announcer.

---
*PR created automatically by Jules for task [7725928713559237649](https://jules.google.com/task/7725928713559237649) started by @ford442*