### PR TITLE
Fix WASM missing export and circular chunk dependency crash

### DIFF
--- a/src/utils/wasm-physics.ts
+++ b/src/utils/wasm-physics.ts
@@ -11,7 +11,7 @@
  */
 
 import * as THREE from 'three';
-import { 
+import {
     cppBatchGroundHeightSimd,
     wasmInstance,
     wasmMemory,
@@ -28,7 +28,6 @@ import {
     wasmFreqToHue,
     wasmLerp,
     getNativeFunc,
-    cppBatchGroundHeightSimd,
     POSITION_OFFSET,
     type WasmExports,
     type Cave,

--- a/src/world/generation-utils.ts
+++ b/src/world/generation-utils.ts
@@ -7,7 +7,7 @@ export const DEFAULT_PROCEDURAL_CHUNK_SIZE = 100;
 
 // Population numbers are now driven from CONFIG.world.population for easier tuning.
 // These are the effective values used by Full mode generation.
-const pop = CONFIG.world?.population ?? {};
+const pop = CONFIG?.world?.population ?? {};
 let popScale = pop.scale ?? 1.0;
 
 // Runtime override for "Fast Full Mode" (chosen in the startup UI)

--- a/vite.config.js
+++ b/vite.config.js
@@ -48,6 +48,11 @@ export default defineConfig({
           if (id.includes('/src/ui/')) {
             return 'ui';
           }
+          // Core config and constants — must load before world and main chunks
+          // to break the circular chunk dependency (main→world→config→main).
+          if (id.includes('/src/core/config.ts') || id.includes('/src/core/config.js')) {
+            return 'utils';
+          }
           // Utility modules (WASM loaders, profilers)
           if (id.includes('/src/utils/')) {
             return 'utils';


### PR DESCRIPTION
## Summary

- **WASM `getGroundHeight` missing export**: The deployed WASM binary was stale (built before `getGroundHeight` was added to `assembly/math.ts`). Rebuilt via `npm run build:wasm` — the AssemblyScript source was already correct. Also removed a duplicate `cppBatchGroundHeightSimd` named binding in `wasm-physics.ts` imports (TS2300 compile error).

- **`TypeError: Cannot read properties of undefined (reading 'world')`**: Root cause was a **circular chunk dependency** — `main.ts` imports from the world chunk, and the world chunk imports `CONFIG` from `config.ts`, which Rollup placed in the main chunk. During module init, the world chunk evaluated before main finished, leaving `CONFIG` as `undefined`. Fix: route `config.ts` into the `utils` chunk (which loads before both `main` and `world`) via `vite.config.js` `manualChunks`, and add a defensive `CONFIG?.world?.population` optional-chain in `generation-utils.ts`.

## Test plan

- [ ] Run `npm run build:wasm` and verify no `asc` errors
- [ ] Run `npm run test:wasm` — all particle bounds tests should pass
- [ ] Run `npm run build` — no duplicate identifier TS errors
- [ ] Boot app in Chrome with WebGPU: no `[WASM] Missing required export` errors in console
- [ ] Boot app: no `TypeError: Cannot read properties of undefined (reading 'world')` in console

https://claude.ai/code/session_01Pep2aDmZkpHvnpWUZJWUjr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pep2aDmZkpHvnpWUZJWUjr)_