### PR TITLE
🎨 Palette: Add :active pressed states for consistent Game Feel

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -57,3 +57,6 @@ Status: Implemented ✅
 Next Step: Continue large file refactoring from `REFACTORING_PLAN_REMAINING.md`.
 nStatus: Implemented ✅
 * Implementation Details: Removed redundant `group.updateMatrix()` calls in `src/foliage/tree-batcher.ts` and replaced multiple matrix clone/premultiply calls with a single `group.updateWorldMatrix(false, false)` followed by manual local matrix multiplication. Added module-level scratch variables (`_scratchMPos`, `_scratchFPos`) in `src/systems/weather/weather-ecosystem.ts` to eliminate `new THREE.Vector3()` instantiations and `.clone()` calls inside the high-frequency tick loop, removing major GC spikes.
+
+Status: Implemented ✅
+* Implementation Details: Added `:active` pressed states (scale 0.95) to `.toggle-button`, `.cta-button`, `.secondary-button`, `.close-icon-btn`, and `.playlist-remove-btn` classes for consistent tactile 'Game Feel' feedback when users click interactive UI elements.

--- a/style.css
+++ b/style.css
@@ -614,3 +614,13 @@ button.pressed,
 #btn-full-game[aria-pressed="true"] {
     box-shadow: 0 5px 18px rgba(125, 211, 252, 0.55);
 }
+
+/* 🎨 Palette: Tactile feedback on interactive elements */
+.toggle-button:not([aria-disabled="true"]):active,
+.cta-button:not([aria-disabled="true"]):active,
+.secondary-button:not([aria-disabled="true"]):active,
+.close-icon-btn:not([aria-disabled="true"]):active,
+.playlist-remove-btn:not([aria-disabled="true"]):active {
+    transform: scale(0.95);
+    transition-duration: 0.05s;
+}


### PR DESCRIPTION
Adds immediate tactile scale-down visual feedback when users click interactive UI elements across the application to improve the overall "Game Feel".

Modifies `style.css` to add `transform: scale(0.95)` and `transition-duration: 0.05s` to the `:active` pseudo-class for `.toggle-button`, `.cta-button`, `.secondary-button`, `.close-icon-btn`, and `.playlist-remove-btn`, skipping elements with `[aria-disabled="true"]`.

---
*PR created automatically by Jules for task [984607811413900979](https://jules.google.com/task/984607811413900979) started by @ford442*