### PR TITLE
⚡ Bolt: [Batcher CPU Overhead] Replace updateMatrix in lod.ts

### DIFF
--- a/src/foliage/lod.ts
+++ b/src/foliage/lod.ts
@@ -805,7 +805,8 @@ export class LODTreeBatcher {
         const treeId = this.nextTreeId++;
         const componentIds: { [geometryType: string]: number } = {};
 
-        group.updateMatrix();
+        // ⚡ OPTIMIZATION: Ensure world matrix is ready without deep traversal
+        group.updateWorldMatrix(false, false);
 
         // Traverse and register each mesh component
         group.traverse((child) => {
@@ -813,7 +814,7 @@ export class LODTreeBatcher {
                 const mesh = child as THREE.Mesh;
                 const mat = (Array.isArray(mesh.material) ? mesh.material[0] : mesh.material) as THREE.MeshStandardMaterial;
                 // ⚡ OPTIMIZATION: Bypass recursive updateWorldMatrix
-                _scratchLODMatrix.copy(mesh.matrix).premultiply(group.matrix);
+                _scratchLODMatrix.multiplyMatrices(group.matrixWorld, mesh.matrix);
                 const col = mat.color || new THREE.Color(0xFFFFFF);
 
                 // Map geometry types to our LOD categories


### PR DESCRIPTION
Replaced `group.updateMatrix()` in `src/foliage/lod.ts` with `group.updateWorldMatrix(false, false)` to avoid deep proxy traversal while ensuring the world matrix is ready. Updated the matrix composition to use `group.matrixWorld` to match optimized patterns in other batchers.

---
*PR created automatically by Jules for task [11061552841115483775](https://jules.google.com/task/11061552841115483775) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transform calculations for level-of-detail tree rendering, ensuring more accurate positioning and scaling of foliage elements in 3D scenes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->