### PR TITLE
🎨 Palette: Fix UI scroll jump bug by applying preventScroll to focus calls

### DIFF
--- a/src/core/input/input.ts
+++ b/src/core/input/input.ts
@@ -131,13 +131,13 @@ export function initInput(
             setTimeout(() => {
                 if (instructions) instructions.style.display = 'none';
                 if (lastFocusedElement && typeof lastFocusedElement.focus === 'function') {
-                    lastFocusedElement.focus();
+                    lastFocusedElement.focus({ preventScroll: true });
                     lastFocusedElement = null;
                 }
             }, 200);
         } else {
             if (lastFocusedElement && typeof lastFocusedElement.focus === 'function') {
-                lastFocusedElement.focus();
+                lastFocusedElement.focus({ preventScroll: true });
                 lastFocusedElement = null;
             }
         }
@@ -196,7 +196,7 @@ export function initInput(
                     if (instructions && instructions.style.display !== 'none') {
                         releasePauseMenuFocus = trapFocusInside(instructions);
                         if (startButton) {
-                            startButton.focus();
+                            startButton.focus({ preventScroll: true });
                         }
                     }
                 }, 200);
@@ -283,7 +283,7 @@ export function initInput(
                         if (instructions && instructions.style.display !== 'none') {
                             releasePauseMenuFocus = trapFocusInside(instructions);
                             if (startButton) {
-                                startButton.focus();
+                                startButton.focus({ preventScroll: true });
                             }
                         }
                     }, 200);

--- a/src/core/input/playlist-manager.ts
+++ b/src/core/input/playlist-manager.ts
@@ -303,7 +303,7 @@ export function renderPlaylist(): void {
             requestAnimationFrame(() => {
                 const newItems = playlistList!.querySelectorAll('.playlist-btn');
                 if (newItems[index] && newItems[index] instanceof HTMLElement) {
-                    (newItems[index] as HTMLElement).focus();
+                    (newItems[index] as HTMLElement).focus({ preventScroll: true });
                 }
             });
         };
@@ -335,18 +335,18 @@ export function renderPlaylist(): void {
 
                 // Try focusing the next remove button (at same index, since list shifted)
                 if (removeBtns[index]) {
-                    (removeBtns[index] as HTMLElement).focus();
+                    (removeBtns[index] as HTMLElement).focus({ preventScroll: true });
                 } else if (removeBtns[index - 1]) {
                     // Or the previous one
-                    (removeBtns[index - 1] as HTMLElement).focus();
+                    (removeBtns[index - 1] as HTMLElement).focus({ preventScroll: true });
                 } else if (playBtns[0]) {
                     // Or the first song
-                    (playBtns[0] as HTMLElement).focus();
+                    (playBtns[0] as HTMLElement).focus({ preventScroll: true });
                 } else {
                     // Fallback to empty state button if list is now empty
                     const emptyBtn = playlistList!.querySelector('button.secondary-button');
                     if (emptyBtn) {
-                        (emptyBtn as HTMLElement).focus();
+                        (emptyBtn as HTMLElement).focus({ preventScroll: true });
                     }
                 }
             });
@@ -449,11 +449,11 @@ export function togglePlaylist(): void {
 
                     if (currentIdx >= 0 && playlistBtns[currentIdx]) {
                         const activeBtn = playlistBtns[currentIdx] as HTMLElement;
-                        activeBtn.focus();
+                        activeBtn.focus({ preventScroll: true });
                         // Ensure the active song is visible in the scrollable list
                         activeBtn.scrollIntoView({ block: 'center', behavior: 'smooth' });
                     } else if (closePlaylistBtn) {
-                        closePlaylistBtn.focus();
+                        closePlaylistBtn.focus({ preventScroll: true });
                     }
                 }
             }, 300);
@@ -488,7 +488,7 @@ export function togglePlaylist(): void {
             }
             // Restore focus to the button that opened the jukebox (e.g. Open Jukebox button)
             if (lastFocusedElement && lastFocusedElement instanceof HTMLElement) {
-                lastFocusedElement.focus();
+                lastFocusedElement.focus({ preventScroll: true });
             }
             // Do NOT lock controls, stay unlocked
         } else {
@@ -563,7 +563,7 @@ export function handlePlaylistKeyDown(event: KeyboardEvent): boolean {
             } else {
                 nextIndex = currentIndex === -1 ? focusableBtns.length - 1 : (currentIndex - 1 + focusableBtns.length) % focusableBtns.length;
             }
-            focusableBtns[nextIndex].focus();
+            focusableBtns[nextIndex].focus({ preventScroll: true });
         }
         return true;
     }
@@ -578,12 +578,12 @@ export function handlePlaylistKeyDown(event: KeyboardEvent): boolean {
 
         if (event.shiftKey) {
             if (document.activeElement === first) {
-                last.focus();
+                last.focus({ preventScroll: true });
                 event.preventDefault();
             }
         } else {
             if (document.activeElement === last) {
-                first.focus();
+                first.focus({ preventScroll: true });
                 event.preventDefault();
             }
         }

--- a/src/ui/accessibility-menu-core.ts
+++ b/src/ui/accessibility-menu-core.ts
@@ -122,7 +122,7 @@ export class AccessibilityMenuCore {
     }
 
     if (this.lastFocusedElement && typeof this.lastFocusedElement.focus === 'function') {
-      this.lastFocusedElement.focus();
+      this.lastFocusedElement.focus({ preventScroll: true });
     }
     this.lastFocusedElement = null;
 
@@ -179,7 +179,7 @@ export class AccessibilityMenuCore {
     this.refreshMainPanel();
     announce(`Switched to ${this.formatActionName(section)} settings`, 'polite');
     const newTab = this.container?.querySelector(`#tab-${section}`) as HTMLElement;
-    if (newTab) newTab.focus();
+    if (newTab) newTab.focus({ preventScroll: true });
   }
 
   protected refreshMainPanel(): void {

--- a/src/ui/accessibility-menu-handlers.ts
+++ b/src/ui/accessibility-menu-handlers.ts
@@ -37,7 +37,7 @@ export class AccessibilityMenuHandlers extends AccessibilityMenuRendering {
           if (nextIndex < 0) nextIndex = tabs.length - 1;
 
           const nextTab = tabs[nextIndex];
-          nextTab.focus();
+          nextTab.focus({ preventScroll: true });
 
           // Assuming tab id is like 'tab-presets' and section is 'presets'
           const tabIdMatch = nextTab.id.match(/^tab-(.+)$/);

--- a/src/ui/analytics-debug-handlers.ts
+++ b/src/ui/analytics-debug-handlers.ts
@@ -160,7 +160,7 @@ export class AnalyticsDebugOverlay {
       this.releaseFocusTrap = null;
     }
     if (this.lastFocusedElement && typeof this.lastFocusedElement.focus === 'function') {
-      this.lastFocusedElement.focus();
+      this.lastFocusedElement.focus({ preventScroll: true });
     }
     this.lastFocusedElement = null;
 

--- a/src/ui/announcer.ts
+++ b/src/ui/announcer.ts
@@ -457,7 +457,7 @@ export class Announcer {
    * Sets focus to a specific element and announces it
    */
   focusAndAnnounce(element: HTMLElement, description?: string): void {
-    element.focus();
+    element.focus({ preventScroll: true });
     
     if (description) {
       this.announce(`${description}, focused`, 'polite');

--- a/src/ui/loading-screen-ui.ts
+++ b/src/ui/loading-screen-ui.ts
@@ -362,7 +362,7 @@ export class LoadingScreen {
         }
 
         if (this.lastFocusedElement && typeof this.lastFocusedElement.focus === 'function') {
-            this.lastFocusedElement.focus();
+            this.lastFocusedElement.focus({ preventScroll: true });
             this.lastFocusedElement = null;
         }
 
@@ -850,7 +850,7 @@ export class LoadingScreen {
             this.releaseFocusTrap = null;
         }
         if (this.lastFocusedElement && typeof this.lastFocusedElement.focus === 'function') {
-            this.lastFocusedElement.focus();
+            this.lastFocusedElement.focus({ preventScroll: true });
             this.lastFocusedElement = null;
         }
 

--- a/src/ui/loading-screen.ts
+++ b/src/ui/loading-screen.ts
@@ -470,7 +470,7 @@ export class LoadingScreen {
         }
 
         if (this.lastFocusedElement && typeof this.lastFocusedElement.focus === 'function') {
-            this.lastFocusedElement.focus();
+            this.lastFocusedElement.focus({ preventScroll: true });
             this.lastFocusedElement = null;
         }
 
@@ -966,7 +966,7 @@ export class LoadingScreen {
             this.releaseFocusTrap = null;
         }
         if (this.lastFocusedElement && typeof this.lastFocusedElement.focus === 'function') {
-            this.lastFocusedElement.focus();
+            this.lastFocusedElement.focus({ preventScroll: true });
             this.lastFocusedElement = null;
         }
 

--- a/src/ui/save-menu/save-menu.ts
+++ b/src/ui/save-menu/save-menu.ts
@@ -163,7 +163,7 @@ export class SaveMenu {
             document.removeEventListener('keydown', this.keydownHandler);
 
             if (this.lastFocusedElement && typeof this.lastFocusedElement.focus === 'function') {
-                this.lastFocusedElement.focus();
+                this.lastFocusedElement.focus({ preventScroll: true });
                 this.lastFocusedElement = null;
             }
 
@@ -251,11 +251,11 @@ export class SaveMenu {
         if (wasFocusedInside && (!document.activeElement || document.activeElement === document.body)) {
             const activeTab = this.container.querySelector(`[role="tab"][aria-selected="true"]`) as HTMLElement;
             if (activeTab) {
-                activeTab.focus();
+                activeTab.focus({ preventScroll: true });
             } else {
                 // Fallback to first focusable element
                 const firstFocusable = this.container.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])') as HTMLElement;
-                if (firstFocusable) firstFocusable.focus();
+                if (firstFocusable) firstFocusable.focus({ preventScroll: true });
             }
         }
 
@@ -462,7 +462,7 @@ export class SaveMenu {
                     if (nextIndex < 0) nextIndex = tabs.length - 1;
 
                     const nextTab = tabs[nextIndex];
-                    nextTab.focus();
+                    nextTab.focus({ preventScroll: true });
 
                     const tabId = nextTab.dataset.tab as MenuTab;
                     if (tabId) {


### PR DESCRIPTION
This PR addresses UI bug #702 where the page was being forced to the bottom or experiencing jarring layout jumps when loading screens were dismissed or when navigating overlays. By passing `{ preventScroll: true }` to all programmatic `.focus()` calls, we maintain focus trapping and accessibility management without causing unwanted browser scrolling side-effects.

Changes:
- Replaced `.focus()` with `.focus({ preventScroll: true })` in `src/ui/loading-screen-ui.ts` and `loading-screen.ts`.
- Applied same fix to `src/core/input/input.ts` and `playlist-manager.ts`.
- Applied same fix to all modal overlay systems in `src/ui/`.

---
*PR created automatically by Jules for task [2585498667151648167](https://jules.google.com/task/2585498667151648167) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unwanted page scrolling when UI elements receive focus during menu transitions, playlist navigation, dialog dismissal, and keyboard navigation throughout the interface. Focus now restores more smoothly without disrupting the user's viewport position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->