### PR TITLE
⚡ Bolt: [TreeBatcher Direct Iteration]

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -73,3 +73,7 @@ Next Step: Review and continue clearing remaining items from `weekly_plan.md` or
 Status: Implemented ✅
 * Implementation Details: Audited remaining batchers (`wisteria-cluster.ts`, `glowing-flower-batcher.ts`, `dandelion-batcher.ts`, `arpeggio-batcher.ts`, `waterfall-batcher.ts`) for VRAM leaks. Introduced `_cachedMergedGeo` and `_cachedHitGeo` singletons in `createWisteriaCluster` to eliminate per-call geometry instantiation leaks. Added fully robust `dispose()` methods to all other tracked batchers to properly clean up `mesh.geometry`, `mesh.material`, and custom attributes like `mesh.instanceColor`. Marked task as complete in `weekly_plan.md`.
 Next Step: Provide next task or continue with REFACTORING_PLAN_REMAINING.md.
+
+Status: Implemented ✅
+* Implementation Details: Replaced `group.traverse()` calls in `src/foliage/tree-batcher.ts` registration methods (`registerBubbleWillow`, `registerBalloonBush`, `registerHelixPlant`, `registerFloweringTree`) with direct `for (let i = 0; i < group.children.length; i++)` iteration over `group.children`. This eliminates recursive function overhead and adheres to zero-allocation guidelines in shallow, known hierarchies.
+Next Step: Ask the user for the next task.

--- a/src/foliage/tree-batcher.ts
+++ b/src/foliage/tree-batcher.ts
@@ -650,7 +650,8 @@ export class TreeBatcher {
     }
 
     private registerBubbleWillow(group: THREE.Group, animType: number, animOffset: number) {
-        group.traverse(child => {
+        for (let i = 0; i < group.children.length; i++) {
+            const child = group.children[i];
             if ((child as THREE.Mesh).isMesh) {
                 const mesh = child as THREE.Mesh;
                 const mat = (Array.isArray(mesh.material) ? mesh.material[0] : mesh.material) as THREE.MeshStandardMaterial;
@@ -669,11 +670,12 @@ export class TreeBatcher {
                      mesh.visible = false;
                 }
             }
-        });
+        }
     }
 
     private registerBalloonBush(group: THREE.Group, animType: number, animOffset: number) {
-        group.traverse(child => {
+        for (let i = 0; i < group.children.length; i++) {
+            const child = group.children[i];
             if ((child as THREE.Mesh).isMesh) {
                 const mesh = child as THREE.Mesh;
                 const mat = (Array.isArray(mesh.material) ? mesh.material[0] : mesh.material) as THREE.MeshStandardMaterial;
@@ -687,11 +689,12 @@ export class TreeBatcher {
                     mesh.visible = false;
                 }
             }
-        });
+        }
     }
 
     private registerHelixPlant(group: THREE.Group, animType: number, animOffset: number) {
-        group.traverse(child => {
+        for (let i = 0; i < group.children.length; i++) {
+            const child = group.children[i];
             if ((child as THREE.Mesh).isMesh) {
                 const mesh = child as THREE.Mesh;
                 const mat = (Array.isArray(mesh.material) ? mesh.material[0] : mesh.material) as THREE.MeshStandardMaterial;
@@ -708,11 +711,12 @@ export class TreeBatcher {
                     mesh.visible = false;
                 }
             }
-        });
+        }
     }
 
     private registerFloweringTree(group: THREE.Group, animType: number, animOffset: number) {
-        group.traverse(child => {
+        for (let i = 0; i < group.children.length; i++) {
+            const child = group.children[i];
             if ((child as THREE.Mesh).isMesh) {
                 const mesh = child as THREE.Mesh;
                 const mat = (Array.isArray(mesh.material) ? mesh.material[0] : mesh.material) as THREE.MeshStandardMaterial;
@@ -730,7 +734,7 @@ export class TreeBatcher {
                 }
                 mesh.visible = false;
             }
-        });
+        }
     }
 
     getStats() {


### PR DESCRIPTION
⚡ Bolt: [TreeBatcher Direct Iteration]

**Bottleneck**: Recursive `group.traverse()` calls inside `tree-batcher.ts` registration methods incur unnecessary function allocation and overhead for shallow hierarchies.
**Fix**: Replaced `group.traverse()` with direct `for (let i = 0; i < group.children.length; i++)` iteration over `group.children` in `registerBubbleWillow`, `registerBalloonBush`, `registerHelixPlant`, and `registerFloweringTree`.
**Impact**: Eliminates recursive function overhead, maintaining the zero-allocation performance pattern during component registration.

---
*PR created automatically by Jules for task [17430658595111558570](https://jules.google.com/task/17430658595111558570) started by @ford442*