### PR TITLE
⚡ Bolt: Plug VRAM Leaks in Rendering & Batchers

### DIFF
--- a/src/core/main.ts
+++ b/src/core/main.ts
@@ -568,6 +568,14 @@ if (startButton) {
             const previewMushroom = (window as any).previewMushroom;
             if (typeof previewMushroom !== 'undefined' && previewMushroom) {
                 scene.remove(previewMushroom);
+                if (previewMushroom.geometry) previewMushroom.geometry.dispose();
+                if (previewMushroom.material) {
+                    if (Array.isArray(previewMushroom.material)) {
+                        previewMushroom.material.forEach((m: any) => m.dispose());
+                    } else {
+                        previewMushroom.material.dispose();
+                    }
+                }
                 previewMushroom.traverse((child: any) => {
                     const mesh = child as THREE.Mesh;
                     if (mesh.geometry) mesh.geometry.dispose();

--- a/src/foliage/luminous-plant-batcher.ts
+++ b/src/foliage/luminous-plant-batcher.ts
@@ -114,6 +114,31 @@ export class LuminousPlantBatcher {
 
         return id;
     }
+
+    dispose(): void {
+        if (this.mesh) {
+            if (this.mesh.geometry) {
+                this.mesh.geometry.dispose();
+                const phaseAttr = this.mesh.geometry.getAttribute('aPhaseOffset');
+                if (phaseAttr && typeof (phaseAttr as any).dispose === 'function') {
+                    try { (phaseAttr as any).dispose(); } catch(e) {}
+                }
+            }
+            if (this.mesh.material) {
+                if (Array.isArray(this.mesh.material)) {
+                    this.mesh.material.forEach(m => m.dispose());
+                } else {
+                    (this.mesh.material as any).dispose();
+                }
+            }
+            if (this.mesh.instanceColor && typeof (this.mesh.instanceColor as any).dispose === 'function') {
+                try { (this.mesh.instanceColor as any).dispose(); } catch (e) {}
+            }
+            if (this.mesh.instanceMatrix && typeof (this.mesh.instanceMatrix as any).dispose === 'function') {
+                try { (this.mesh.instanceMatrix as any).dispose(); } catch (e) {}
+            }
+        }
+    }
 }
 
 export const luminousPlantBatcher = new LuminousPlantBatcher(CONFIG.luminousPlants?.density || 150);

--- a/src/rendering/shader-warmup.ts
+++ b/src/rendering/shader-warmup.ts
@@ -298,6 +298,7 @@ export class ShaderWarmup {
         }
       }
 
+      if (mesh.geometry) mesh.geometry.dispose();
       scene.remove(mesh);
 
       if (mesh.instanceColor) {


### PR DESCRIPTION
⚡ Bolt: Plug VRAM leaks — add missing dispose() calls across rendering & batchers

Bottleneck: 
Multiple locations were removing meshes from the scene without calling `.dispose()` on their underlying geometry, materials, and buffer attributes. In long-running sessions, this causes VRAM leaks leading to stuttering, GC pressure, and out-of-memory crashes.

Fix:
1. `src/rendering/shader-warmup.ts`: Added missing `mesh.geometry.dispose()` before `scene.remove(mesh)`.
2. `src/core/main.ts`: Added explicit `previewMushroom.geometry.dispose()` and material cleanup for the root `previewMushroom` object before recursively traversing its children.
3. `src/foliage/luminous-plant-batcher.ts`: Added a comprehensive `dispose()` method to `LuminousPlantBatcher` that correctly cleans up its `InstancedMesh`, geometry, materials, and custom buffer attributes.

Impact:
Eliminates compounding GPU memory leaks when assets are hot-swapped, removed, or during map loads, greatly improving baseline memory stability.

---
*PR created automatically by Jules for task [11787457935445920748](https://jules.google.com/task/11787457935445920748) started by @ford442*