### PR TITLE
plan: weekly dispatch 2026-06-02 — Fix First (scene-loading regression)

### DIFF
--- a/weekly_plan.md
+++ b/weekly_plan.md
@@ -1,12 +1,17 @@
 # candy_world — Weekly Plan
 
 ## Today's focus
-**2026-05-26 — New Idea: Channel-to-Biome Visual Mapping Completeness.**
-Audit and wire every orphaned foliage/atmospheric batcher that currently has no channel-driven uniform:
-`aurora.ts`, `arpeggio.ts` / `arpeggio-batcher.ts`, `chromatic.ts`, `panning-pads.ts`, `silence-spirits.ts`,
-`waterfall-batcher.ts`, `musical_flora.ts`, `lake_features.ts`. Each batcher gets a `BiomeId` tag,
-an entry in `assets/music-bindings.json`, and at least one TSL uniform (noteColor / shimmer / hueShift)
-consumed from `getBiomeUniforms()`. Prefer reusing existing BiomeIds before adding new ones.
+**2026-06-02 — FIX FIRST: Root-cause the scene-loading / world-population regression (#1133).**
+Objects, foliage, and musical scenery frequently fail to appear on startup. A 10-issue cluster
+(#1133–#1142) was filed 2026-06-02 and `spawn-tracker.ts` + `window.__worldHealth` scaffolding has
+already landed on this branch; Copilot draft PR #1138 owns the telemetry/UI layer. Today's job is the
+*actual root cause*: why do `processMapEntity` (generation-core.ts) / `populateProceduralExtras`
+(generation-decorators.ts) / `background-processor.ts` / `deferred-loader.ts` silently drop spawns?
+Use the existing SpawnTracker report as ground truth — boot, read `window.__worldPopulationReport`,
+identify which types fail and why (null factory, throw, scheduling drop, generationToken race), fix the
+orchestration so a clean FULL boot reaches `failCount === 0` deterministically. Add a feature-flag
+guarantee so the world always boots to a usable state even when a heavy subsystem fails.
+No new feature work until full-world population is reliable.
 
 ## Ideas
 <!--
@@ -16,23 +21,20 @@ Format: - [ ] Short description (optional: more context on next line indented)
 Routine will mark picked items as "[in progress — YYYY-MM-DD]".
 -->
 - [ ] **Three.js ColorSpace enum regression** — In `src/core/init.js` we fall back to string literals (`'display-p3'`, `'srgb'`) for `outputColorSpace` because `THREE.DisplayP3ColorSpace` / `THREE.SRGBColorSpace` produced TS/build warnings with the current `three` version. When updating Three.js, revert to the proper enum. Opportunistic — activate when upgrading Three.js version, not a standalone sprint.
-- [completed — 2026-05-19] **Per-channel MOD note-color propagation from sky to foliage** — All three tasks completed sequentially:
-  - **A**: Sky Wave fully data-driven via target_biomes (luminous_plants added + visible effect).
-  - **B**: BiomeId + getBiomeUniforms() helper + tagging on creation + usage in 2 batchers + debug hook.
-  - **C**: ChannelData type completed (note + notes[]), portamento uTwilight explicitly wired + documented (backlog item closed), channel-range validation added in music-reactivity.
-  Smoke test reached "✓ Scene is ready!" + "No console errors" (partial run due to env timeout). WASM tests green. All changes are non-breaking.
-- [completed — 2026-05-26] **Channel-to-Biome visual mapping completeness** — Wire all orphaned batchers (aurora, arpeggio, chromatic, panning-pads, silence-spirits, waterfall, musical_flora, lake_features) to BiomeUniforms + music-bindings.json. Each batcher gets a BiomeId, at least one driven uniform, and a music-bindings.json entry.
-- [completed — 2026-05-30] **Sky wave → plant pose transitions** — Drive ADSR pose-state-machine transitions (`plant-pose-machine.ts`) from wave arrival timestamp rather than channel intensity alone; plants physically respond to the beat wave sweeping across the terrain.
-- [x] **TSL batcher geometry + VRAM audit** — Survey remaining batchers (wisteria-cluster, glowing-flower-batcher, dandelion-batcher, arpeggio-batcher, waterfall-batcher) for shared geometry patterns, missing `dispose()` calls, and VRAM leak potential matching the tree-batcher VRAM leak fix (PR #1075).
+
+<!-- Completed ideas archived to Done below (2026-05-19 sky→foliage propagation, 2026-05-26 channel-to-biome completeness, 2026-05-30 sky-wave→plant-pose, TSL/VRAM audit). -->
+- [ ] **Day/night plant behaviour** *(promoted to Copilot issue 2026-06-02 — see Backlog)* — Plants should physically open/glow by day and close/dim at night driven by the day/night cycle, not just music-channel intensity. Builds on `plant-pose-machine.ts`. Deferred behind the loading Fix First; queued for Copilot.
 
 ## Backlog
 <!--
 Unfinished items, known bugs, deferred ideas.
 Routine maintains this automatically — you can add items too.
 -->
-- [ ] **Review open draft PRs** — 5 drafts need eyes before merge: #817 (advanced instancing, LuminousPlantBatcher), #853 (portamento uTwilight — Copilot, already verified correct), #1081 (loading-screen module refactor), #1082 (ARIA mode selection + D-Pad), #1085 (scaleX progress bar animation). #853 is safe to merge immediately.
+- [ ] **🔴 LOADING REGRESSION CLUSTER (filed 2026-06-02)** — Scene/world population unreliable; objects, foliage, musical scenery frequently missing on startup. Parent: **#1133** (regression). Sub-tasks: **#1135** (visible progress + completion guarantee + error surfacing — umbrella), **#1136** (consolidate duplicated `LoadingScreen` class: `loading-screen.ts` vs `loading-screen-ui.ts`), **#1137** (SpawnTracker + visible error badge — *`spawn-tracker.ts` already in tree*), **#1139** (wire `BackgroundProcessor`/deferred queue into `LoadingManager`), **#1140** (post-deferred `validateWorldPopulation` + `window.__worldHealth`), **#1141** (smoke test FULL-mode + assert spawn counts), **#1142** ("Wait for full population" startup option + ETA). Today's kimi-cli Fix First targets the *root cause* in the generation/background orchestration.
+- [ ] **#1134 — Stable release / pinned-build process** — annotated tags + GitHub Releases for known-good states; feature flags to disable heavy subsystems so boot is always usable. Process decision, defer until loading is fixed.
+- [ ] **Open draft PR #1138 (Copilot)** — adds `spawn-tracker.ts` telemetry + visible failure badge + `window.__worldPopulationReport`; touches `generation-core.ts`, `generation-decorators.ts`, `background-processor.ts`, `deferred-loader.ts`, `loading-screen*.ts`. ⚠️ **Overlaps the kimi-cli Fix First files** — land or close #1138 before/early in the kimi loop, or have kimi build strictly on its telemetry (read, don't rewrite). (Stale draft-PR list #817/#853/#1081/#1082/#1085 cleared — all merged/closed; #853 & loading-screen/ARIA refactors are in `main`.)
 - [ ] Accessibility note: `Announcer` in `src/ui/announcer.ts` dynamically injects `aria-live` regions rather than relying on static HTML — future ARIA work should use the dynamic path, not add static tags.
-- [ ] **[ui bug — #702]** Auto-scroll on live site forces page to bottom on load, blocking top-row links. Separate: no links to external apps are clickable. Labeled "jules" on GitHub. Likely a `scroll-behavior` or `focus` side-effect from loading-screen dismissal.
+- [ ] **[ui bug — #702]** Auto-scroll forces page to bottom on load, blocking top-row links — *likely resolved* by `preventScroll: true` on all `.focus()` calls (commit 88f2bf3, PR #1125). Verify on live site, then close.
 - [ ] Three.js ColorSpace enum — opportunistic, activate when upgrading Three.js version (not a standalone sprint).
 
 ## Done
@@ -40,6 +42,8 @@ Routine maintains this automatically — you can add items too.
 Completed items, routine archives here with date.
 Prune occasionally when this gets long.
 -->
+- [x] **2026-05-30** Sky Wave → Plant Pose transitions — ADSR pose-state-machine (`plant-pose-machine.ts`) transitions driven by wave arrival timestamp; plants physically respond to the beat wave sweeping the terrain.
+- [x] **2026-05-30** TSL batcher geometry + VRAM audit — surveyed remaining batchers; added missing `dispose()` calls across rendering & batchers; KickDrumGeyserBatcher converted to InstancedMesh (PRs #1131, #1132; commits b9d73d3, 4bf8ff7, f22b152).
 - [x] **2026-05-26** Channel-to-Biome Visual Mapping Completeness — Wired orphaned batchers (aurora, arpeggio, chromatic, panning-pads, silence-spirits, waterfall, musical_flora, lake_features) to the music-reactivity pipeline via BiomeUniforms + music-bindings.json.
 - [x] **2026-05-26** Sky Wave Propagation — beat-driven color wave from `BiomeUniforms.skyMoon.moonNoteColor` down to foliage emissive uniforms; fully data-driven via `music-bindings.json sky_wave`; zero-allocation hot path; build green; WASM tests green.
 - [x] **2026-05-21** Portamento-batcher uTwilight fix (PR #853, Copilot) — `uTwilight` now properly multiplied into `twilightGlowTint` at line 155; emissive node includes `twilightGlowTint`; pattern matches `simple-flower-batcher.ts`.
@@ -68,7 +72,8 @@ Prune occasionally when this gets long.
 
 ## Last run
 <!-- Routine writes summary here each run. Overwrites previous. -->
-Date: 2026-05-26
-Mode: New Idea — Ideas list had no actionable items (Three.js ColorSpace was tagged opportunistic). Foundation stable: sky wave landed and verified, portamento fix confirmed in code (PR #853), main builds clean.
-Focus: Channel-to-Biome visual mapping completeness — wire all orphaned atmospheric/foliage batchers (aurora, arpeggio, chromatic, panning-pads, silence-spirits, waterfall, musical_flora, lake_features) to the music-reactivity pipeline via BiomeUniforms + music-bindings.json.
-Outcome: Successfully mapped all orphaned batchers to BiomeUniforms, added musical_flora and lake_features biomes to music-bindings.json and systems.
+Date: 2026-06-02
+Mode: FIX FIRST — last week's channel-to-biome / sky-wave / VRAM work all merged cleanly (moved to Done), but a 10-issue cluster (#1133–#1142) filed today flags an active foundation crack: full-world population is unreliable, objects/scenery silently missing on startup. No new feature work until boot is reliable.
+Focus: Root-cause the scene-loading regression (#1133) — find why `processMapEntity` / `populateProceduralExtras` / `background-processor` / `deferred-loader` drop spawns, fix the orchestration so a clean FULL boot reaches `failCount === 0`, and add a feature-flag fallback so the world always boots usable. SpawnTracker telemetry (already in tree) is the diagnostic substrate; Copilot PR #1138 owns the telemetry/UI layer (coordinate to avoid file collision).
+Outcome: <!-- fill in at end of day after kimi-cli loop -->
+Context gap: No access to recent_chats / conversation_search in this environment — prior-session reconstruction is from git history, open issues, weekly_plan.md, and .swarm-state.md only.


### PR DESCRIPTION
Weekly planner run for 2026-06-02. Updates `weekly_plan.md` only (no source changes).

**Mode:** Fix First. A 10-issue cluster (#1133–#1142) filed today flags an active foundation crack — full-world population is unreliable, objects/scenery silently missing on startup. Last week's channel-to-biome / sky-wave / VRAM work merged cleanly and was archived to Done.

**Changes to `weekly_plan.md`:**
- `Today's focus` → root-cause the scene-loading regression (#1133).
- Moved Sky-wave→plant-pose and TSL/VRAM audit into Done; cleared stale draft-PR review list.
- Backlog updated with the loading cluster, #1134 stable-release process, draft PR #1138 collision note, and #702 likely-resolved verification.
- `Last run` rewritten; flagged context gap (no recent_chats/conversation_search in this env).

Today's dispatch (kimi-cli swarm, Copilot issue, chat-model expansion prompts, Claude Code hygiene, Jules wrap-up template, review prompts) was delivered to Noah in chat.

https://claude.ai/code/session_01SCPmfZnLPGY6WSaY2HBwTb

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCPmfZnLPGY6WSaY2HBwTb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated planning documentation with revised focus areas and clarified task lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->