### PR TITLE
⚡ Bolt: [Performance Math and Batcher Array Optimizations]

### DIFF
--- a/src/foliage/kick-drum-geyser-batcher.ts
+++ b/src/foliage/kick-drum-geyser-batcher.ts
@@ -106,12 +106,15 @@ export class KickDrumGeyserBatcher {
         this.plumeMesh.count = this._count;
 
         // Apply Transform
-        proxy.updateMatrixWorld(true);
-        this.baseMesh.setMatrixAt(i, proxy.matrixWorld);
-        this.coreMesh.setMatrixAt(i, proxy.matrixWorld);
+        // ⚡ OPTIMIZATION: Bypassed THREE.Object3D proxy and setMatrixAt() overhead by writing directly to instanceMatrix
+        proxy.updateWorldMatrix(false, false);
+        const matrixArray = proxy.matrixWorld.elements;
 
-        // Plume will be scaled dynamically
-        this.plumeMesh.setMatrixAt(i, proxy.matrixWorld);
+        for (let j = 0; j < 16; j++) {
+            this.baseMesh.instanceMatrix.array[i * 16 + j] = matrixArray[j];
+            this.coreMesh.instanceMatrix.array[i * 16 + j] = matrixArray[j];
+            this.plumeMesh.instanceMatrix.array[i * 16 + j] = matrixArray[j]; // Plume will be scaled dynamically later
+        }
 
         this.baseMesh.instanceMatrix.needsUpdate = true;
         this.coreMesh.instanceMatrix.needsUpdate = true;
@@ -166,13 +169,30 @@ export class KickDrumGeyserBatcher {
 
             // Manual matrix composition for plume
             // Keep base transform, but scale Y axis
-            this._scratchMatrix.fromArray(baseArray, i * 16);
+            // ⚡ OPTIMIZATION: Bypassed Matrix4 composition overhead by directly modifying the Y-axis basis vector in the Float32Array
+            const scaleY = targetHeight + 0.01; // 0.01 to prevent singular matrix warning
+            const baseIndex = i * 16;
 
-            // Scale the y axis by targetHeight
-            this._scratchVec3.set(1, targetHeight + 0.01, 1); // 0.01 to prevent singular matrix warning
-            this._scratchMatrix.scale(this._scratchVec3);
+            plumeArray[baseIndex + 0] = baseArray[baseIndex + 0];
+            plumeArray[baseIndex + 1] = baseArray[baseIndex + 1];
+            plumeArray[baseIndex + 2] = baseArray[baseIndex + 2];
+            plumeArray[baseIndex + 3] = baseArray[baseIndex + 3];
 
-            this._scratchMatrix.toArray(plumeArray, i * 16);
+            // Scale Y-axis basis vector
+            plumeArray[baseIndex + 4] = baseArray[baseIndex + 4] * scaleY;
+            plumeArray[baseIndex + 5] = baseArray[baseIndex + 5] * scaleY;
+            plumeArray[baseIndex + 6] = baseArray[baseIndex + 6] * scaleY;
+            plumeArray[baseIndex + 7] = baseArray[baseIndex + 7] * scaleY;
+
+            plumeArray[baseIndex + 8] = baseArray[baseIndex + 8];
+            plumeArray[baseIndex + 9] = baseArray[baseIndex + 9];
+            plumeArray[baseIndex + 10] = baseArray[baseIndex + 10];
+            plumeArray[baseIndex + 11] = baseArray[baseIndex + 11];
+
+            plumeArray[baseIndex + 12] = baseArray[baseIndex + 12];
+            plumeArray[baseIndex + 13] = baseArray[baseIndex + 13];
+            plumeArray[baseIndex + 14] = baseArray[baseIndex + 14];
+            plumeArray[baseIndex + 15] = baseArray[baseIndex + 15];
         }
 
         this.plumeMesh.instanceMatrix.needsUpdate = true;

--- a/src/systems/music-reactivity.ts
+++ b/src/systems/music-reactivity.ts
@@ -149,12 +149,16 @@ const _skyWaveUniformMap: Record<string, { value: THREE.Color }> = {
 export interface ActiveWave { color: THREE.Color; timestamp: number; origin?: THREE.Vector3; speed?: number; }
 let _activeWave: ActiveWave | null = null;
 
-const _scratchWavePos = new THREE.Vector3();
+const _zeroVec = new THREE.Vector3();
 export function computeWaveTimeSinceArrival(plantWorldPos: THREE.Vector3, activeWave: ActiveWave | null, cameraPosition?: THREE.Vector3): number {
     if (!activeWave) return -999;
-    const origin = activeWave.origin || cameraPosition || new THREE.Vector3();
+    const origin = activeWave.origin || cameraPosition || _zeroVec;
     const speed = activeWave.speed || 25.0;
-    const distance = _scratchWavePos.copy(plantWorldPos).distanceTo(origin);
+    // ⚡ OPTIMIZATION: Bypassed THREE.Vector3.distanceTo() overhead in hot loop with raw math
+    const dx = plantWorldPos.x - origin.x;
+    const dy = plantWorldPos.y - origin.y;
+    const dz = plantWorldPos.z - origin.z;
+    const distance = Math.sqrt(dx * dx + dy * dy + dz * dz);
     const arrivalTime = activeWave.timestamp + (distance / speed) * 1000;
     return (performance.now() - arrivalTime) / 1000;
 }


### PR DESCRIPTION
Bottleneck: Was executing `distanceTo()` inside a high-frequency `O(N)` loop per-plant update, and `KickDrumGeyserBatcher` was using expensive `setMatrixAt` and `Matrix4` operations for base composition and scaling per instance.

Fix: 
- Converted `computeWaveTimeSinceArrival` to use raw inline mathematics to calculate distance, preventing `Vector3` creations and `.copy()` calls.
- Converted `KickDrumGeyserBatcher` to use direct `Float32Array` accesses: mapping `proxy.matrixWorld.elements` values directly to bypass `.setMatrixAt()`, and modifying the Y-axis scale directly into the `Float32Array` column rather than using `Matrix4.scale()`.

Impact: Eliminated CPU math bottlenecks and GC spikes caused by temporary variables and Object3D proxy iteration overheads, improving the zero-allocation pattern within the hot rendering loop.

---
*PR created automatically by Jules for task [4201825542586507803](https://jules.google.com/task/4201825542586507803) started by @ford442*