### PR TITLE
♿ Aria: [UX improvement] - Map Tactile Feedback to ARIA States

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,19 +141,19 @@
         #btn-full-game[aria-pressed="true"] { box-shadow: 0 5px 18px rgba(125, 211, 252, 0.55); }
         #btn-fast-full[aria-pressed="true"] { box-shadow: 0 5px 18px rgba(165, 214, 167, 0.7); }
         .cta-button:active,
-        .cta-button.pressed,
+        .cta-button[aria-pressed="true"],
         .toggle-button:active,
-        .toggle-button.pressed,
+        .toggle-button[aria-pressed="true"],
         .secondary-button:active,
-        .secondary-button.pressed,
+        .secondary-button[aria-pressed="true"],
         .playlist-btn:active,
-        .playlist-btn.pressed,
+        .playlist-btn[aria-pressed="true"],
         .close-icon-btn:active,
-        .close-icon-btn.pressed,
+        .close-icon-btn[aria-pressed="true"],
         .file-label:active,
-        .file-label.pressed,
+        .file-label[aria-pressed="true"],
         .playlist-remove-btn:active,
-        .playlist-remove-btn.pressed {
+        .playlist-remove-btn[aria-pressed="true"] {
             transform: scale(0.95);
             transition-duration: 0.05s;
         }

--- a/src/core/input/input-types.ts
+++ b/src/core/input/input-types.ts
@@ -42,10 +42,10 @@ export function triggerAbility(
     element?: HTMLElement | null
 ): void {
     keyStates[ability] = true;
-    if (element) element.classList.add('pressed');
+    if (element) element.setAttribute('aria-pressed', 'true');
     setTimeout(() => {
         keyStates[ability] = false;
-        if (element) element.classList.remove('pressed');
+        if (element) element.setAttribute('aria-pressed', 'false');
     }, 100);
 }
 

--- a/src/core/input/input.ts
+++ b/src/core/input/input.ts
@@ -392,8 +392,8 @@ export function initInput(
                 event.preventDefault();
                 const closePlaylistBtn = document.getElementById('closePlaylistBtn');
                 if (closePlaylistBtn) {
-                    closePlaylistBtn.classList.add('pressed');
-                    setTimeout(() => closePlaylistBtn.classList.remove('pressed'), 150);
+                    closePlaylistBtn.setAttribute('aria-pressed', 'true');
+                    setTimeout(() => closePlaylistBtn.setAttribute('aria-pressed', 'false'), 150);
                 }
                 togglePlaylist();
                 return;
@@ -504,12 +504,12 @@ export function initInput(
             case 'KeyD': keyStates.right = true; break;
             case 'KeyF':
                 keyStates.action = true;
-                if (hudMine) hudMine.classList.add('pressed');
+                if (hudMine) hudMine.setAttribute('aria-pressed', 'true');
                 break; // Jitter Mine Ability
             case 'KeyE':
             case 'e':
                 keyStates.dash = true;
-                if (hudDash) hudDash.classList.add('pressed');
+                if (hudDash) hudDash.setAttribute('aria-pressed', 'true');
                 break; // Dash Ability
             case 'KeyX':
             case 'x':
@@ -518,7 +518,7 @@ export function initInput(
             case 'KeyZ':
             case 'z':
                 keyStates.phase = true;
-                if (hudPhase) hudPhase.classList.add('pressed');
+                if (hudPhase) hudPhase.setAttribute('aria-pressed', 'true');
                 break; // Phase Shift Ability
             case 'KeyC':
             case 'c':
@@ -599,12 +599,12 @@ export function initInput(
             case 'KeyD': keyStates.right = false; break;
             case 'KeyF':
                 keyStates.action = false;
-                if (hudMine) hudMine.classList.remove('pressed');
+                if (hudMine) hudMine.setAttribute('aria-pressed', 'false');
                 break;
             case 'KeyE':
             case 'e':
                 keyStates.dash = false;
-                if (hudDash) hudDash.classList.remove('pressed');
+                if (hudDash) hudDash.setAttribute('aria-pressed', 'false');
                 break;
             case 'KeyX':
             case 'x':
@@ -613,7 +613,7 @@ export function initInput(
             case 'KeyZ':
             case 'z':
                 keyStates.phase = false;
-                if (hudPhase) hudPhase.classList.remove('pressed');
+                if (hudPhase) hudPhase.setAttribute('aria-pressed', 'false');
                 break;
             case 'KeyR':
             case 'r':
@@ -653,14 +653,14 @@ const buttonPressTimeouts = new Map<string, NodeJS.Timeout | number>();
 function triggerButtonPress(buttonId: string): void {
     const btn = document.getElementById(buttonId);
     if (btn && btn.getAttribute('aria-disabled') !== 'true') {
-        btn.classList.add('pressed');
+        btn.setAttribute('aria-pressed', 'true');
 
         if (buttonPressTimeouts.has(buttonId)) {
             clearTimeout(buttonPressTimeouts.get(buttonId) as any);
         }
 
         const timeoutId = setTimeout(() => {
-            btn.classList.remove('pressed');
+            btn.setAttribute('aria-pressed', 'false');
             buttonPressTimeouts.delete(buttonId);
         }, 150);
 
@@ -689,13 +689,13 @@ function triggerButtonPress(buttonId: string): void {
     const dpadPress = (dir: DpadDirection, btn: HTMLElement) => {
         dpadHeld.add(dir);
         keyStates[dir] = true;
-        btn.classList.add('dpad-pressed');
+        btn.setAttribute('aria-pressed', 'true');
     };
 
     const dpadRelease = (dir: DpadDirection, btn: HTMLElement) => {
         dpadHeld.delete(dir);
         keyStates[dir] = false;
-        btn.classList.remove('dpad-pressed');
+        btn.setAttribute('aria-pressed', 'false');
     };
 
     for (const [id, dir] of Object.entries(dpadMap)) {

--- a/src/core/input/playlist-manager.ts
+++ b/src/core/input/playlist-manager.ts
@@ -530,8 +530,8 @@ export function handlePlaylistKeyDown(event: KeyboardEvent): boolean {
     if (event.code === 'KeyQ') {
         event.preventDefault();
         if (closePlaylistBtn) {
-            closePlaylistBtn.classList.add('pressed');
-            setTimeout(() => closePlaylistBtn.classList.remove('pressed'), 150);
+            closePlaylistBtn.setAttribute('aria-pressed', 'true');
+            setTimeout(() => closePlaylistBtn.setAttribute('aria-pressed', 'false'), 150);
         }
         togglePlaylist();
         return true;
@@ -542,8 +542,8 @@ export function handlePlaylistKeyDown(event: KeyboardEvent): boolean {
         const playlistInput = document.getElementById('playlistUploadInput') as HTMLInputElement;
         const addSongsBtnEl = document.getElementById('addSongsBtn');
         if (addSongsBtnEl) {
-            addSongsBtnEl.classList.add('pressed');
-            setTimeout(() => addSongsBtnEl.classList.remove('pressed'), 150);
+            addSongsBtnEl.setAttribute('aria-pressed', 'true');
+            setTimeout(() => addSongsBtnEl.setAttribute('aria-pressed', 'false'), 150);
         }
         if (playlistInput) playlistInput.click();
         return true;

--- a/style.css
+++ b/style.css
@@ -355,7 +355,7 @@ body.a11y-motion-reduced .spinner {
 }
 
 .ability-slot[aria-disabled="false"]:not([aria-pressed="true"]):active,
-.ability-slot.pressed {
+.ability-slot[aria-pressed="true"] {
     transform: scale(0.9);
     border-color: #FF4081; /* High contrast feedback */
     box-shadow: 0 0 10px rgba(255, 64, 129, 0.5);
@@ -536,14 +536,14 @@ kbd.key.key-highlight {
     box-shadow: 0 0 0 3px #ffffff, 0 0 0 6px #FF4081;
 }
 
-.dpad-btn.dpad-pressed,
+.dpad-btn[aria-pressed="true"],
 .dpad-btn:active {
     background: rgba(255, 100, 150, 0.90);
     transform: scale(0.92);
     box-shadow: 0 2px 8px rgba(255, 107, 107, 0.35), inset 0 1px 0 rgba(255,255,255,0.4);
 }
 
-.dpad-btn.dpad-pressed svg {
+.dpad-btn[aria-pressed="true"] svg {
     fill: #ffffff;
 }
 
@@ -576,12 +576,12 @@ kbd.key.key-highlight {
 }
 
 /* 🎨 Palette: Keyboard tactile feedback */
-.action-btn.pressed,
-button.pressed,
-.icon-btn.pressed,
-.secondary-button.pressed,
-.cta-button.pressed,
-.file-label.pressed {
+.action-btn[aria-pressed="true"],
+button[aria-pressed="true"],
+.icon-btn[aria-pressed="true"],
+.secondary-button[aria-pressed="true"],
+.cta-button[aria-pressed="true"],
+.file-label[aria-pressed="true"] {
     transform: scale(0.95) !important;
     filter: brightness(0.9) !important;
     transition-duration: 0.05s !important;


### PR DESCRIPTION
## ♿ Aria: Tactile Feedback ARIA State Mapping

### 💡 What
Refactored the tactile visual feedback system (scale down on press) for UI elements to use the standard `[aria-pressed="true"]` attribute instead of custom `.pressed` and `.dpad-pressed` CSS classes.

### 🎯 Why
This adheres to the project's UX Coding Standards which dictate that visual styling for UI element states should be tied directly to their corresponding ARIA attributes. This removes redundant class manipulation in JavaScript, simplifies the CSS, and ensures the visual "pressed" state is always synchronized with the semantic accessibility state.

### ♿ Accessibility
Instead of manually appending and removing custom state classes, standard `[aria-pressed="true"]` and `[aria-pressed="false"]` attributes are updated dynamically when interacting with abilities, jukebox buttons, and D-pad controls. This improves keyboard and screen-reader context while preserving the visual "Game Feel" tactile scaling.

**Note:** E2E Playwright tests were skipped as per discussion due to a pre-existing infrastructure issue (`chromium_headless_shell-1223` binary mismatch). `npm run build` and `npm run test:wasm` completed successfully.

---
*PR created automatically by Jules for task [3148739456907146869](https://jules.google.com/task/3148739456907146869) started by @ford442*