### PR TITLE
♿ Aria: [Volume Buttons Keyboard UX Feedback]

### DIFF
--- a/src/core/input/audio-controls.ts
+++ b/src/core/input/audio-controls.ts
@@ -153,4 +153,11 @@ export function handleMuteKey(): void {
  */
 export function handleVolumeKey(delta: number): void {
     adjustVolume(delta);
+
+    // Provide visual feedback for keyboard interaction
+    const btn = delta > 0 ? volUpBtn : volDownBtn;
+    if (btn && btn.getAttribute('aria-disabled') !== 'true') {
+        btn.setAttribute('aria-pressed', 'true');
+        setTimeout(() => btn.setAttribute('aria-pressed', 'false'), 150);
+    }
 }

--- a/src/core/input/audio-controls.ts
+++ b/src/core/input/audio-controls.ts
@@ -148,16 +148,28 @@ export function handleMuteKey(): void {
     toggleMute();
 }
 
+// Timers for visual feedback
+let volUpTimeout: ReturnType<typeof setTimeout> | null = null;
+let volDownTimeout: ReturnType<typeof setTimeout> | null = null;
+
 /**
  * Handle volume adjustment keys (+/-)
  */
 export function handleVolumeKey(delta: number): void {
     adjustVolume(delta);
+    if (delta === 0) return;
 
     // Provide visual feedback for keyboard interaction
     const btn = delta > 0 ? volUpBtn : volDownBtn;
     if (btn && btn.getAttribute('aria-disabled') !== 'true') {
-        btn.setAttribute('aria-pressed', 'true');
-        setTimeout(() => btn.setAttribute('aria-pressed', 'false'), 150);
+        btn.classList.add('keyboard-active');
+
+        if (delta > 0) {
+            if (volUpTimeout) clearTimeout(volUpTimeout);
+            volUpTimeout = setTimeout(() => btn.classList.remove('keyboard-active'), 150);
+        } else {
+            if (volDownTimeout) clearTimeout(volDownTimeout);
+            volDownTimeout = setTimeout(() => btn.classList.remove('keyboard-active'), 150);
+        }
     }
 }

--- a/src/foliage/mushroom-batcher.ts
+++ b/src/foliage/mushroom-batcher.ts
@@ -563,7 +563,6 @@ private createMaterials(): MeshStandardNodeMaterial[] {
 
     return [stemMat, capMat, gillMat, spotMat, eyeMat, pupilMat, mouthMat, cheekMat];
 }
-    }
     register(dummy: THREE.Object3D, options: any) {
         if (!this.initialized) this.init();
         if (this.count >= MAX_MUSHROOMS) return;

--- a/style.css
+++ b/style.css
@@ -617,6 +617,7 @@ button[aria-pressed="true"],
 
 /* 🎨 Palette: Tactile feedback on interactive elements */
 .toggle-button:not([aria-disabled="true"]):active,
+.toggle-button.keyboard-active,
 .cta-button:not([aria-disabled="true"]):active,
 .secondary-button:not([aria-disabled="true"]):active,
 .close-icon-btn:not([aria-disabled="true"]):active,


### PR DESCRIPTION
- Added `.keyboard-active` class to volume up/down buttons when triggered via `+`/`-` keyboard shortcuts.
- Class mimics the existing `:active` visual state for consistency.
- Avoids using `aria-pressed` toggling to prevent screen reader spam on non-toggle buttons.
- Improves keyboard accessibility and discoverability for volume controls.

---
*PR created automatically by Jules for task [13692338957224369778](https://jules.google.com/task/13692338957224369778) started by @ford442*