### PR TITLE
🎨 Palette: [Accessibility Polish] Fix momentary ARIA states

### DIFF
--- a/src/ui/accessibility-menu-rendering.ts
+++ b/src/ui/accessibility-menu-rendering.ts
@@ -102,8 +102,8 @@ export class AccessibilityMenuRendering extends AccessibilityMenuCore {
       font-size: 1.2rem;
     `;
     closeBtn.onclick = () => {
-      closeBtn.setAttribute('aria-pressed', 'true');
-      setTimeout(() => closeBtn.setAttribute('aria-pressed', 'false'), 150);
+      closeBtn.classList.add('keyboard-active');
+      setTimeout(() => closeBtn.classList.remove('keyboard-active'), 150);
       this.close();
     };
     closeBtn.setAttribute('aria-label', 'Close accessibility menu');

--- a/src/ui/accessibility-menu.css
+++ b/src/ui/accessibility-menu.css
@@ -42,7 +42,8 @@
 .a11y-preset-card:active,
 .a11y-preset-card[aria-pressed="true"],
 .a11y-close-btn:active,
-.a11y-close-btn[aria-pressed="true"] {
+.a11y-close-btn[aria-pressed="true"],
+.a11y-close-btn.keyboard-active {
     transform: scale(0.95);
     transition-duration: 0.05s;
 }


### PR DESCRIPTION
This PR implements an accessibility and visual polish pass on the Accessibility Menu.

Changes:
- Removed the accessibility anti-pattern of rapidly toggling `aria-pressed` to `true` then `false` within 150ms just to trigger an `:active` CSS animation scale.
- Replaced the logic to add a temporary `keyboard-active` CSS class instead.
- Updated `src/ui/accessibility-menu.css` to map the new `.keyboard-active` class to the existing `transform: scale(0.95)` animation.

This preserves the "Juice" and Game Feel of momentary tactile button feedback while adhering strictly to ARIA guidelines.

---
*PR created automatically by Jules for task [17957674545658205479](https://jules.google.com/task/17957674545658205479) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard interaction visual feedback for the accessibility menu close button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->