### PR TITLE
♿ Aria: [UX improvement] Fix aria-pressed anti-pattern

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,14 +132,14 @@
         #btn-full-game:hover, #btn-full-game:focus-visible { background: #38bdf8; }
         #btn-fast-full:hover, #btn-fast-full:focus-visible { background: #81c784; }
 
-        .mode-btn[aria-pressed="true"] {
+        .mode-btn.keyboard-active {
             border-color: #fff;
             transform: scale(1.1);
             box-shadow: 0 4px 15px rgba(0,0,0,0.2);
         }
-        #btn-core-only[aria-pressed="true"] { box-shadow: 0 5px 18px rgba(255, 158, 205, 0.7); }
-        #btn-full-game[aria-pressed="true"] { box-shadow: 0 5px 18px rgba(125, 211, 252, 0.55); }
-        #btn-fast-full[aria-pressed="true"] { box-shadow: 0 5px 18px rgba(165, 214, 167, 0.7); }
+        #btn-core-only.keyboard-active { box-shadow: 0 5px 18px rgba(255, 158, 205, 0.7); }
+        #btn-full-game.keyboard-active { box-shadow: 0 5px 18px rgba(125, 211, 252, 0.55); }
+        #btn-fast-full.keyboard-active { box-shadow: 0 5px 18px rgba(165, 214, 167, 0.7); }
 
         /* Custom Checkbox for Wait Full Option */
         .custom-checkbox {
@@ -190,19 +190,19 @@
         }
 
         .cta-button:active,
-        .cta-button[aria-pressed="true"],
+        .cta-button.keyboard-active,
         .toggle-button:active,
-        .toggle-button[aria-pressed="true"],
+        .toggle-button.keyboard-active, .toggle-button[aria-pressed="true"],
         .secondary-button:active,
-        .secondary-button[aria-pressed="true"],
+        .secondary-button.keyboard-active,
         .playlist-btn:active,
-        .playlist-btn[aria-pressed="true"],
+        .playlist-btn.keyboard-active,
         .close-icon-btn:active,
-        .close-icon-btn[aria-pressed="true"],
+        .close-icon-btn.keyboard-active,
         .file-label:active,
-        .file-label[aria-pressed="true"],
+        .file-label.keyboard-active,
         .playlist-remove-btn:active,
-        .playlist-remove-btn[aria-pressed="true"] {
+        .playlist-remove-btn.keyboard-active {
             transform: scale(0.95);
             transition-duration: 0.05s;
         }

--- a/src/core/input/input-types.ts
+++ b/src/core/input/input-types.ts
@@ -42,10 +42,10 @@ export function triggerAbility(
     element?: HTMLElement | null
 ): void {
     keyStates[ability] = true;
-    if (element) element.setAttribute('aria-pressed', 'true');
+    if (element) element.classList.add('keyboard-active');
     setTimeout(() => {
         keyStates[ability] = false;
-        if (element) element.setAttribute('aria-pressed', 'false');
+        if (element) element.classList.remove('keyboard-active');
     }, 100);
 }
 

--- a/src/core/input/input.ts
+++ b/src/core/input/input.ts
@@ -392,8 +392,8 @@ export function initInput(
                 event.preventDefault();
                 const closePlaylistBtn = document.getElementById('closePlaylistBtn');
                 if (closePlaylistBtn) {
-                    closePlaylistBtn.setAttribute('aria-pressed', 'true');
-                    setTimeout(() => closePlaylistBtn.setAttribute('aria-pressed', 'false'), 150);
+                    closePlaylistBtn.classList.add('keyboard-active');
+                    setTimeout(() => closePlaylistBtn.classList.remove('keyboard-active'), 150);
                 }
                 togglePlaylist();
                 return;
@@ -504,12 +504,12 @@ export function initInput(
             case 'KeyD': keyStates.right = true; break;
             case 'KeyF':
                 keyStates.action = true;
-                if (hudMine) hudMine.setAttribute('aria-pressed', 'true');
+                if (hudMine) hudMine.classList.add('keyboard-active');
                 break; // Jitter Mine Ability
             case 'KeyE':
             case 'e':
                 keyStates.dash = true;
-                if (hudDash) hudDash.setAttribute('aria-pressed', 'true');
+                if (hudDash) hudDash.classList.add('keyboard-active');
                 break; // Dash Ability
             case 'KeyX':
             case 'x':
@@ -518,7 +518,7 @@ export function initInput(
             case 'KeyZ':
             case 'z':
                 keyStates.phase = true;
-                if (hudPhase) hudPhase.setAttribute('aria-pressed', 'true');
+                if (hudPhase) hudPhase.classList.add('keyboard-active');
                 break; // Phase Shift Ability
             case 'KeyC':
             case 'c':
@@ -599,12 +599,12 @@ export function initInput(
             case 'KeyD': keyStates.right = false; break;
             case 'KeyF':
                 keyStates.action = false;
-                if (hudMine) hudMine.setAttribute('aria-pressed', 'false');
+                if (hudMine) hudMine.classList.remove('keyboard-active');
                 break;
             case 'KeyE':
             case 'e':
                 keyStates.dash = false;
-                if (hudDash) hudDash.setAttribute('aria-pressed', 'false');
+                if (hudDash) hudDash.classList.remove('keyboard-active');
                 break;
             case 'KeyX':
             case 'x':
@@ -613,7 +613,7 @@ export function initInput(
             case 'KeyZ':
             case 'z':
                 keyStates.phase = false;
-                if (hudPhase) hudPhase.setAttribute('aria-pressed', 'false');
+                if (hudPhase) hudPhase.classList.remove('keyboard-active');
                 break;
             case 'KeyR':
             case 'r':
@@ -653,14 +653,14 @@ const buttonPressTimeouts = new Map<string, NodeJS.Timeout | number>();
 function triggerButtonPress(buttonId: string): void {
     const btn = document.getElementById(buttonId);
     if (btn && btn.getAttribute('aria-disabled') !== 'true') {
-        btn.setAttribute('aria-pressed', 'true');
+        btn.classList.add('keyboard-active');
 
         if (buttonPressTimeouts.has(buttonId)) {
             clearTimeout(buttonPressTimeouts.get(buttonId) as any);
         }
 
         const timeoutId = setTimeout(() => {
-            btn.setAttribute('aria-pressed', 'false');
+            btn.classList.remove('keyboard-active');
             buttonPressTimeouts.delete(buttonId);
         }, 150);
 
@@ -689,13 +689,13 @@ function triggerButtonPress(buttonId: string): void {
     const dpadPress = (dir: DpadDirection, btn: HTMLElement) => {
         dpadHeld.add(dir);
         keyStates[dir] = true;
-        btn.setAttribute('aria-pressed', 'true');
+        btn.classList.add('keyboard-active');
     };
 
     const dpadRelease = (dir: DpadDirection, btn: HTMLElement) => {
         dpadHeld.delete(dir);
         keyStates[dir] = false;
-        btn.setAttribute('aria-pressed', 'false');
+        btn.classList.remove('keyboard-active');
     };
 
     for (const [id, dir] of Object.entries(dpadMap)) {

--- a/src/core/input/playlist-manager.ts
+++ b/src/core/input/playlist-manager.ts
@@ -530,8 +530,8 @@ export function handlePlaylistKeyDown(event: KeyboardEvent): boolean {
     if (event.code === 'KeyQ') {
         event.preventDefault();
         if (closePlaylistBtn) {
-            closePlaylistBtn.setAttribute('aria-pressed', 'true');
-            setTimeout(() => closePlaylistBtn.setAttribute('aria-pressed', 'false'), 150);
+            closePlaylistBtn.classList.add('keyboard-active');
+            setTimeout(() => closePlaylistBtn.classList.remove('keyboard-active'), 150);
         }
         togglePlaylist();
         return true;
@@ -542,8 +542,8 @@ export function handlePlaylistKeyDown(event: KeyboardEvent): boolean {
         const playlistInput = document.getElementById('playlistUploadInput') as HTMLInputElement;
         const addSongsBtnEl = document.getElementById('addSongsBtn');
         if (addSongsBtnEl) {
-            addSongsBtnEl.setAttribute('aria-pressed', 'true');
-            setTimeout(() => addSongsBtnEl.setAttribute('aria-pressed', 'false'), 150);
+            addSongsBtnEl.classList.add('keyboard-active');
+            setTimeout(() => addSongsBtnEl.classList.remove('keyboard-active'), 150);
         }
         if (playlistInput) playlistInput.click();
         return true;

--- a/src/ui/accessibility-menu-rendering.ts
+++ b/src/ui/accessibility-menu-rendering.ts
@@ -102,8 +102,8 @@ export class AccessibilityMenuRendering extends AccessibilityMenuCore {
       font-size: 1.2rem;
     `;
     closeBtn.onclick = () => {
-      closeBtn.setAttribute('aria-pressed', 'true');
-      setTimeout(() => closeBtn.setAttribute('aria-pressed', 'false'), 150);
+      closeBtn.classList.add('keyboard-active');
+      setTimeout(() => closeBtn.classList.remove('keyboard-active'), 150);
       this.close();
     };
     closeBtn.setAttribute('aria-label', 'Close accessibility menu');
@@ -172,8 +172,8 @@ export class AccessibilityMenuRendering extends AccessibilityMenuCore {
         text-align: left;
       `;
       tab.onclick = () => {
-        tab.setAttribute('aria-pressed', 'true');
-        setTimeout(() => tab.setAttribute('aria-pressed', 'false'), 150);
+        tab.classList.add('keyboard-active');
+        setTimeout(() => tab.classList.remove('keyboard-active'), 150);
         this.switchSection(section as MenuSection);
       };
 
@@ -355,8 +355,8 @@ export class AccessibilityMenuRendering extends AccessibilityMenuCore {
       btn.textContent = binding.key || 'Unbound';
       btn.style.cssText = `${this.getButtonStyle()} width: 120px;`;
       btn.onclick = () => {
-        btn.setAttribute('aria-pressed', 'true');
-        setTimeout(() => btn.setAttribute('aria-pressed', 'false'), 150);
+        btn.classList.add('keyboard-active');
+        setTimeout(() => btn.classList.remove('keyboard-active'), 150);
         this.startKeyRebind(action, btn);
       };
 

--- a/src/ui/accessibility-menu.css
+++ b/src/ui/accessibility-menu.css
@@ -36,13 +36,13 @@
 
 /* 🎨 Palette: "Game Feel" Active Pressed State */
 .a11y-tab:active,
-.a11y-tab[aria-pressed="true"],
+.a11y-tab.keyboard-active,
 .a11y-button:active,
-.a11y-button[aria-pressed="true"],
+.a11y-button.keyboard-active,
 .a11y-preset-card:active,
-.a11y-preset-card[aria-pressed="true"],
+.a11y-preset-card.keyboard-active,
 .a11y-close-btn:active,
-.a11y-close-btn[aria-pressed="true"] {
+.a11y-close-btn.keyboard-active {
     transform: scale(0.95);
     transition-duration: 0.05s;
 }

--- a/style.css
+++ b/style.css
@@ -309,7 +309,7 @@ body.a11y-motion-reduced .spinner {
 }
 
 /* Ready State */
-.ability-slot[aria-disabled="false"]:not([aria-pressed="true"]) {
+.ability-slot[aria-disabled="false"]:not(.keyboard-active) {
     border-color: #4CAF50;
     box-shadow: 0 0 15px rgba(76, 175, 80, 0.5);
     background: #ffffff;
@@ -324,7 +324,7 @@ body.a11y-motion-reduced .spinner {
 }
 
 /* 🎨 Palette: Active State (Duration Running) */
-.ability-slot[aria-pressed="true"] {
+.ability-slot.keyboard-active {
     border-color: #D500F9;
     box-shadow: 0 0 15px rgba(213, 0, 249, 0.6);
     background: #F3E5F5;
@@ -348,14 +348,14 @@ body.a11y-motion-reduced .spinner {
     pointer-events: none;
 }
 
-.ability-slot[aria-disabled="false"]:not([aria-pressed="true"]) .ability-icon {
+.ability-slot[aria-disabled="false"]:not(.keyboard-active) .ability-icon {
     filter: grayscale(0%);
     opacity: 1;
     transform: scale(1.1);
 }
 
-.ability-slot[aria-disabled="false"]:not([aria-pressed="true"]):active,
-.ability-slot[aria-pressed="true"] {
+.ability-slot[aria-disabled="false"]:not(.keyboard-active):active,
+.ability-slot.keyboard-active {
     transform: scale(0.9);
     border-color: #FF4081; /* High contrast feedback */
     box-shadow: 0 0 10px rgba(255, 64, 129, 0.5);
@@ -364,7 +364,7 @@ body.a11y-motion-reduced .spinner {
 
 /* 🎨 Palette: Pressed State */
 /* Visually differentiates active toggle buttons (e.g., Muted, Night Mode) */
-.toggle-button[aria-pressed="true"],
+.toggle-button[aria-pressed="true"], .toggle-button.keyboard-active,
 .toggle-button[aria-expanded="true"] {
     background: #FF4081; /* Higher contrast active color */
     box-shadow: inset 0 2px 5px rgba(0,0,0,0.2);
@@ -372,7 +372,7 @@ body.a11y-motion-reduced .spinner {
     padding: 8px 18px; /* Offset border to prevent layout shift */
 }
 
-.toggle-button[aria-pressed="true"]:hover,
+.toggle-button[aria-pressed="true"]:hover, .toggle-button.keyboard-active:hover,
 .toggle-button[aria-expanded="true"]:hover {
     background: #F50057;
 }
@@ -536,14 +536,14 @@ kbd.key.key-highlight {
     box-shadow: 0 0 0 3px #ffffff, 0 0 0 6px #FF4081;
 }
 
-.dpad-btn[aria-pressed="true"],
+.dpad-btn.keyboard-active,
 .dpad-btn:active {
     background: rgba(255, 100, 150, 0.90);
     transform: scale(0.92);
     box-shadow: 0 2px 8px rgba(255, 107, 107, 0.35), inset 0 1px 0 rgba(255,255,255,0.4);
 }
 
-.dpad-btn[aria-pressed="true"] svg {
+.dpad-btn.keyboard-active svg {
     fill: #ffffff;
 }
 
@@ -576,12 +576,12 @@ kbd.key.key-highlight {
 }
 
 /* 🎨 Palette: Keyboard tactile feedback */
-.action-btn[aria-pressed="true"],
-button[aria-pressed="true"],
-.icon-btn[aria-pressed="true"],
-.secondary-button[aria-pressed="true"],
-.cta-button[aria-pressed="true"],
-.file-label[aria-pressed="true"] {
+.action-btn.keyboard-active,
+button.keyboard-active,
+.icon-btn.keyboard-active,
+.secondary-button.keyboard-active,
+.cta-button.keyboard-active,
+.file-label.keyboard-active {
     transform: scale(0.95) !important;
     filter: brightness(0.9) !important;
     transition-duration: 0.05s !important;
@@ -608,10 +608,10 @@ button[aria-pressed="true"],
 }
 
 /* ♿ Aria: Mode Selection ARIA States */
-#btn-core-only[aria-pressed="true"] {
+#btn-core-only.keyboard-active {
     box-shadow: 0 5px 18px rgba(255, 156, 205, 0.55);
 }
-#btn-full-game[aria-pressed="true"] {
+#btn-full-game.keyboard-active {
     box-shadow: 0 5px 18px rgba(125, 211, 252, 0.55);
 }
 

--- a/style.css
+++ b/style.css
@@ -364,7 +364,7 @@ body.a11y-motion-reduced .spinner {
 
 /* 🎨 Palette: Pressed State */
 /* Visually differentiates active toggle buttons (e.g., Muted, Night Mode) */
-.toggle-button[aria-pressed="true"], .toggle-button.keyboard-active,
+.toggle-button.keyboard-active, .toggle-button.keyboard-active,
 .toggle-button[aria-expanded="true"] {
     background: #FF4081; /* Higher contrast active color */
     box-shadow: inset 0 2px 5px rgba(0,0,0,0.2);
@@ -372,7 +372,7 @@ body.a11y-motion-reduced .spinner {
     padding: 8px 18px; /* Offset border to prevent layout shift */
 }
 
-.toggle-button[aria-pressed="true"]:hover, .toggle-button.keyboard-active:hover,
+.toggle-button.keyboard-active, .toggle-button.keyboard-active:hover,
 .toggle-button[aria-expanded="true"]:hover {
     background: #F50057;
 }


### PR DESCRIPTION
💡 What: Replaced the rapid `aria-pressed` toggling logic with a dedicated `.keyboard-active` CSS class to provide tactile keyboard feedback on buttons.

🎯 Why: Rapidly toggling `aria-pressed="true"` and `false` (e.g., within 150ms) to create a visual "pushed" button state is an accessibility anti-pattern. It causes screen readers to spam the user with incorrect toggle state changes for buttons that are not actual toggles (like ability HUD icons or one-shot UI buttons).

♿ Accessibility: Preserves tactile visual feedback for keyboard users (scale down effects) using a pure CSS class (`.keyboard-active`), while removing the semantic `aria-pressed` state changes from elements that aren't actually toggle switches. `aria-pressed` is correctly maintained for actual toggle elements (like Mute and Day/Night).

---
*PR created automatically by Jules for task [14599368235418533237](https://jules.google.com/task/14599368235418533237) started by @ford442*