### PR TITLE
⚡ Bolt: [Memory Rescue] Fix Aurora VRAM leak

### DIFF
--- a/src/systems/weather/weather-effects.ts
+++ b/src/systems/weather/weather-effects.ts
@@ -281,7 +281,7 @@ export class EffectsManager {
      * Dispose of all effects
      */
     dispose(): void {
-        const { percussionRain, melodicMist, rainMesh, mistMesh, lightningLight, rainbow } = this.state;
+        const { percussionRain, melodicMist, rainMesh, mistMesh, lightningLight, rainbow, aurora } = this.state;
         
         if (percussionRain) {
             percussionRain.dispose();
@@ -326,6 +326,18 @@ export class EffectsManager {
                 }
             }
             this.scene.remove(rainbow);
+        }
+        if (aurora) {
+            // ⚡ OPTIMIZATION: Ensure aurora mesh and materials are disposed to prevent VRAM leak when weather effects are torn down.
+            if (aurora.geometry) aurora.geometry.dispose();
+            if (aurora.material) {
+                if (Array.isArray(aurora.material)) {
+                    aurora.material.forEach((m: any) => m.dispose());
+                } else {
+                    (aurora.material as any).dispose();
+                }
+            }
+            this.scene.remove(aurora);
         }
     }
 }


### PR DESCRIPTION
Bottleneck: The aurora mesh and its procedural materials were not being disposed when the weather effects system was dismantled, causing a permanent memory (VRAM) leak.
Fix: Extracted the aurora from the effects state and explicitly called `.dispose()` on its geometry and materials before removing it from the scene in `weather-effects.ts`.
Impact: Prevents VRAM leaks during world tears downs and preserves device stability during long play sessions.

---
*PR created automatically by Jules for task [17142774183540089007](https://jules.google.com/task/17142774183540089007) started by @ford442*