### PR TITLE
♿ Aria: [Accessibility & UX Improvements]

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies
         run: |
           # Use pnpm since there is a pnpm-lock.yaml file
-          npm install -g pnpm
+          npm install -g pnpm@9
           pnpm install
           cd tools/visual-regression
           pnpm install

--- a/src/core/hud.ts
+++ b/src/core/hud.ts
@@ -221,7 +221,7 @@ export function updateDashHUD(
     if (isReady) {
         const kick = _cachedPrefersReducedMotion ? 0 : (audioState?.kickTrigger || 0);
         const scale = 1.0 + kick * 0.15;
-        const pressed = hudDash.classList.contains('pressed');
+        const pressed = hudDash.classList.contains('keyboard-active') || hudDash.matches(':active');
         // Multiply by 0.9 if pressed (mimics CSS active state)
         const finalScale = pressed ? scale * 0.9 : scale;
         hudDash.style.transform = `scale(${finalScale.toFixed(3)})`;
@@ -257,7 +257,7 @@ export function updateMineHUD(
     if (isReady) {
         const kick = _cachedPrefersReducedMotion ? 0 : (audioState?.kickTrigger || 0);
         const scale = 1.0 + kick * 0.15;
-        const pressed = hudMine.classList.contains('pressed');
+        const pressed = hudMine.classList.contains('keyboard-active') || hudMine.matches(':active');
         const finalScale = pressed ? scale * 0.9 : scale;
         hudMine.style.transform = `scale(${finalScale.toFixed(3)})`;
     } else {
@@ -331,7 +331,7 @@ export function updatePhaseHUD(
         if (isReady) {
             const kick = _cachedPrefersReducedMotion ? 0 : (audioState?.kickTrigger || 0);
             const scale = 1.0 + kick * 0.15;
-            const pressed = hudPhase.classList.contains('pressed');
+            const pressed = hudPhase.classList.contains('keyboard-active') || hudPhase.matches(':active');
             const finalScale = pressed ? scale * 0.9 : scale;
             hudPhase.style.transform = `scale(${finalScale.toFixed(3)})`;
         } else {

--- a/src/ui/save-menu/save-slots.ts
+++ b/src/ui/save-menu/save-slots.ts
@@ -165,6 +165,7 @@ export async function handleSlotAction(
     // Set busy state if button was provided
     if (btnElement) {
         btnElement.setAttribute('aria-busy', 'true');
+        btnElement.setAttribute('aria-disabled', 'true');
         btnElement.style.pointerEvents = 'none';
         btnElement.style.opacity = '0.7';
         const originalText = btnElement.innerHTML;
@@ -173,6 +174,7 @@ export async function handleSlotAction(
         // Setup cleanup to restore state
         const cleanup = () => {
             btnElement.removeAttribute('aria-busy');
+            btnElement.removeAttribute('aria-disabled');
             btnElement.style.pointerEvents = '';
             btnElement.style.opacity = '';
             btnElement.innerHTML = originalText;


### PR DESCRIPTION
💡 What: 
1. Added `aria-disabled="true"` to buttons during asynchronous actions (like saving/loading) in the save menu.
2. Fixed the visual squish effect on HUD icons (Dash, Mine, Phase) so that keyboard (`.keyboard-active`) and mouse (`:active`) feedback properly scales down the icon instead of being overridden by the audio-reactive pulse.

🎯 Why: 
1. `aria-busy` alone does not stop a screen reader or keyboard user from focusing and attempting to re-trigger an ongoing save/load operation. It needed `aria-disabled` as well.
2. The UI felt slightly unresponsive to ability presses because the JavaScript audio pulse override wasn't checking the correct class (`pressed` instead of `keyboard-active`), breaking the intended CSS feedback.

♿ Accessibility: 
Implemented robust loading state markers via ARIA attributes in async UI processes, and ensured tactile visual feedback occurs consistently regardless of the input method.

---
*PR created automatically by Jules for task [7924296253593542665](https://jules.google.com/task/7924296253593542665) started by @ford442*