### PR TITLE
Progressive boot pipeline: evaluate debug staging and add halt-on-failure startup

### DIFF
--- a/docs/PROGRESSIVE_BOOT.md
+++ b/docs/PROGRESSIVE_BOOT.md
@@ -1,0 +1,75 @@
+# Progressive Boot Pipeline
+
+## Evaluation of the Previous Setup
+
+The project had **two parallel startup systems** that were not unified:
+
+| System | Trigger | Purpose |
+|--------|---------|---------|
+| **Debug staging** (`StageLoader`, `?debug=1`) | URL + panel checkboxes | Skip individual subsystems to isolate failures |
+| **World modes** (CORE / FULL / FAST_FULL) | Start-screen buttons | Control map population depth on Enter |
+
+### What worked well
+
+- Colored per-stage console logs (`✓` / `✗` / `⏭️`) made it easy to see which subsystem finished
+- The sandbox `DEBUG_STAGES` default correctly disabled heavy stages (shader warmup, world gen, WASM)
+- CORE vs FULL buttons gave users a fast path without touching debug URLs
+- Error boundary + loading-screen race guard prevented silent hangs
+
+### Gaps
+
+1. **No halt on failure** — failed stages logged red but boot continued, masking the root cause
+2. **No dependency graph** — disabling `weather` did not auto-skip `worldCritical` with a clear reason
+3. **Debug-only stage skipping** — `?debug=1` required; `?halt=1` did not exist for CI/headless
+4. **Two mental models** — debug stages vs world modes were unrelated; no `sandbox → full` progression
+5. **Duplicated deferred visuals** — `deferredVisuals` ran via both `DeferredLoader` and background processor
+6. **Panel toggles need reload** — checkbox changes don't apply until refresh
+
+## New Progressive Boot
+
+### URL parameters
+
+```
+?debug=1                  # Debug panel + limited sandbox preset + halt on critical failure
+?halt=1                   # Halt on critical failure without full debug UI
+?boot=sandbox|limited|standard|full   # Apply a stage preset
+```
+
+### Presets
+
+| Preset | Stages enabled | Use case |
+|--------|----------------|----------|
+| `sandbox` / `limited` | Core scene + minimal systems, no world gen | First boot sanity check |
+| `standard` | Through game loop + shader warmup, Enter triggers world | Normal dev |
+| `full` | All stages including deferred | Full progressive load |
+
+### Recommended progression
+
+1. `?debug=1&boot=sandbox` — verify renderer, terrain, Enter button
+2. Enable `shaderWarmup` in panel → reload
+3. Enable `worldGeneration` → Enter world
+4. Enable `postProcessing`, `wasm`, `deferredVisuals`, `deferredWorld` one at a time
+5. Or jump to `?boot=full` once stable
+
+### Console helpers
+
+```js
+window.__bootPipeline.summary()   // Print stage table
+window.__bootPipeline.state()     // { completed, failed, skipped, halted }
+window.__bootPipeline.preset('standard')  // Apply preset (reload required)
+```
+
+## Architecture
+
+```
+src/debug/boot-registry.ts       — Stage order, dependencies, presets
+src/debug/progressive-bootstrap.ts — runBootStage(), halt, dependency skip
+src/core/progressive-startup.ts  — Pre-loop pipeline (core → wasm)
+src/core/main.ts                 — Shader warmup, Enter world, deferred queues
+```
+
+## Files
+
+- `src/debug/stages.ts` — Stage flags + `StageLoader` (unchanged API)
+- `src/debug/progressive-bootstrap.ts` — Orchestrator
+- `tests/progressive-boot.test.mjs` — Dependency + halt unit tests

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test:world-health": "node tests/world-health.test.mjs",
     "test:wasm-loader": "node tests/wasm-loader-reliability.mjs",
     "test:startup": "node tests/startup-bootstrap.mjs",
+    "test:progressive-boot": "node tests/progressive-boot.test.mjs",
     "test:integration": "npm run build:wasm && npm run test:wasm && npm run test:spawn-tracker && npm run test:world-health && npm run test",
     "test:smoke:full": "FULL_BOOT=1 npm run test",
     "test:smoke:fast": "FULL_BOOT=fast npm run test",

--- a/src/core/main.ts
+++ b/src/core/main.ts
@@ -14,39 +14,32 @@ declare global {
     }
 }
 import '../../style.css';
-import { validateNodeGeometries } from '../foliage/index.ts';
 
 import { InteractionSystem } from '../systems/interaction.ts';
-import { musicReactivitySystem } from '../systems/music-reactivity.ts';
-import { fluidSystem } from '../systems/fluid_system.ts';
-import { AudioSystem } from '../audio/audio-system.ts';
-import { BeatSync } from '../audio/beat-sync.ts';
-import { WeatherSystem } from '../systems/weather.ts';
-import { initWasm, getGroundHeight } from '../utils/wasm-loader.ts';
+import { getGroundHeight } from '../utils/wasm-loader.ts';
 import { getUnifiedGroundHeightTyped } from '../systems/physics.core.ts';
 import { profiler } from '../utils/profiler.ts';
-import { enableStartupProfiler, finalizeStartupProfile, recordWASMInit, toggleOverlay } from '../utils/startup-profiler.ts';
+import { enableStartupProfiler, finalizeStartupProfile, toggleOverlay } from '../utils/startup-profiler.ts';
 import { startPhase, endPhase } from '../utils/startup-profiler.ts';
 import { glitchGrenadeSystem } from '../systems/glitch-grenade.ts';
 
 // Core imports
 import { CONFIG } from './config.ts';
-import { initScene } from './init.ts';
 import { ShaderWarmup } from '../rendering/shader-warmup.ts';
-import { initInput, keyStates } from './input/index.ts';
-import { initPostProcessing } from '../foliage/post-processing.ts';
+import { keyStates } from './input/index.ts';
+import { setCameraRef } from './camera-ref.ts';
 
 // World & System imports
-import { initCriticalWorld, initDeferredWorldContent, initWorld, initWorldCritical, initWorldContent, generateMap, populateWorld, WorldMode, DEFAULT_MAP_CHUNK_SIZE } from '../world/generation.ts';
+import { initDeferredWorldContent, populateWorld, WorldMode } from '../world/generation.ts';
 import { animatedFoliage, interactiveObjects } from '../world/state.ts';
 import { installWorldExportTools } from '../world/map-exporter.ts';
 import { fireRainbow } from '../gameplay/rainbow-blaster.ts';
 import { player, populatePhysicsGrids } from '../systems/physics/index.ts';
 
 // Refactored module imports
-import { animate, initGameLoopDependencies, addCameraShake } from './game-loop.ts';
-import { updateTheme, toggleDayNight, setInputSystem } from './hud.ts';
-import { initDeferredVisuals, initDeferredVisualsDependencies, runDeferredWarmup } from './deferred-init.ts';
+import { animate, addCameraShake } from './game-loop.ts';
+import { updateTheme } from './hud.ts';
+import { initDeferredVisuals, runDeferredWarmup } from './deferred-init.ts';
 import { globalBackgroundProcessor } from '../utils/background-processor.ts';
 import { showDeferredIndicator, hideDeferredIndicator } from '../ui/index.ts';
 import { reset as resetSpawnTracker, getReport as getSpawnReport } from '../world/spawn-tracker.ts';
@@ -57,11 +50,9 @@ import { DeferredLoader, LoadPriority } from '../systems/deferred-loader.ts';
 import { initLoadingScreen, installLegacyAPI } from '../ui/loading-screen.ts';
 import { installBatcherTelemetry } from '../foliage/batcher-telemetry.ts';
 
-// Debug staging system
-import { StageLoader, showDebugError, initDebugPanel } from '../debug/index.ts';
-
-// Constants for loading progress
-const POST_PROCESSING_PROGRESS = 70;
+// Debug staging + progressive boot
+import { initDebugPanel, runBootStage } from '../debug/index.ts';
+import { runPreLoopBootstrap } from './progressive-startup.ts';
 
 // Export core objects for use by other modules
 // We defer the export until after sceneInitResult is available, but for now we just declare let and assign them.
@@ -136,205 +127,42 @@ enableStartupProfiler({
 initDebugPanel();
 installBatcherTelemetry();
 
-// --- Initialization Pipeline with Debug Staging ---
+// --- Progressive pre-loop boot (core → wasm) ---
+const timeOffset = { value: 0 };
 
-// Phase 1: Core Scene Setup (Immediate)
-loadingScreen.startPhase('core-scene');
-console.time('Core Scene Setup');
-
-let sceneInitResult: ReturnType<typeof initScene> | undefined;
-await StageLoader.loadStage('core', () => {
-    sceneInitResult = initScene();
-});
-
-if (!sceneInitResult) {
-    const msg = 'Core scene initialization was skipped or failed';
-    console.error('[Startup] Core Scene Setup failed');
-    loadingScreen.showFatalError(`Failed to initialize 3D scene.\n${msg}`);
-    throw new Error(msg);
+const bootResult = await runPreLoopBootstrap(loadingScreen, timeOffset);
+if (!bootResult) {
+    throw new Error('Progressive boot halted before game loop could start');
 }
 
-const { mode, ambientLight, sunLight, sunGlow, sunCorona, lightShaftGroup, sunGlowMat, coronaMat, uShaftOpacity } = sceneInitResult;
-scene = sceneInitResult.scene;
-camera = sceneInitResult.camera;
-import { setCameraRef } from './camera-ref.ts';
+scene = bootResult.scene;
+camera = bootResult.camera;
+renderer = bootResult.renderer;
+const mode = bootResult.mode;
+const postProcessing = bootResult.postProcessing;
+const audioSystem = bootResult.audioSystem;
+const beatSync = bootResult.beatSync;
+const weatherSystem = bootResult.weatherSystem;
+const moon = bootResult.moon;
+const inputSystem = bootResult.inputSystem;
+const controls = bootResult.controls;
+let interactionSystem = bootResult.interactionSystem;
+const {
+    ambientLight,
+    sunLight,
+    sunGlow,
+    sunCorona,
+    lightShaftGroup,
+    sunGlowMat,
+    coronaMat,
+    uShaftOpacity,
+} = bootResult;
+
 setCameraRef(camera);
-renderer = sceneInitResult.renderer;
 
 // Set global game object so playwright tests can interact with camera, etc
 (window as any).game = { camera, scene, animatedFoliage, interactiveObjects };
 installWorldExportTools();
-
-// Notify user if using WebGL fallback
-if (mode === 'webgl') {
-    console.warn('[Startup] WebGL fallback mode active. Some visual features may be limited.');
-    loadingScreen.updateProgress(POST_PROCESSING_PROGRESS, 'Switching to WebGL mode...');
-} else {
-    loadingScreen.updateProgress(POST_PROCESSING_PROGRESS, 'Initializing post-processing...');
-}
-
-// Initialize Post Processing Pipeline
-let postProcessing: any;
-await StageLoader.loadStage('postProcessing', () => {
-    postProcessing = initPostProcessing(renderer, scene, camera, mode);
-});
-
-console.timeEnd('Core Scene Setup');
-loadingScreen.updateProgress(100);
-loadingScreen.completePhase('core-scene');
-
-// Phase 2: Audio & Weather Systems (Lightweight)
-loadingScreen.startPhase('audio-init');
-console.time('Audio & Systems Init');
-
-let audioSystem: AudioSystem | undefined;
-let beatSync: BeatSync | undefined;
-await StageLoader.loadStage('audio', () => {
-    audioSystem = new AudioSystem(CONFIG.audio.useScriptProcessorNode);
-    (window as any).AudioSystem = audioSystem;
-    loadingScreen.updateProgress(40, 'Creating audio system...');
-    beatSync = new BeatSync(audioSystem);
-});
-
-let weatherSystem: WeatherSystem | undefined;
-await StageLoader.loadStage('weather', () => {
-    loadingScreen.updateProgress(70, 'Initializing weather system...');
-    weatherSystem = new WeatherSystem(scene);
-    weatherSystem.setRenderer(renderer);
-});
-console.timeEnd('Audio & Systems Init');
-loadingScreen.updateProgress(100);
-loadingScreen.completePhase('audio-init');
-
-// Phase 3: World Generation (Critical Path)
-loadingScreen.startPhase('world-generation');
-console.time('World Generation');
-loadingScreen.updateProgress(10, 'Loading critical world...');
-
-// CHANGE: Load only the base world (sky/ground) initially, defer content.
-// initWorldCritical is now async and yields control between heavy subsystems
-// so the loading screen stays responsive throughout terrain generation.
-let moon: any;
-await StageLoader.loadStage('worldCritical', async () => {
-    loadingScreen.updateProgress(20, 'Generating terrain...');
-    const result = await initWorldCritical(scene, weatherSystem!);
-    moon = result.moon;
-    loadingScreen.updateProgress(90, 'World objects ready...');
-});
-
-console.timeEnd('World Generation');
-loadingScreen.updateProgress(100, 'Base world ready');
-loadingScreen.completePhase('world-generation');
-
-// Initialize Music Reactivity with dependencies
-await StageLoader.loadStage('musicReactivity', () => {
-    musicReactivitySystem.init(scene, weatherSystem!, beatSync);
-    // Explicitly register moon (cleaner than traversing scene later)
-    if (moon) {
-        musicReactivitySystem.registerMoon(moon);
-    }
-    
-    // Hook up audio system note events to music reactivity
-    if (audioSystem) {
-        if (audioSystem.onNote) {
-            audioSystem.onNote((note: string, velocity: number, channel: number) => {
-                musicReactivitySystem.handleNoteOn(note, velocity, channel);
-            });
-        } else if (audioSystem.setNoteCallback) {
-            // If not, we might need to modify AudioSystem or use a polling approach in animate()
-            // For now, let's assume we will add setNoteCallback to AudioSystem
-            audioSystem.setNoteCallback((note: string, velocity: number, channel: number) => {
-                musicReactivitySystem.handleNoteOn(note, velocity, channel);
-            });
-        }
-    }
-});
-
-// Validate node material geometries to avoid TSL attribute errors
-// DEFERRED: This full-scene traversal is expensive. Run it during idle time.
-if ('requestIdleCallback' in window) {
-    requestIdleCallback(() => validateNodeGeometries(scene), { timeout: 3000 });
-} else {
-    setTimeout(() => validateNodeGeometries(scene), 100);
-}
-
-// Time offset for day/night cycle (shared with game-loop)
-const timeOffset = { value: 0 };
-
-// 4. Input Handling
-let inputSystem: any;
-let controls: any;
-await StageLoader.loadStage('input', () => {
-    inputSystem = initInput(camera, audioSystem!, 
-        () => toggleDayNight(timeOffset), 
-        () => (player as any).isDancing
-    );
-    setInputSystem(inputSystem);
-    controls = inputSystem.controls;
-});
-
-// Fallback: Null object pattern for skipped input
-if (!inputSystem) {
-    inputSystem = {
-        controls: null,
-        updateReticleState: () => {},
-        setPlaylistMode: () => {},
-        getPlaylistIndex: () => -1,
-    };
-}
-
-// Initialize Interaction System
-let interactionSystem: InteractionSystem | undefined;
-await StageLoader.loadStage('interaction', () => {
-    interactionSystem = new InteractionSystem(camera, inputSystem.updateReticleState);
-});
-
-// Fallback: Null object pattern for skipped interaction system
-if (!interactionSystem) {
-    interactionSystem = {
-        triggerClick: () => false,
-        update: () => {},
-        dispose: () => {},
-    } as any;
-}
-
-// Initialize deferred visual dependencies
-initDeferredVisualsDependencies(scene, camera, renderer);
-
-// Initialize game loop dependencies
-await StageLoader.loadStage('gameLoop', () => {
-    // Fallback gracefully instead of throwing
-    if (!interactionSystem) {
-        console.warn('[gameLoop] InteractionSystem not initialized, using dummy');
-        interactionSystem = {
-            triggerClick: () => false,
-            update: () => {},
-            dispose: () => {},
-        } as any;
-    }
-    initGameLoopDependencies({
-        scene,
-        camera,
-        renderer,
-        postProcessing,
-        weatherSystem: weatherSystem!,
-        audioSystem: audioSystem!,
-        beatSync: beatSync!,
-        interactionSystem: interactionSystem!,
-        moon,
-        fireflies: null,
-        controls,
-        sunLight,
-        ambientLight,
-        sunGlow,
-        sunCorona,
-        lightShaftGroup,
-        sunGlowMat,
-        coronaMat,
-        uShaftOpacity,
-        timeOffset
-    });
-});
 
 // Optimization: Hoist reusable objects to module scope to prevent GC in animation loop
 const _scratchClickDir = new THREE.Vector3();
@@ -391,37 +219,9 @@ player.position.copy(camera.position);
 player.velocity.set(0, 0, 0);
 console.log(`[Startup] Camera positioned at ground height: y=${camera.position.y.toFixed(2)}`);
 
-// --- Phase 4: WASM Initialization (Emscripten, sequential with loading phase) ---
-// initWasm() loads the optional Emscripten C++ module that adds native-SIMD
-// performance on top of the already-active AssemblyScript fallbacks. Running it
-// here (before shader warmup, after world generation) means:
-//   • the loading screen shows a distinct "wasm-init" phase with attempt counter,
-//   • failures produce a user-visible error via setWasmError(), and
-//   • JS fallbacks are already active so the game stays playable regardless.
-loadingScreen.startPhase('wasm-init');
-await StageLoader.loadStage('wasm', async () => {
-    try {
-        const wasmOk = await initWasm();
-        if (wasmOk) {
-            console.log('[WASM] Emscripten loaded successfully');
-            recordWASMInit(performance.now(), true, true);
-        } else {
-            console.warn('[WASM] Emscripten unavailable - JS fallbacks active');
-            recordWASMInit(performance.now(), false, false);
-        }
-    } catch (err) {
-        console.warn('[WASM] Emscripten failed, using JS fallbacks:', err);
-        recordWASMInit(performance.now(), false, false);
-    }
-    // Initialize fluid system regardless of Emscripten availability;
-    // it has its own internal fallback path when the native module is absent.
-    fluidSystem.init();
-});
-loadingScreen.completePhase('wasm-init');
-
 // --- SHADER WARMUP (before loop starts to prevent first-frame stutter) ---
 (async function warmupAndStartLoop() {
-    await StageLoader.loadStage('shaderWarmup', async () => {
+    await runBootStage('shaderWarmup', async () => {
         if (CONFIG.safeMode) {
             console.warn('[Startup] safeMode active — skipping shader warmup and compileAsync');
             return;
@@ -600,7 +400,7 @@ if (startButton) {
         const useFastPopulation = fastFullMode;   // "Fast Full" = Full map but with aggressive population reduction
         let activeWorldMode: WorldMode = requestedMode;
 
-        const worldGenResult = await StageLoader.loadStage('worldGeneration', async () => {
+        const worldGenResult = await runBootStage('worldGeneration', async () => {
             // Clean up preview mushroom if it exists (from optimize branch)
             // Note: previewMushroom is defined in previous world generation runs
             const previewMushroom = (window as any).previewMushroom;
@@ -797,7 +597,7 @@ if (startButton) {
                 id: 'deferred_visuals',
                 priority: 100,
                 execute: () => {
-                    StageLoader.loadStage('deferredVisuals', () => {
+                    runBootStage('deferredVisuals', () => {
                         console.log('[Deferred] Loading celestial bodies and aurora...');
                         startPhase('Deferred Visuals Init');
                         initDeferredVisuals();
@@ -861,7 +661,7 @@ if (startButton) {
 
 // --- DEFERRED WORLD CONTENT (non-blocking, after loop is running) ---
 function startDeferredWorldLoading() {
-    StageLoader.loadStage('deferredWorld', async () => {
+    runBootStage('deferredWorld', async () => {
         await initDeferredWorldContent(scene, weatherSystem!, (pct, label) => {
             if (pct % 25 === 0 || pct === 100) {
                 console.log(`[Deferred World] ${pct}%: ${label}`);

--- a/src/core/progressive-startup.ts
+++ b/src/core/progressive-startup.ts
@@ -1,0 +1,327 @@
+// src/core/progressive-startup.ts
+// Progressive pre-loop boot pipeline — ordered subsystem loading with halt-on-failure.
+
+import * as THREE from 'three';
+import { validateNodeGeometries } from '../foliage/index.ts';
+import { InteractionSystem } from '../systems/interaction.ts';
+import { musicReactivitySystem } from '../systems/music-reactivity.ts';
+import { fluidSystem } from '../systems/fluid_system.ts';
+import { AudioSystem } from '../audio/audio-system.ts';
+import { BeatSync } from '../audio/beat-sync.ts';
+import { WeatherSystem } from '../systems/weather.ts';
+import { initWasm } from '../utils/wasm-loader.ts';
+import { recordWASMInit } from '../utils/startup-profiler.ts';
+import { CONFIG } from './config.ts';
+import { initScene } from './init.ts';
+import { initInput } from './input/index.ts';
+import { initPostProcessing } from '../foliage/post-processing.ts';
+import { initWorldCritical } from '../world/generation.ts';
+import { initGameLoopDependencies } from './game-loop.ts';
+import { initDeferredVisualsDependencies } from './deferred-init.ts';
+import { setInputSystem, toggleDayNight } from './hud.ts';
+import { player } from '../systems/physics/index.ts';
+import {
+  getBootPipelineState,
+  initProgressiveBoot,
+  printBootSummary,
+  runBootStage,
+  installBootDebugHooks,
+} from '../debug/progressive-bootstrap.ts';
+import type { LoadingScreen } from '../ui/loading-screen-ui.ts';
+
+const POST_PROCESSING_PROGRESS = 70;
+
+export interface PreLoopBootResult {
+  scene: THREE.Scene;
+  camera: THREE.PerspectiveCamera;
+  renderer: THREE.WebGPURenderer | THREE.WebGLRenderer;
+  mode: string;
+  postProcessing: unknown;
+  audioSystem?: AudioSystem;
+  beatSync?: BeatSync;
+  weatherSystem?: WeatherSystem;
+  moon: unknown;
+  inputSystem: ReturnType<typeof initInput> | DummyInputSystem;
+  controls: unknown;
+  interactionSystem: InteractionSystem | DummyInteractionSystem;
+  ambientLight: THREE.Light;
+  sunLight: THREE.Light;
+  sunGlow: unknown;
+  sunCorona: unknown;
+  lightShaftGroup: unknown;
+  sunGlowMat: unknown;
+  coronaMat: unknown;
+  uShaftOpacity: unknown;
+  halted: boolean;
+}
+
+interface DummyInputSystem {
+  controls: null;
+  updateReticleState: () => void;
+  setPlaylistMode: () => void;
+  getPlaylistIndex: () => number;
+}
+
+interface DummyInteractionSystem {
+  triggerClick: () => boolean;
+  update: () => void;
+  dispose: () => void;
+}
+
+const DUMMY_INPUT: DummyInputSystem = {
+  controls: null,
+  updateReticleState: () => {},
+  setPlaylistMode: () => {},
+  getPlaylistIndex: () => -1,
+};
+
+const DUMMY_INTERACTION: DummyInteractionSystem = {
+  triggerClick: () => false,
+  update: () => {},
+  dispose: () => {},
+};
+
+/**
+ * Run the ordered pre-loop boot pipeline (core → game loop → wasm).
+ * Halts with console + overlay when a critical stage fails in debug/halt mode.
+ */
+export async function runPreLoopBootstrap(
+  loadingScreen: LoadingScreen,
+  timeOffset: { value: number }
+): Promise<PreLoopBootResult | null> {
+  initProgressiveBoot();
+  installBootDebugHooks();
+
+  // --- Phase 1: Core scene ---
+  loadingScreen.startPhase('core-scene');
+  console.time('Core Scene Setup');
+
+  let sceneInitResult: ReturnType<typeof initScene> | undefined;
+  await runBootStage('core', () => {
+    sceneInitResult = initScene();
+  });
+
+  if (!sceneInitResult || getBootPipelineState().halted) {
+    const msg = getBootPipelineState().haltError ?? 'Core scene initialization was skipped or failed';
+    console.error('[Startup] Core Scene Setup failed');
+    loadingScreen.showFatalError(`Failed to initialize 3D scene.\n${msg}`);
+    printBootSummary(true);
+    return null;
+  }
+
+  const {
+    mode,
+    ambientLight,
+    sunLight,
+    sunGlow,
+    sunCorona,
+    lightShaftGroup,
+    sunGlowMat,
+    coronaMat,
+    uShaftOpacity,
+  } = sceneInitResult;
+  const scene = sceneInitResult.scene;
+  const camera = sceneInitResult.camera;
+  const renderer = sceneInitResult.renderer;
+
+  if (mode === 'webgl') {
+    console.warn('[Startup] WebGL fallback mode active. Some visual features may be limited.');
+    loadingScreen.updateProgress(POST_PROCESSING_PROGRESS, 'Switching to WebGL mode...');
+  } else {
+    loadingScreen.updateProgress(POST_PROCESSING_PROGRESS, 'Initializing post-processing...');
+  }
+
+  let postProcessing: unknown;
+  await runBootStage('postProcessing', () => {
+    postProcessing = initPostProcessing(renderer, scene, camera, mode);
+  });
+
+  console.timeEnd('Core Scene Setup');
+  loadingScreen.updateProgress(100);
+  loadingScreen.completePhase('core-scene');
+
+  if (getBootPipelineState().halted) {
+    printBootSummary(true);
+    return null;
+  }
+
+  // --- Phase 2: Audio & weather ---
+  loadingScreen.startPhase('audio-init');
+  console.time('Audio & Systems Init');
+
+  let audioSystem: AudioSystem | undefined;
+  let beatSync: BeatSync | undefined;
+  await runBootStage('audio', () => {
+    audioSystem = new AudioSystem(CONFIG.audio.useScriptProcessorNode);
+    (window as any).AudioSystem = audioSystem;
+    loadingScreen.updateProgress(40, 'Creating audio system...');
+    beatSync = new BeatSync(audioSystem);
+  });
+
+  let weatherSystem: WeatherSystem | undefined;
+  await runBootStage('weather', () => {
+    loadingScreen.updateProgress(70, 'Initializing weather system...');
+    weatherSystem = new WeatherSystem(scene);
+    weatherSystem.setRenderer(renderer);
+  });
+
+  console.timeEnd('Audio & Systems Init');
+  loadingScreen.updateProgress(100);
+  loadingScreen.completePhase('audio-init');
+
+  if (getBootPipelineState().halted) {
+    printBootSummary(true);
+    return null;
+  }
+
+  // --- Phase 3: Critical world ---
+  loadingScreen.startPhase('world-generation');
+  console.time('World Generation');
+  loadingScreen.updateProgress(10, 'Loading critical world...');
+
+  let moon: unknown;
+  await runBootStage('worldCritical', async () => {
+    loadingScreen.updateProgress(20, 'Generating terrain...');
+    const result = await initWorldCritical(scene, weatherSystem!);
+    moon = result.moon;
+    loadingScreen.updateProgress(90, 'World objects ready...');
+  });
+
+  console.timeEnd('World Generation');
+  loadingScreen.updateProgress(100, 'Base world ready');
+  loadingScreen.completePhase('world-generation');
+
+  if (getBootPipelineState().halted) {
+    printBootSummary(true);
+    return null;
+  }
+
+  // --- Music reactivity ---
+  await runBootStage('musicReactivity', () => {
+    musicReactivitySystem.init(scene, weatherSystem!, beatSync);
+    if (moon) {
+      musicReactivitySystem.registerMoon(moon);
+    }
+    if (audioSystem) {
+      if (audioSystem.onNote) {
+        audioSystem.onNote((note: string, velocity: number, channel: number) => {
+          musicReactivitySystem.handleNoteOn(note, velocity, channel);
+        });
+      } else if (audioSystem.setNoteCallback) {
+        audioSystem.setNoteCallback((note: string, velocity: number, channel: number) => {
+          musicReactivitySystem.handleNoteOn(note, velocity, channel);
+        });
+      }
+    }
+  });
+
+  if ('requestIdleCallback' in window) {
+    requestIdleCallback(() => validateNodeGeometries(scene), { timeout: 3000 });
+  } else {
+    setTimeout(() => validateNodeGeometries(scene), 100);
+  }
+
+  // --- Input & interaction ---
+  let inputSystem: ReturnType<typeof initInput> | DummyInputSystem = DUMMY_INPUT;
+  let controls: unknown = null;
+  await runBootStage('input', () => {
+    inputSystem = initInput(
+      camera,
+      audioSystem!,
+      () => toggleDayNight(timeOffset),
+      () => (player as any).isDancing
+    );
+    setInputSystem(inputSystem as ReturnType<typeof initInput>);
+    controls = (inputSystem as ReturnType<typeof initInput>).controls;
+  });
+
+  let interactionSystem: InteractionSystem | DummyInteractionSystem = DUMMY_INTERACTION;
+  await runBootStage('interaction', () => {
+    interactionSystem = new InteractionSystem(
+      camera,
+      (inputSystem as ReturnType<typeof initInput>).updateReticleState
+    );
+  });
+
+  initDeferredVisualsDependencies(scene, camera, renderer);
+
+  await runBootStage('gameLoop', () => {
+    if (!interactionSystem || interactionSystem === DUMMY_INTERACTION) {
+      console.warn('[gameLoop] InteractionSystem not initialized, using dummy');
+      interactionSystem = { ...DUMMY_INTERACTION };
+    }
+    initGameLoopDependencies({
+      scene,
+      camera,
+      renderer,
+      postProcessing,
+      weatherSystem: weatherSystem!,
+      audioSystem: audioSystem!,
+      beatSync: beatSync!,
+      interactionSystem: interactionSystem as InteractionSystem,
+      moon,
+      fireflies: null,
+      controls,
+      sunLight,
+      ambientLight,
+      sunGlow,
+      sunCorona,
+      lightShaftGroup,
+      sunGlowMat,
+      coronaMat,
+      uShaftOpacity,
+      timeOffset,
+    });
+  });
+
+  if (getBootPipelineState().halted) {
+    printBootSummary(true);
+    return null;
+  }
+
+  // --- WASM (optional Emscripten) ---
+  loadingScreen.startPhase('wasm-init');
+  await runBootStage('wasm', async () => {
+    try {
+      const wasmOk = await initWasm();
+      if (wasmOk) {
+        console.log('[WASM] Emscripten loaded successfully');
+        recordWASMInit(performance.now(), true, true);
+      } else {
+        console.warn('[WASM] Emscripten unavailable - JS fallbacks active');
+        recordWASMInit(performance.now(), false, false);
+      }
+    } catch (err) {
+      console.warn('[WASM] Emscripten failed, using JS fallbacks:', err);
+      recordWASMInit(performance.now(), false, false);
+    }
+    fluidSystem.init();
+  });
+  loadingScreen.completePhase('wasm-init');
+
+  printBootSummary();
+
+  return {
+    scene,
+    camera,
+    renderer,
+    mode,
+    postProcessing,
+    audioSystem,
+    beatSync,
+    weatherSystem,
+    moon,
+    inputSystem,
+    controls,
+    interactionSystem: interactionSystem as InteractionSystem,
+    ambientLight,
+    sunLight,
+    sunGlow,
+    sunCorona,
+    lightShaftGroup,
+    sunGlowMat,
+    coronaMat,
+    uShaftOpacity,
+    halted: getBootPipelineState().halted,
+  };
+}

--- a/src/debug/boot-registry.ts
+++ b/src/debug/boot-registry.ts
@@ -1,0 +1,221 @@
+// src/debug/boot-registry.ts
+// Ordered boot stage metadata: dependencies, criticality, and preset groupings.
+
+import type { DebugStages } from './stages.ts';
+
+export type BootStageId = keyof DebugStages;
+
+export type BootPresetId = 'sandbox' | 'limited' | 'standard' | 'full';
+
+export interface StageDefinition {
+  /** Human-readable label for console summaries */
+  label: string;
+  /** Lower numbers run first */
+  order: number;
+  /** If true, failure halts the progressive boot pipeline */
+  critical: boolean;
+  /** Stages that must succeed before this one runs */
+  dependsOn: BootStageId[];
+  /** Stages in the same boot group (for preset docs) */
+  group: 'render' | 'systems' | 'world' | 'gameplay' | 'compute' | 'deferred';
+}
+
+/**
+ * Canonical boot order and dependency graph.
+ * Used by ProgressiveBootstrap to skip dependents and halt on critical failures.
+ */
+export const STAGE_REGISTRY: Record<BootStageId, StageDefinition> = {
+  core: {
+    label: 'Core scene (renderer, camera, lights)',
+    order: 0,
+    critical: true,
+    dependsOn: [],
+    group: 'render',
+  },
+  postProcessing: {
+    label: 'Post-processing pipeline',
+    order: 10,
+    critical: false,
+    dependsOn: ['core'],
+    group: 'render',
+  },
+  audio: {
+    label: 'Audio system and beat sync',
+    order: 20,
+    critical: false,
+    dependsOn: ['core'],
+    group: 'systems',
+  },
+  weather: {
+    label: 'Weather system',
+    order: 30,
+    critical: false,
+    dependsOn: ['core'],
+    group: 'systems',
+  },
+  worldCritical: {
+    label: 'Critical world (sky, ground, moon)',
+    order: 40,
+    critical: true,
+    dependsOn: ['core', 'weather'],
+    group: 'world',
+  },
+  musicReactivity: {
+    label: 'Music reactivity bindings',
+    order: 50,
+    critical: false,
+    dependsOn: ['audio', 'weather', 'worldCritical'],
+    group: 'systems',
+  },
+  input: {
+    label: 'Input and pointer-lock controls',
+    order: 60,
+    critical: false,
+    dependsOn: ['core', 'audio'],
+    group: 'gameplay',
+  },
+  interaction: {
+    label: 'Interaction / reticle system',
+    order: 70,
+    critical: false,
+    dependsOn: ['core', 'input'],
+    group: 'gameplay',
+  },
+  gameLoop: {
+    label: 'Game loop dependency wiring',
+    order: 80,
+    critical: true,
+    dependsOn: ['core', 'weather', 'audio', 'interaction', 'worldCritical'],
+    group: 'gameplay',
+  },
+  shaderWarmup: {
+    label: 'Shader pre-compilation',
+    order: 90,
+    critical: false,
+    dependsOn: ['core', 'postProcessing', 'gameLoop'],
+    group: 'render',
+  },
+  wasm: {
+    label: 'Emscripten WASM (optional SIMD)',
+    order: 85,
+    critical: false,
+    dependsOn: ['core'],
+    group: 'compute',
+  },
+  worldGeneration: {
+    label: 'World population (CORE / FULL map)',
+    order: 100,
+    critical: false,
+    dependsOn: ['core', 'worldCritical', 'gameLoop'],
+    group: 'world',
+  },
+  deferredVisuals: {
+    label: 'Deferred visuals (aurora, celestial)',
+    order: 110,
+    critical: false,
+    dependsOn: ['core', 'worldGeneration'],
+    group: 'deferred',
+  },
+  deferredWorld: {
+    label: 'Deferred world content',
+    order: 120,
+    critical: false,
+    dependsOn: ['core', 'worldCritical'],
+    group: 'deferred',
+  },
+};
+
+/** Preset stage toggles — applied when ?boot=<preset> or ?debug=1 without explicit toggles */
+export const BOOT_PRESETS: Record<BootPresetId, Partial<DebugStages>> = {
+  /**
+   * Empty sandbox: renderer + minimal systems only.
+   * Matches the recommended debug progression starting point.
+   */
+  sandbox: {
+    core: true,
+    postProcessing: false,
+    audio: true,
+    weather: true,
+    worldCritical: true,
+    input: true,
+    interaction: true,
+    musicReactivity: false,
+    gameLoop: true,
+    shaderWarmup: false,
+    wasm: false,
+    worldGeneration: false,
+    deferredVisuals: false,
+    deferredWorld: false,
+  },
+  /**
+   * Limited startup (current DEBUG_STAGES default): playable scene, no heavy world.
+   */
+  limited: {
+    core: true,
+    postProcessing: false,
+    audio: true,
+    weather: true,
+    worldCritical: true,
+    input: true,
+    interaction: true,
+    musicReactivity: false,
+    gameLoop: true,
+    shaderWarmup: false,
+    wasm: false,
+    worldGeneration: false,
+    deferredVisuals: false,
+    deferredWorld: false,
+  },
+  /**
+   * Standard: everything through game loop, user triggers world on Enter.
+   */
+  standard: {
+    core: true,
+    postProcessing: true,
+    audio: true,
+    weather: true,
+    worldCritical: true,
+    input: true,
+    interaction: true,
+    musicReactivity: true,
+    gameLoop: true,
+    shaderWarmup: true,
+    wasm: true,
+    worldGeneration: false,
+    deferredVisuals: false,
+    deferredWorld: false,
+  },
+  /** Full progressive load: all stages enabled */
+  full: {
+    core: true,
+    postProcessing: true,
+    audio: true,
+    weather: true,
+    worldCritical: true,
+    input: true,
+    interaction: true,
+    musicReactivity: true,
+    gameLoop: true,
+    shaderWarmup: true,
+    wasm: true,
+    worldGeneration: true,
+    deferredVisuals: true,
+    deferredWorld: true,
+  },
+};
+
+export function getOrderedStageIds(): BootStageId[] {
+  return (Object.keys(STAGE_REGISTRY) as BootStageId[]).sort(
+    (a, b) => STAGE_REGISTRY[a].order - STAGE_REGISTRY[b].order
+  );
+}
+
+export function parseBootPreset(search: string): BootPresetId | null {
+  const value = new URLSearchParams(search).get('boot');
+  if (!value) return null;
+  if (value === 'sandbox' || value === 'limited' || value === 'standard' || value === 'full') {
+    return value;
+  }
+  console.warn(`[Boot] Unknown preset "${value}" — use sandbox|limited|standard|full`);
+  return null;
+}

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -14,4 +14,26 @@ export {
   type StageMetadata,
 } from './stages.ts';
 
+export {
+  BOOT_PRESETS,
+  STAGE_REGISTRY,
+  getOrderedStageIds,
+  parseBootPreset,
+  type BootPresetId,
+  type BootStageId,
+} from './boot-registry.ts';
+
+export {
+  PROGRESSIVE_BOOT_CONFIG,
+  applyBootPreset,
+  initProgressiveBoot,
+  getBootPipelineState,
+  printBootSummary,
+  runBootStage,
+  installBootDebugHooks,
+  resetBootPipeline,
+  type ProgressiveBootConfig,
+  type BootPipelineState,
+} from './progressive-bootstrap.ts';
+
 export { DebugPanel, getDebugPanel, initDebugPanel } from './panel.ts';

--- a/src/debug/panel.ts
+++ b/src/debug/panel.ts
@@ -144,6 +144,8 @@ export class DebugPanel {
       <div style="color: #0f0; margin-bottom: 4px;">Keyboard Shortcuts:</div>
       <div>• <kbd style="background:#333;padding:1px 4px;border-radius:2px">P</kbd> - Toggle Profiler</div>
       <div>• <kbd style="background:#333;padding:1px 4px;border-radius:2px">O</kbd> - Toggle Startup Overlay</div>
+      <div style="margin-top: 6px; color: #0f0;">Boot Presets (?boot=):</div>
+      <div>sandbox → limited → standard → full</div>
       <div style="margin-top: 6px; color: #0f0;">Status Legend:</div>
       <div>⏳ Loading • ✅ Success • ❌ Failed • ⏭️ Skipped</div>
     `;

--- a/src/debug/progressive-bootstrap.ts
+++ b/src/debug/progressive-bootstrap.ts
@@ -1,0 +1,306 @@
+// src/debug/progressive-bootstrap.ts
+// Progressive boot orchestrator: ordered stages, dependency checks, halt-on-failure.
+
+import {
+  DEBUG_CONFIG,
+  DEBUG_STAGES,
+  StageLoader,
+  StageStatus,
+  showDebugError,
+  updateStageStatus,
+  type DebugStages,
+  type StageResult,
+} from './stages.ts';
+import {
+  BOOT_PRESETS,
+  STAGE_REGISTRY,
+  getOrderedStageIds,
+  parseBootPreset,
+  type BootPresetId,
+  type BootStageId,
+} from './boot-registry.ts';
+
+export interface ProgressiveBootConfig {
+  /** When true, critical stage failures stop the pipeline and surface an error */
+  haltOnFailure: boolean;
+  /** When true, skip stages whose dependencies failed or were skipped in debug mode */
+  respectDependencies: boolean;
+  /** Verbose grouped console summary after each stage */
+  verbose: boolean;
+  /** Active preset name (if any) */
+  preset: BootPresetId | null;
+}
+
+export interface BootPipelineState {
+  halted: boolean;
+  haltStage?: BootStageId;
+  haltError?: string;
+  completed: BootStageId[];
+  failed: BootStageId[];
+  skipped: BootStageId[];
+}
+
+const pipelineState: BootPipelineState = {
+  halted: false,
+  completed: [],
+  failed: [],
+  skipped: [],
+};
+
+function readBootConfig(): ProgressiveBootConfig {
+  const params = new URLSearchParams(
+    typeof window !== 'undefined' ? window.location.search : ''
+  );
+  const debug = params.has('debug');
+  const haltExplicit = params.has('halt') || params.get('halt') === '1';
+  const preset = parseBootPreset(params.toString());
+
+  return {
+    haltOnFailure: debug || haltExplicit,
+    respectDependencies: debug || haltExplicit,
+    verbose: debug || haltExplicit || params.has('boot'),
+    preset,
+  };
+}
+
+export const PROGRESSIVE_BOOT_CONFIG: ProgressiveBootConfig = readBootConfig();
+
+/**
+ * Apply a boot preset to DEBUG_STAGES (debug mode only).
+ * Call once during startup before any stages run.
+ */
+export function applyBootPreset(presetId: BootPresetId): void {
+  const preset = BOOT_PRESETS[presetId];
+  if (!preset) return;
+
+  (Object.keys(preset) as BootStageId[]).forEach((stage) => {
+    const enabled = preset[stage];
+    if (enabled !== undefined) {
+      DEBUG_STAGES[stage] = enabled;
+    }
+  });
+
+  console.log(
+    `%c[Boot] Applied preset "${presetId}"`,
+  'color: #7dd3fc; font-weight: bold'
+  );
+}
+
+/**
+ * Initialize progressive boot from URL params.
+ * - ?debug=1&boot=sandbox   → limited sandbox preset + halt on failure
+ * - ?halt=1                 → halt on critical failures without full debug UI
+ */
+export function initProgressiveBoot(): ProgressiveBootConfig {
+  resetBootPipeline();
+
+  const config = PROGRESSIVE_BOOT_CONFIG;
+
+  if (config.preset) {
+    applyBootPreset(config.preset);
+  } else if (DEBUG_CONFIG.enabled) {
+    // Debug mode without explicit preset keeps stages.ts defaults (limited/sandbox).
+    applyBootPreset('limited');
+  }
+
+  if (config.verbose) {
+    console.log(
+      '%c[Boot] Progressive startup active',
+      'color: #7dd3fc; font-weight: bold',
+      {
+        haltOnFailure: config.haltOnFailure,
+        respectDependencies: config.respectDependencies,
+        preset: config.preset ?? (DEBUG_CONFIG.enabled ? 'limited' : 'production'),
+      }
+    );
+    console.log(
+      '%c[Boot] Enable stages incrementally: ?debug=1&boot=sandbox → standard → full',
+      'color: #94a3b8'
+    );
+  }
+
+  return config;
+}
+
+export function resetBootPipeline(): void {
+  pipelineState.halted = false;
+  pipelineState.haltStage = undefined;
+  pipelineState.haltError = undefined;
+  pipelineState.completed = [];
+  pipelineState.failed = [];
+  pipelineState.skipped = [];
+}
+
+export function getBootPipelineState(): Readonly<BootPipelineState> {
+  return pipelineState;
+}
+
+function dependencyBlocked(stage: BootStageId): string | null {
+  if (!PROGRESSIVE_BOOT_CONFIG.respectDependencies) return null;
+
+  const def = STAGE_REGISTRY[stage];
+  for (const dep of def.dependsOn) {
+    if (pipelineState.failed.includes(dep)) {
+      return `dependency "${dep}" failed`;
+    }
+    if (pipelineState.skipped.includes(dep) && STAGE_REGISTRY[dep].critical) {
+      return `critical dependency "${dep}" was skipped`;
+    }
+    if (
+      DEBUG_CONFIG.enabled &&
+      !DEBUG_STAGES[dep] &&
+      STAGE_REGISTRY[dep].critical
+    ) {
+      return `critical dependency "${dep}" is disabled`;
+    }
+  }
+  return null;
+}
+
+function recordStageOutcome(stage: BootStageId, result: StageResult, skipped = false): void {
+  if (skipped) {
+    if (!pipelineState.skipped.includes(stage)) pipelineState.skipped.push(stage);
+    return;
+  }
+  if (result.success) {
+    pipelineState.completed.push(stage);
+  } else {
+    pipelineState.failed.push(stage);
+  }
+}
+
+function haltPipeline(stage: BootStageId, error: string): never {
+  pipelineState.halted = true;
+  pipelineState.haltStage = stage;
+  pipelineState.haltError = error;
+
+  printBootSummary(true);
+
+  const message = `[Boot] HALTED at stage "${stage}": ${error}`;
+  console.error(`%c${message}`, 'color: #f87171; font-weight: bold; font-size: 13px');
+
+  showDebugError(stage, new Error(error));
+  throw new Error(message);
+}
+
+/**
+ * Run a single boot stage through the progressive pipeline.
+ * Replaces direct StageLoader.loadStage calls in main.ts.
+ */
+export async function runBootStage(
+  stage: BootStageId,
+  initFn: () => Promise<void> | void
+): Promise<StageResult> {
+  if (pipelineState.halted) {
+    const skipResult: StageResult = { success: false, duration: 0, error: 'pipeline already halted' };
+    updateStageStatus(stage, StageStatus.SKIPPED, 0, skipResult.error);
+    recordStageOutcome(stage, skipResult, true);
+    return skipResult;
+  }
+
+  const blocked = dependencyBlocked(stage);
+  if (blocked) {
+    console.log(
+      `%c[${stage}] ⏭️  SKIPPED (${blocked})`,
+      'color: gray; font-weight: bold'
+    );
+    updateStageStatus(stage, StageStatus.SKIPPED, 0, blocked);
+    recordStageOutcome(stage, { success: true, duration: 0 }, true);
+    return { success: true, duration: 0 };
+  }
+
+  const result = await StageLoader.loadStage(stage, initFn);
+  recordStageOutcome(stage, result);
+
+  if (PROGRESSIVE_BOOT_CONFIG.verbose) {
+    logStageProgress(stage, result);
+  }
+
+  if (!result.success) {
+    const critical = STAGE_REGISTRY[stage].critical;
+    if (PROGRESSIVE_BOOT_CONFIG.haltOnFailure && critical) {
+      haltPipeline(stage, result.error ?? 'unknown error');
+    } else if (PROGRESSIVE_BOOT_CONFIG.haltOnFailure) {
+      console.warn(
+        `%c[Boot] Non-critical stage "${stage}" failed — continuing. Re-enable after fix.`,
+        'color: #fbbf24; font-weight: bold',
+        result.error
+      );
+    }
+  }
+
+  return result;
+}
+
+function logStageProgress(stage: BootStageId, result: StageResult): void {
+  const def = STAGE_REGISTRY[stage];
+  const index = getOrderedStageIds().indexOf(stage) + 1;
+  const total = getOrderedStageIds().length;
+  const status = result.success ? 'ok' : 'FAIL';
+  console.log(
+    `%c[Boot ${index}/${total}] ${stage} (${def.label}) → ${status}`,
+    `color: ${result.success ? '#86efac' : '#f87171'}`
+  );
+}
+
+/**
+ * Print a grouped summary of all stages — call at end of boot or on halt.
+ */
+export function printBootSummary(force = false): void {
+  if (!PROGRESSIVE_BOOT_CONFIG.verbose && !force) return;
+
+  const ordered = getOrderedStageIds();
+  console.group(
+    pipelineState.halted
+      ? `%c🛑 Boot Halted${pipelineState.haltStage ? ` @ ${pipelineState.haltStage}` : ''}`
+      : '%c✅ Boot Pipeline Summary',
+    `color: ${pipelineState.halted ? '#f87171' : '#86efac'}; font-weight: bold`
+  );
+
+  for (const stage of ordered) {
+    const def = STAGE_REGISTRY[stage];
+    let icon = '⏸️';
+    if (pipelineState.completed.includes(stage)) icon = '✓';
+    else if (pipelineState.failed.includes(stage)) icon = '✗';
+    else if (pipelineState.skipped.includes(stage)) icon = '⏭️';
+
+    const enabled = !DEBUG_CONFIG.enabled || DEBUG_STAGES[stage];
+    console.log(
+      `  ${icon} ${stage.padEnd(18)} ${enabled ? '' : '(disabled) '}${def.label}`
+    );
+  }
+
+  if (pipelineState.halted && pipelineState.haltError) {
+    console.error('  Reason:', pipelineState.haltError);
+    console.log(
+      '%c  Next: fix the error above, or disable the stage via ?debug=1 panel and reload',
+      'color: #94a3b8'
+    );
+  } else if (DEBUG_CONFIG.enabled) {
+    const nextDisabled = ordered.find(
+      (s) => !DEBUG_STAGES[s] && !pipelineState.skipped.includes(s)
+    );
+    if (nextDisabled) {
+      console.log(
+        `%c  Next stage to enable: ${nextDisabled} (${STAGE_REGISTRY[nextDisabled].label})`,
+        'color: #7dd3fc'
+      );
+    }
+  }
+
+  console.groupEnd();
+}
+
+/** Expose on window for console debugging */
+export function installBootDebugHooks(): void {
+  if (typeof window === 'undefined') return;
+  (window as any).__bootPipeline = {
+    state: () => getBootPipelineState(),
+    summary: () => printBootSummary(true),
+    preset: (id: BootPresetId) => {
+      applyBootPreset(id);
+      console.log('[Boot] Preset applied — reload to take effect');
+    },
+    stages: () => ({ ...DEBUG_STAGES }),
+  };
+}

--- a/tests/progressive-boot.test.mjs
+++ b/tests/progressive-boot.test.mjs
@@ -1,0 +1,95 @@
+// tests/progressive-boot.test.mjs
+// Unit tests for progressive boot dependency + halt logic.
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`✅ PASS: ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`❌ FAIL: ${name} — ${err.message}`);
+    failed++;
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message || 'Assertion failed');
+}
+
+// Mirrors STAGE_REGISTRY dependency checks from src/debug/boot-registry.ts
+const STAGE_REGISTRY = {
+  core: { critical: true, dependsOn: [] },
+  weather: { critical: false, dependsOn: ['core'] },
+  worldCritical: { critical: true, dependsOn: ['core', 'weather'] },
+  gameLoop: { critical: true, dependsOn: ['core', 'weather', 'interaction', 'worldCritical'] },
+  worldGeneration: { critical: false, dependsOn: ['core', 'worldCritical', 'gameLoop'] },
+};
+
+function dependencyBlocked(stage, state, debugStages, debugEnabled) {
+  const def = STAGE_REGISTRY[stage];
+  if (!def) return null;
+  for (const dep of def.dependsOn) {
+    if (state.failed.includes(dep)) return `dependency "${dep}" failed`;
+    if (state.skipped.includes(dep) && STAGE_REGISTRY[dep].critical) {
+      return `critical dependency "${dep}" was skipped`;
+    }
+    if (debugEnabled && debugStages[dep] === false && STAGE_REGISTRY[dep].critical) {
+      return `critical dependency "${dep}" is disabled`;
+    }
+  }
+  return null;
+}
+
+function shouldHalt(stage, result, haltOnFailure) {
+  if (!result.success && haltOnFailure && STAGE_REGISTRY[stage]?.critical) {
+    return true;
+  }
+  return false;
+}
+
+test('dependency: worldCritical blocked when weather failed', () => {
+  const blocked = dependencyBlocked(
+    'worldCritical',
+    { failed: ['weather'], skipped: [], completed: ['core'] },
+    { core: true, weather: true },
+    true
+  );
+  assert(blocked?.includes('weather'), 'should block on failed weather');
+});
+
+test('dependency: gameLoop blocked when critical worldCritical skipped', () => {
+  const blocked = dependencyBlocked(
+    'gameLoop',
+    { failed: [], skipped: ['worldCritical'], completed: ['core', 'weather'] },
+    { worldCritical: false },
+    true
+  );
+  assert(blocked?.includes('worldCritical'), 'should block when critical dep skipped');
+});
+
+test('halt: critical core failure triggers halt in debug mode', () => {
+  assert(
+    shouldHalt('core', { success: false }, true),
+    'core failure should halt when haltOnFailure enabled'
+  );
+});
+
+test('halt: non-critical worldGeneration failure does not halt', () => {
+  assert(
+    !shouldHalt('worldGeneration', { success: false }, true),
+    'worldGeneration failure should not halt pipeline'
+  );
+});
+
+test('preset sandbox: worldGeneration disabled in limited preset', async () => {
+  const { readFileSync } = await import('node:fs');
+  const src = readFileSync('src/debug/boot-registry.ts', 'utf8');
+  assert(src.includes('worldGeneration: false'), 'sandbox/limited presets should disable worldGeneration');
+  assert(src.includes("'sandbox'"), 'boot-registry should define sandbox preset');
+});
+
+console.log(`\n📊 Progressive boot tests: ${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Evaluates the existing **debug staging** (`?debug=1` + `StageLoader`) vs **limited/full world modes** (CORE / FULL / FAST_FULL start buttons), then begins migrating initialization into a **progressive boot pipeline** that loads subsystems in order, skips dependents with clear logs, and **halts on critical failures**.

## Evaluation (what worked / what didn't)

### Worked well
- Per-stage colored console logs made isolation practical
- Sandbox `DEBUG_STAGES` default correctly disabled heavy paths (shader warmup, world gen, WASM)
- CORE / FULL buttons gave a user-facing fast path without debug URLs
- Error boundary + loading-screen race guard prevented silent 0% hangs

### Gaps addressed in this PR
| Gap | Fix |
|-----|-----|
| Failed stages logged but boot continued | `?debug=1` or `?halt=1` halts on **critical** stage failure |
| No dependency awareness | `STAGE_REGISTRY` skips dependents with `⏭️ SKIPPED (dependency "x" failed)` |
| Debug staging vs world modes unrelated | Boot presets: `sandbox → limited → standard → full` |
| Init logic embedded in 900-line `main.ts` | Pre-loop pipeline extracted to `progressive-startup.ts` |

### Still TODO (follow-up)
- Panel checkbox toggles still require reload
- `deferredVisuals` still duplicated (DeferredLoader + background processor)
- World mode buttons (CORE/FULL) not yet mapped to boot presets automatically

## New usage

```
?debug=1&boot=sandbox     # Minimal playable scene, halt on critical failure
?debug=1&boot=standard    # Through game loop; Enter triggers world
?halt=1                   # Halt without debug panel
```

Console helpers: `window.__bootPipeline.summary()`, `.state()`, `.preset('full')`

Recommended progression: sandbox → enable `shaderWarmup` → `worldGeneration` → `postProcessing` / `wasm` / deferred stages one at a time.

## Architecture

- `src/debug/boot-registry.ts` — stage order, dependencies, presets
- `src/debug/progressive-bootstrap.ts` — `runBootStage()`, halt, dependency skip
- `src/core/progressive-startup.ts` — pre-loop boot (core → wasm)
- `src/core/main.ts` — shader warmup, Enter world, deferred queues (now via `runBootStage`)

## Testing

- `npm run test:startup` — 19 passed
- `npm run test:progressive-boot` — 5 passed (new)
- `npm run build:wasm && npx vite build` — succeeds

## Docs

- `docs/PROGRESSIVE_BOOT.md` — full evaluation + usage guide
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd621e2e-e874-4237-8897-35b79c98c037"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd621e2e-e874-4237-8897-35b79c98c037"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

