### PR TITLE
♿ Aria: [UX improvement] Accessible Canvas Focus & Live Region

### DIFF
--- a/index.html
+++ b/index.html
@@ -887,7 +887,8 @@
         </button>
     </div>
 
-    <canvas id="glCanvas" role="img" aria-label="Game World: Use mouse and keyboard to navigate"></canvas>
+    <canvas id="glCanvas" role="img" aria-label="Immersive pastel candy forest world with glowing mushrooms, floating clouds, and music-reactive elements" tabindex="0" aria-live="polite" aria-describedby="world-status"></canvas>
+    <div id="world-status" aria-live="polite" class="visually-hidden">Loading candy world...</div>
     <script type="module" src="src/main.ts"></script>
 </body>
 

--- a/src/core/main.ts
+++ b/src/core/main.ts
@@ -286,6 +286,7 @@ console.log(`[Startup] Camera positioned at ground height: y=${camera.position.y
 
 // --- START BUTTON + MAP GENERATION (unchanged UX) ---
 const startButton = document.getElementById('startButton') as HTMLButtonElement | null;
+const statusEl = document.getElementById('world-status');
 
 if (startButton) {
     startButton.disabled = false;
@@ -451,6 +452,11 @@ if (startButton) {
                 const baseLabel = label ?? getGenerationLabel(requestedMode);
                 const progressLabel = entityType ? `${baseLabel} · ${entityType}` : baseLabel;
                 loadingScreen.updateProgress(percent, progressLabel);
+
+                if (statusEl) {
+                    statusEl.textContent = progressLabel;
+                }
+
                 startButton.style.background = requestedMode === 'CORE'
                     ? `linear-gradient(90deg, #FF9ECD ${percent}%, #FFD4E3 ${percent}%)`
                     : `linear-gradient(90deg, #FF6B6B ${percent}%, #FFB6C1 ${percent}%)`;
@@ -477,6 +483,10 @@ if (startButton) {
             loadingScreen.updateProgress(100, 'World generation complete!');
             loadingScreen.completePhase('map-generation');
             loadingScreen.hide();
+
+            if (statusEl) {
+                statusEl.textContent = 'World generated. Welcome to Candy World.';
+            }
 
             // ♿ Aria: Announce that the game is fully loaded and exploration has started
             import('../ui/announcer.ts').then(({ announce }) => {

--- a/style.css
+++ b/style.css
@@ -629,3 +629,22 @@ button.keyboard-active,
     transform: scale(0.95);
     transition: transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 }
+
+
+/* ♿ Aria: Canvas focus visible state */
+#glCanvas:focus-visible {
+    outline: 3px solid rgba(255, 182, 255, 0.8);
+    box-shadow: 0 0 20px rgba(180, 255, 200, 0.6);
+}
+
+
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+}


### PR DESCRIPTION
This PR implements accessibility improvements to the core WebGPU canvas in Candy World to make it more inclusive for screen reader and keyboard users:
- **Screen Reader Announcements**: An invisible `aria-live="polite"` region has been added (`#world-status`) that announces loading and world population progress dynamically. The canvas links to this using `aria-describedby`.
- **Canvas Focusability**: The main `<canvas>` element now has `tabindex="0"` and a descriptive `aria-label` detailing the immersive candy landscape. 
- **Focus Polish**: A subtle, pastel pink focus ring (`#glCanvas:focus-visible`) has been added using CSS `outline` and `box-shadow` for keyboard users, avoiding the default browser styles while preventing focus outlines on mouse clicks.

---
*PR created automatically by Jules for task [15153437265108453141](https://jules.google.com/task/15153437265108453141) started by @ford442*