### PR TITLE
🎨 Palette: [Visual Polish] Add TSL Juice to Subwoofer Lotus

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -105,3 +105,7 @@ Status: Implemented ✅
 Next Step: Ask the user for the next task.
 * Implementation Details: Applied "Juice" to the `flowers.ts` component by adding `calculateWindSway` and `applyPlayerInteraction` TSL logic into the position graph so that it responds dynamically to weather and player forces.
 Next Step: Ask the user for the next task.
+
+Status: Implemented ✅
+* Implementation Details: Applied "Juice" to the `subwoofer-lotus-batcher.ts` component by adding `calculateWindSway`, `applyPlayerInteraction`, and `createJuicyRimLight` TSL logic to the base pad, rings, and center portal.
+Next Step: Ask the user for the next task.

--- a/src/foliage/subwoofer-lotus-batcher.ts
+++ b/src/foliage/subwoofer-lotus-batcher.ts
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { MeshStandardNodeMaterial } from 'three/webgpu';
 import {
-    color, float, vec3, positionLocal,
+    color, float, vec3, positionLocal, normalLocal,
     mix, sin, abs, smoothstep,
     mx_noise_float, uv, length, atan2, max
 } from 'three/tsl';
@@ -11,7 +11,10 @@ import {
     registerReactiveMaterial,
     uAudioLow,
     uGlitchIntensity,
-    uTime
+    uTime,
+    createJuicyRimLight,
+    calculateWindSway,
+    applyPlayerInteraction
 } from './index.ts';
 import { BiomeUniforms } from '../systems/biome-uniforms.ts';
 import { makeInteractive } from '../utils/interaction-utils.ts';
@@ -44,6 +47,7 @@ export class SubwooferLotusBatcher {
 
         // 1. Base Pad
         const padMat = createClayMaterial(hexColor);
+        padMat.positionNode = applyPlayerInteraction(positionLocal.add(calculateWindSway(positionLocal)));
         this.padMesh = new THREE.InstancedMesh(sharedGeometries.unitCylinder, padMat, MAX_LOTUS);
         this.padMesh.count = 0;
         this.padMesh.castShadow = true;
@@ -78,10 +82,10 @@ export class SubwooferLotusBatcher {
             .mul(uTwilight)
             .mul(float(CONFIG.glow.glowIntensityMax))
             .mul(float(0.3).add(idlePulse));
-        ringMat.emissiveNode = emission.add(twilightGlowTint);
+        ringMat.emissiveNode = emission.add(twilightGlowTint).add(createJuicyRimLight(color(0x00FFFF), float(2.0), float(3.0), normalLocal));
 
         const newPos = positionLocal.add(vec3(0.0, displacement, 0.0));
-        ringMat.positionNode = newPos;
+        ringMat.positionNode = applyPlayerInteraction(newPos.add(calculateWindSway(newPos)));
 
         registerReactiveMaterial(ringMat);
 
@@ -124,6 +128,7 @@ export class SubwooferLotusBatcher {
 
         centerMat.colorNode = vec3(0.0);
         centerMat.emissiveNode = finalPortal.add(hotCenter);
+        centerMat.positionNode = applyPlayerInteraction(positionLocal.add(calculateWindSway(positionLocal)));
 
         this.centerMesh = new THREE.InstancedMesh(centerGeo, centerMat, MAX_LOTUS);
         this.centerMesh.count = 0;


### PR DESCRIPTION
This PR adds high-impact TSL visual polish (Juice) to the `SubwooferLotusBatcher`.

**Visual Change:**
The Subwoofer Lotus now sways with the wind, displaces interactively when the player walks over it, and features a glossy, neon-cyan rim light on its rings that responds to audio reactivity and day/night cycles.

**"Juice" Factor:**
It integrates movement (wind + player interaction) and lighting (rim light) directly via TSL nodes without any CPU cost, elevating a previously static batcher into a living, responsive part of the "Candy World" environment.

**Technical Details:**
- Imported `calculateWindSway`, `applyPlayerInteraction`, and `createJuicyRimLight`.
- Fixed node composition order by feeding the base position plus the wind sway offset into `applyPlayerInteraction(pos.add(windOffset))`. This prevents the position doubling bug that occurs when chaining absolute position functions with `.add()`.
- Implemented TSL rim light onto the existing emissive node mix.

---
*PR created automatically by Jules for task [2970155613911991897](https://jules.google.com/task/2970155613911991897) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dynamic visual effects to lotus foliage including player interaction response, wind sway animations, and enhanced rim lighting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->