### PR TITLE
♿ Aria: Fix aria-pressed anti-pattern for momentary buttons

### DIFF
--- a/src/ui/accessibility-menu-rendering.ts
+++ b/src/ui/accessibility-menu-rendering.ts
@@ -102,8 +102,8 @@ export class AccessibilityMenuRendering extends AccessibilityMenuCore {
       font-size: 1.2rem;
     `;
     closeBtn.onclick = () => {
-      closeBtn.setAttribute('aria-pressed', 'true');
-      setTimeout(() => closeBtn.setAttribute('aria-pressed', 'false'), 150);
+      closeBtn.classList.add('keyboard-active');
+      setTimeout(() => closeBtn.classList.remove('keyboard-active'), 150);
       this.close();
     };
     closeBtn.setAttribute('aria-label', 'Close accessibility menu');
@@ -172,8 +172,8 @@ export class AccessibilityMenuRendering extends AccessibilityMenuCore {
         text-align: left;
       `;
       tab.onclick = () => {
-        tab.setAttribute('aria-pressed', 'true');
-        setTimeout(() => tab.setAttribute('aria-pressed', 'false'), 150);
+        tab.classList.add('keyboard-active');
+        setTimeout(() => tab.classList.remove('keyboard-active'), 150);
         this.switchSection(section as MenuSection);
       };
 
@@ -355,8 +355,8 @@ export class AccessibilityMenuRendering extends AccessibilityMenuCore {
       btn.textContent = binding.key || 'Unbound';
       btn.style.cssText = `${this.getButtonStyle()} width: 120px;`;
       btn.onclick = () => {
-        btn.setAttribute('aria-pressed', 'true');
-        setTimeout(() => btn.setAttribute('aria-pressed', 'false'), 150);
+        btn.classList.add('keyboard-active');
+        setTimeout(() => btn.classList.remove('keyboard-active'), 150);
         this.startKeyRebind(action, btn);
       };
 

--- a/src/ui/accessibility-menu.css
+++ b/src/ui/accessibility-menu.css
@@ -37,12 +37,16 @@
 /* 🎨 Palette: "Game Feel" Active Pressed State */
 .a11y-tab:active,
 .a11y-tab[aria-pressed="true"],
+.a11y-tab.keyboard-active,
 .a11y-button:active,
 .a11y-button[aria-pressed="true"],
+.a11y-button.keyboard-active,
 .a11y-preset-card:active,
 .a11y-preset-card[aria-pressed="true"],
+.a11y-preset-card.keyboard-active,
 .a11y-close-btn:active,
-.a11y-close-btn[aria-pressed="true"] {
+.a11y-close-btn[aria-pressed="true"],
+.a11y-close-btn.keyboard-active {
     transform: scale(0.95);
     transition-duration: 0.05s;
 }

--- a/tests/ability-hud-accessibility.test.ts
+++ b/tests/ability-hud-accessibility.test.ts
@@ -93,24 +93,24 @@ test('triggerAbility sets keyState to true immediately', () => {
   keyStates.dash = false;
 });
 
-test('triggerAbility applies pressed class to element', () => {
+test('triggerAbility applies keyboard-active class to element', () => {
   const el = createMockElement();
 
   triggerAbility('dash', el as unknown as HTMLElement);
-  assertTrue(el.classList.contains('pressed'), 'pressed class should be added immediately');
+  assertTrue(el.classList.contains('keyboard-active'), 'keyboard-active class should be added immediately');
 
   // Clean up
   keyStates.dash = false;
 });
 
-test('triggerAbility removes pressed class after timeout', async () => {
+test('triggerAbility removes keyboard-active class after timeout', async () => {
   const el = createMockElement();
 
   triggerAbility('action', el as unknown as HTMLElement);
-  assertTrue(el.classList.contains('pressed'), 'pressed class should be added immediately');
+  assertTrue(el.classList.contains('keyboard-active'), 'keyboard-active class should be added immediately');
 
   await new Promise(resolve => setTimeout(resolve, 150));
-  assertEqual(el.classList.contains('pressed'), false, 'pressed class should be removed after timeout');
+  assertEqual(el.classList.contains('keyboard-active'), false, 'keyboard-active class should be removed after timeout');
 
   keyStates.action = false;
 });


### PR DESCRIPTION
💡 What: Replaced rapid toggling of `aria-pressed` with a visual-only `.keyboard-active` CSS class in the Accessibility Menu rendering for momentary button clicks.
🎯 Why: Rapidly toggling `aria-pressed` state just to trigger a visual CSS transform is an accessibility anti-pattern because it spams screen readers with conflicting state changes ("pressed", then "not pressed" 150ms later). This change maintains the juicy "Game Feel" pop while keeping screen readers silent for momentary actions.
♿ Accessibility: Preserved focus states while separating visual click feedback from semantic ARIA state. Tests updated.

---
*PR created automatically by Jules for task [4999460670680246915](https://jules.google.com/task/4999460670680246915) started by @ford442*