### PR TITLE
🎨 Palette: Add Wind Sway to Batched Mushrooms

### DIFF
--- a/src/foliage/mushroom-batcher.ts
+++ b/src/foliage/mushroom-batcher.ts
@@ -16,7 +16,7 @@ const modFloat = (x: any, y: any) => {
 import {
     sharedGeometries, foliageMaterials, uTime,
     uAudioLow, uAudioHigh, createRimLight, createJuicyRimLight, uPlayerPosition, colorFromNote,
-    createSugarSparkle, applyPlayerInteraction
+    createSugarSparkle, applyPlayerInteraction, calculateWindSway, getCachedProceduralMaterial
 } from './index.ts';
 import { uTwilight } from './sky.ts';
 import { BiomeUniforms, uCircadianPhase } from '../systems/biome-uniforms.ts';
@@ -529,15 +529,23 @@ export class MushroomBatcher {
         // --- Material Definitions ---
 
         // 0. Stem
-        const stemMat = (foliageMaterials.mushroomStem as MeshStandardNodeMaterial).clone();
-        stemMat.positionNode = applyPlayerInteraction(deform(positionLocal));
+        const stemMat = getCachedProceduralMaterial('mushroom_stem_wind', 0xFFFFFF, () => {
+            const m = (foliageMaterials.mushroomStem as MeshStandardNodeMaterial).clone();
+            const defPos = deform(positionLocal);
+            m.positionNode = applyPlayerInteraction(defPos.add(calculateWindSway(defPos)));
+            return m;
+        }) as MeshStandardNodeMaterial;
 
         // 1. Cap
         // PALETTE: Upgraded to use instanceColor + Juicy Rim Light
         // mushroomCap is an array of materials in common.ts
         const capList = foliageMaterials.mushroomCap as MeshStandardNodeMaterial[];
-        const capMat = capList[0].clone();
-        capMat.positionNode = applyPlayerInteraction(deform(positionLocal));
+        const capMat = getCachedProceduralMaterial('mushroom_cap_wind', 0xFFFFFF, () => {
+            const m = capList[0].clone();
+            const defPos = deform(positionLocal);
+            m.positionNode = applyPlayerInteraction(defPos.add(calculateWindSway(defPos)));
+            return m;
+        }) as MeshStandardNodeMaterial;
 
         // Base color from instance (set via register/setColorAt)
         // Uses the vInstanceColor varying populated by InstancedMeshNode
@@ -600,13 +608,21 @@ export class MushroomBatcher {
         capMat.emissiveIntensityNode = float(1.0); // Resetting multiplier since we multiply inside node
 
         // 2. Gills
-        const gillMat = (foliageMaterials.mushroomGills as MeshStandardNodeMaterial).clone();
-        gillMat.positionNode = applyPlayerInteraction(deform(positionLocal));
-        gillMat.emissiveIntensityNode = totalGlow.mul(0.3);
+        const gillMat = getCachedProceduralMaterial('mushroom_gill_wind', 0xFFFFFF, () => {
+            const m = (foliageMaterials.mushroomGills as MeshStandardNodeMaterial).clone();
+            const defPos = deform(positionLocal);
+            m.positionNode = applyPlayerInteraction(defPos.add(calculateWindSway(defPos)));
+            m.emissiveIntensityNode = totalGlow.mul(0.3);
+            return m;
+        }) as MeshStandardNodeMaterial;
 
         // 3. Spots
-        const spotMat = (foliageMaterials.mushroomSpots as MeshStandardNodeMaterial).clone();
-        spotMat.positionNode = applyPlayerInteraction(deform(positionLocal));
+        const spotMat = getCachedProceduralMaterial('mushroom_spot_wind', 0xFFFFFF, () => {
+            const m = (foliageMaterials.mushroomSpots as MeshStandardNodeMaterial).clone();
+            const defPos = deform(positionLocal);
+            m.positionNode = applyPlayerInteraction(defPos.add(calculateWindSway(defPos)));
+            return m;
+        }) as MeshStandardNodeMaterial;
         const spotPulse = sin(uTime.mul(3.0)).mul(0.1).add(0.3);
         const spotAudio = uAudioHigh.mul(0.8); // 🎨 PALETTE: Make spots pop more on highs
         spotMat.emissiveIntensityNode = flashIntensity.add(spotPulse).add(spotAudio);


### PR DESCRIPTION
Visual Change: The batched mushrooms (stems, caps, gills, spots) now sway organically in the wind in addition to reacting to player interaction.

Juice Factor: Increases the game feel by having the world react dynamically to both the player and the global wind uniforms, improving organic immersion.

Technical:
- Extracted duplicate `deform(positionLocal)` TSL calls into local variables `defPos` to prevent double evaluation in the WebGPU compilation graph.
- Rewrote the inline material `.clone()` logic to use `getCachedProceduralMaterial`, establishing a module-level material cache to prevent severe WebGPU compilation freezes during batcher initialization.
- Imported `calculateWindSway` and correctly nested it using `applyPlayerInteraction(defPos.add(calculateWindSway(defPos)))` to avoid compounding visual explosions.

---
*PR created automatically by Jules for task [51325362055746202](https://jules.google.com/task/51325362055746202) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Mushroom visual rendering has been refactored with improvements to material consistency across stem, cap, gills, and spot components. Deformation effects, interactive player responses, and environmental wind sway continue to work exactly as before with no changes to visual output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->