### PR TITLE
🎨 Palette: Add keyboard active state to loading screen buttons

### DIFF
--- a/src/ui/loading-screen-ui.ts
+++ b/src/ui/loading-screen-ui.ts
@@ -207,6 +207,12 @@ export class LoadingScreen {
             this.skipButton.innerHTML = '<span aria-hidden="true">⏭️ </span>Skip Optional Content';
             this.skipButton.style.display = 'none';
             this.skipButton.addEventListener('click', () => this.skipCurrentPhase());
+            this.skipButton.addEventListener('keydown', (e: KeyboardEvent) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    this.skipButton!.classList.add('keyboard-active');
+                    setTimeout(() => this.skipButton!.classList.remove('keyboard-active'), 150);
+                }
+            });
             content.appendChild(this.skipButton);
         }
 
@@ -925,6 +931,12 @@ export class LoadingScreen {
                 reloadBtn.setAttribute('aria-label', 'Reload page to try again');
                 reloadBtn.innerHTML = '<span aria-hidden="true">🔄</span> Reload Page';
                 reloadBtn.addEventListener('click', () => window.location.reload());
+                reloadBtn.addEventListener('keydown', (e: KeyboardEvent) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        reloadBtn.classList.add('keyboard-active');
+                        setTimeout(() => reloadBtn.classList.remove('keyboard-active'), 150);
+                    }
+                });
                 this.container.querySelector('.loading-content')?.appendChild(reloadBtn);
             }
         }

--- a/src/ui/loading-screen.css
+++ b/src/ui/loading-screen.css
@@ -419,7 +419,9 @@
 }
 
 .skip-button:active,
-.fatal-error-reload:active {
+.skip-button.keyboard-active,
+.fatal-error-reload:active,
+.fatal-error-reload.keyboard-active {
   transform: translateY(0) scale(0.95);
   transition-duration: 0.05s;
   box-shadow: 


### PR DESCRIPTION
Added tactile 'Game Feel' feedback (via `.keyboard-active` mapping to `:active` CSS scale properties) to the loading screen's skip and reload buttons when activated using the keyboard.

---
*PR created automatically by Jules for task [5801116610116770591](https://jules.google.com/task/5801116610116770591) started by @ford442*