### PR TITLE
♿ Aria: [Toggle Accessibility Improvement] Add role=switch and aria-checked to UI toggles

### DIFF
--- a/index.html
+++ b/index.html
@@ -675,7 +675,7 @@
                 🌿 Fast Full (Light)
             </button>
             <label id="wait-full-label" class="wait-full-option" style="display:flex;align-items:center;justify-content:center;gap:8px;margin-top:12px;cursor:pointer;font-size:0.82rem;opacity:0.85;">
-                <input type="checkbox" id="wait-full-checkbox" style="width:15px;height:15px;cursor:pointer;accent-color:#FFB6C1;">
+                <input type="checkbox" id="wait-full-checkbox" role="switch" aria-checked="false" style="width:15px;height:15px;cursor:pointer;accent-color:#FFB6C1;">
                 <span>Wait for complete scenery before entering</span>
             </label>
         </div>

--- a/src/core/main.ts
+++ b/src/core/main.ts
@@ -572,8 +572,10 @@ if (startButton) {
     const waitFullCheckbox = document.getElementById('wait-full-checkbox') as HTMLInputElement | null;
     if (waitFullCheckbox) {
         waitFullCheckbox.checked = waitForFullPopulation;
+        waitFullCheckbox.setAttribute('aria-checked', String(waitForFullPopulation));
         waitFullCheckbox.addEventListener('change', () => {
             waitForFullPopulation = waitFullCheckbox.checked;
+            waitFullCheckbox.setAttribute('aria-checked', String(waitForFullPopulation));
             localStorage.setItem(WAIT_FULL_KEY, waitForFullPopulation ? '1' : '0');
         });
     }

--- a/src/ui/accessibility-menu-rendering.ts
+++ b/src/ui/accessibility-menu-rendering.ts
@@ -537,8 +537,13 @@ export class AccessibilityMenuRendering extends AccessibilityMenuCore {
     checkbox.type = 'checkbox';
     checkbox.id = id;
     checkbox.checked = checked;
+    checkbox.setAttribute('role', 'switch');
+    checkbox.setAttribute('aria-checked', String(checked));
     checkbox.style.cssText = 'width: 20px; height: 20px; cursor: pointer;';
-    checkbox.onchange = () => onChange(checkbox.checked);
+    checkbox.onchange = () => {
+      checkbox.setAttribute('aria-checked', String(checkbox.checked));
+      onChange(checkbox.checked);
+    };
 
     wrapper.appendChild(labelEl);
     wrapper.appendChild(checkbox);


### PR DESCRIPTION
💡 What: Added `role="switch"` and active management of the `aria-checked` attribute to all custom toggle checkboxes in the UI (specifically `wait-full-checkbox` on the main screen and dynamically generated toggles in the Accessibility Menu).

🎯 Why: To ensure screen readers announce these inputs as true "On/Off" switches rather than generic form checkboxes, fulfilling the AGENTS.md requirement for true on/off toggle inputs.

♿ Accessibility: The semantic meaning of toggles is now properly conveyed to assistive technologies, making the settings menus much more intuitive for keyboard and screen-reader users to navigate.

---
*PR created automatically by Jules for task [8875508309425805913](https://jules.google.com/task/8875508309425805913) started by @ford442*