### PR TITLE
⚡ Bolt: Fix Scene-Loading Regression by fixing world generation tokens

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -102,6 +102,10 @@ Status: Implemented ✅
 Next Step: Wait for user instructions.
 
 Status: Implemented ✅
+* Implementation Details: Fixed the Root-cause of the Scene-Loading Regression (#1133) by making `worldGenerationToken` the single source of truth across the boot sequence and properly passing `taskToken` in the background deferred task processor. Further stabilized background-processor by giving tasks a single-retry threshold.
+Next Step: Provide instructions for next feature.
+
+Status: Implemented ✅
 * Implementation Details: Replaced single mesh subwoofer lotus with `SubwooferLotusBatcher` in `src/foliage/subwoofer-lotus-batcher.ts`, fully adopting `InstancedMesh` with TSL bass pulse scaling, glitch distortion, and proper VRAM disposal for the Subwoofer Lotus.
 Next Step: Continue large file refactoring from `REFACTORING_PLAN_REMAINING.md`.
 1. *Add `dispose` method to `LuminousPlantBatcher` in `src/foliage/luminous-plant-batcher.ts`.*

--- a/src/utils/background-processor.ts
+++ b/src/utils/background-processor.ts
@@ -18,6 +18,7 @@ export interface DeferredTask {
     id: string;
     execute: () => void | Promise<void>;
     priority?: number;
+    retryCount?: number;
 }
 
 // Detect requestIdleCallback at module level to avoid repeated property lookups.
@@ -164,6 +165,12 @@ export class BackgroundProcessor {
                     await result;
                 }
             } catch (e) {
+                if ((task.retryCount || 0) < 1) {
+                    task.retryCount = (task.retryCount || 0) + 1;
+                    console.warn(`[BackgroundProcessor] Task ${task.id} failed, retrying once. Error:`, e);
+                    this.queue.unshift(task);
+                    continue;
+                }
                 console.error(`[BackgroundProcessor] Error executing task ${task.id}:`, e);
                 maybeRecordBackgroundFailure(task.id, e);
                 this.failedTasks++;

--- a/src/world/generation-core.ts
+++ b/src/world/generation-core.ts
@@ -479,7 +479,7 @@ export async function generateMap(
                 id: `map_stream_${queuedType}_${queuedId}`,
                 priority: streamPriority,
                 execute: () => {
-                    const currentToken = (window as any).__currentWorldGenerationToken ?? 0;
+                    const currentToken = worldGenerationToken;
                     if (taskToken !== currentToken && !(window as any).__IS_FULL_BOOT_TEST) {
                         console.warn(`[Generation] Map task obsoleted (token ${taskToken} !== ${currentToken})`);
                         return;
@@ -518,7 +518,7 @@ export async function generateMap(
             id: `map_fallback_${item.type}_${item.id}`,
             priority: 1,
             execute: () => {
-                const currentToken = (window as any).__currentWorldGenerationToken ?? 0;
+                const currentToken = worldGenerationToken;
                 if (taskToken !== currentToken && !(window as any).__IS_FULL_BOOT_TEST) {
                     console.warn(`[Generation] Map fallback task obsoleted (token ${taskToken} !== ${currentToken})`);
                     return;
@@ -708,7 +708,6 @@ export async function populateWorld(
 ): Promise<WorldMode> {
     worldGenerationToken = Date.now();
     const currentToken = worldGenerationToken;
-    (window as any).__currentWorldGenerationToken = currentToken;
     console.log(`[World] Starting populateWorld() in ${mode} mode`);
 
     // Fast Full Mode: apply aggressive population reduction on top of user config

--- a/src/world/generation-decorators.ts
+++ b/src/world/generation-decorators.ts
@@ -521,14 +521,12 @@ export async function populateProceduralExtras(
     // Sort deferred extras nearest-first so the background processor populates the
     // area around the player before filling in the far horizon.
     deferredItems.sort((a, b) => a.distSq - b.distSq);
-    const currentTaskToken = worldGenerationToken;
     for (const item of deferredItems) {
         // ⚡ OPTIMIZATION: Bypassed Math.sqrt() in hot procedural sorting loop using distance decay estimation
         const priority = Math.max(1, 60 - Math.floor(item.distSq / 16));
         globalBackgroundProcessor.enqueue({ id: item.id, execute: () => {
-             const currentToken = (window as any).__currentWorldGenerationToken ?? worldGenerationToken;
-             if (currentTaskToken !== -1 && currentTaskToken !== currentToken && !(window as any).__IS_FULL_BOOT_TEST) {
-                 console.warn(`[Generation] Procedural task obsoleted (token ${currentTaskToken} !== ${currentToken})`);
+             if (taskToken !== -1 && taskToken !== worldGenerationToken && !(window as any).__IS_FULL_BOOT_TEST) {
+                 console.warn(`[Generation] Procedural task obsoleted (token ${taskToken} !== ${worldGenerationToken})`);
                  return;
              }
              item.execute();


### PR DESCRIPTION
This submission implements a fix for the Scene-Loading Regression (#1133) where objects/scenery would silently disappear upon startup in FULL mode. The issue stemmed from a set of fragile token-tracking logic used for cancelling deferred tasks when the map sequence is updated.

Changes:
- Replaced unreliable token tracking using `(window as any).__currentWorldGenerationToken` with a single source of truth token generated by `populateWorld` acting as `Date.now()`.
- Addressed propagation errors in `populateProceduralExtras` that missed using the `taskToken` parameter entirely, resolving procedural population bugs.
- Implemented a single retry capability inside the `globalBackgroundProcessor` handling to recover tasks dynamically if they fail execution immediately.

---
*PR created automatically by Jules for task [16995631750939451870](https://jules.google.com/task/16995631750939451870) started by @ford442*