### PR TITLE
⚡ Bolt: Direct Typed Array Writes Optimization

### DIFF
--- a/src/foliage/flower-batcher.ts
+++ b/src/foliage/flower-batcher.ts
@@ -445,6 +445,8 @@ export class FlowerBatcher {
 
         // Update aPoseState for all active instances across all meshes
         const meshes = [this.stems, this.centers, this.stamens, this.petalsSimple, this.petalsMulti, this.petalsSpiral];
+        // ⚡ OPTIMIZATION: Get reference to the entire pose array once instead of calling getPose(i) in the inner loop
+        const poses = this._poseMachine.currentPoses;
         for (const mesh of meshes) {
             if (!mesh || mesh.count === 0) continue;
             const attr = mesh.geometry.attributes.aPoseState as THREE.InstancedBufferAttribute;
@@ -452,11 +454,12 @@ export class FlowerBatcher {
             
             // ⚡ OPTIMIZATION: Bypassed THREE.BufferAttribute.setX overhead by writing directly to typed array
             const array = attr.array as Float32Array;
-            for (let i = 0; i < mesh.count; i++) {
+            const count = mesh.count;
+            for (let i = 0; i < count; i++) {
                 // _poseMachine covers up to MAX_PETALS, which is MAX_FLOWERS * 8
                 // Ensure we don't read out of bounds. Stamens can have up to MAX_FLOWERS * 3 instances.
                 // Stems and Centers have up to MAX_FLOWERS instances.
-                array[i * attr.itemSize] = this._poseMachine.getPose(i);
+                array[i] = poses[i];
             }
             attr.needsUpdate = true;
         }

--- a/src/foliage/mushroom-batcher.ts
+++ b/src/foliage/mushroom-batcher.ts
@@ -713,7 +713,13 @@ export class MushroomBatcher {
         const packedFlags = (noteIndex + 1) + hasFace * 20 + isGiant * 40;
         
         // instanceData: x=packedFlags, y=spawnTime, z=triggerTime, w=velocity
-        this.instanceData!.setXYZW(i, packedFlags, spawnTime, -100.0, 0);
+        // ⚡ OPTIMIZATION: Bypassed THREE.BufferAttribute.setXYZW overhead by writing directly to typed array
+        const instanceDataArray = this.instanceData!.array as Float32Array;
+        const i4 = i * 4;
+        instanceDataArray[i4] = packedFlags;
+        instanceDataArray[i4 + 1] = spawnTime;
+        instanceDataArray[i4 + 2] = -100.0;
+        instanceDataArray[i4 + 3] = 0;
 
         // 3. Update Mapping
         if (noteIndex >= 0) {
@@ -739,7 +745,8 @@ export class MushroomBatcher {
 
         // 1. Remove from Note Mapping
         // Decode noteIndex from packedFlags: noteIndex = (packed % 20) - 1
-        const removedPackedFlags = this.instanceData!.getX(indexToRemove);
+        const instanceDataArray = this.instanceData!.array as Float32Array;
+        const removedPackedFlags = instanceDataArray[indexToRemove * 4];
         const removedNoteIndex = (removedPackedFlags % 20) - 1;
         if (removedNoteIndex >= 0) {
             const list = this.noteToInstances.get(removedNoteIndex);
@@ -753,7 +760,7 @@ export class MushroomBatcher {
         if (indexToRemove !== lastIndex) {
             const lastId = this.instanceToLogicId[lastIndex];
             // Decode noteIndex from packedFlags
-            const lastPackedFlags = this.instanceData!.getX(lastIndex);
+            const lastPackedFlags = instanceDataArray[lastIndex * 4];
             const movedNoteIndex = (lastPackedFlags % 20) - 1;
 
             // A. Copy Attributes from Last to Removed
@@ -774,13 +781,13 @@ export class MushroomBatcher {
             }
 
             // Single packed attribute
-            this.instanceData!.setXYZW(
-                indexToRemove,
-                this.instanceData!.getX(lastIndex),
-                this.instanceData!.getY(lastIndex),
-                this.instanceData!.getZ(lastIndex),
-                this.instanceData!.getW(lastIndex)
-            );
+            // ⚡ OPTIMIZATION: Bypassed setXYZW overhead
+            const iRem4 = indexToRemove * 4;
+            const iLast4 = lastIndex * 4;
+            instanceDataArray[iRem4] = instanceDataArray[iLast4];
+            instanceDataArray[iRem4 + 1] = instanceDataArray[iLast4 + 1];
+            instanceDataArray[iRem4 + 2] = instanceDataArray[iLast4 + 2];
+            instanceDataArray[iRem4 + 3] = instanceDataArray[iLast4 + 3];
 
             // B. Update Note Mapping for the MOVED instance
             if (movedNoteIndex >= 0) {
@@ -818,10 +825,13 @@ export class MushroomBatcher {
             const now = ((uTime as any).value !== undefined) ? (uTime as any).value : performance.now() / 1000.0;
             const normalizedVelocity = velocity / 127.0;
 
+            const instanceDataArray = this.instanceData!.array as Float32Array;
+
             for (const i of indices) {
                 // Update triggerTime (z) and velocity (w) in packed attribute
-                this.instanceData!.setZ(i, now);
-                this.instanceData!.setW(i, normalizedVelocity); // Normalize velocity
+                // ⚡ OPTIMIZATION: Bypassed BufferAttribute setters
+                instanceDataArray[i * 4 + 2] = now;
+                instanceDataArray[i * 4 + 3] = normalizedVelocity; // Normalize velocity
 
                 // PALETTE: Spawn Spores!
                 if (this.mesh) {

--- a/src/foliage/plant-pose-machine.ts
+++ b/src/foliage/plant-pose-machine.ts
@@ -130,6 +130,11 @@ export class PlantPoseMachine {
         }
     }
 
+    /** Get the entire array of current poses (⚡ OPTIMIZATION) */
+    get currentPoses(): Float32Array {
+        return this._currentPose;
+    }
+
     /** Read the current (smoothed) pose value for instance `index`. */
     getPose(index: number): number {
         return this._currentPose[index];

--- a/src/foliage/tree-batcher.ts
+++ b/src/foliage/tree-batcher.ts
@@ -672,8 +672,16 @@ export class TreeBatcher {
 
         const typeAttr = mesh.geometry.attributes.instanceAnimType as THREE.InstancedBufferAttribute;
         const offsetAttr = mesh.geometry.attributes.instanceAnimOffset as THREE.InstancedBufferAttribute;
-        if (typeAttr) { typeAttr.setX(index, animType); typeAttr.needsUpdate = true; }
-        if (offsetAttr) { offsetAttr.setX(index, animOffset); offsetAttr.needsUpdate = true; }
+
+        // ⚡ OPTIMIZATION: Direct array write bypasses setX() overhead
+        if (typeAttr?.array) {
+            (typeAttr.array as Float32Array)[index] = animType;
+            typeAttr.needsUpdate = true;
+        }
+        if (offsetAttr?.array) {
+            (offsetAttr.array as Float32Array)[index] = animOffset;
+            offsetAttr.needsUpdate = true;
+        }
 
         // Update count
         switch (countProp) {

--- a/src/particles/cpu-particle-system.ts
+++ b/src/particles/cpu-particle-system.ts
@@ -226,6 +226,11 @@ export class CPUParticleSystem {
         const posAttr = this.mesh.geometry.getAttribute('position') as THREE.BufferAttribute;
         const positions = posAttr.array as Float32Array;
         
+        // ⚡ OPTIMIZATION: Cache timestamp once per frame
+        const now = Date.now();
+        const timeOffsetFirefly = Math.cos(now * 0.001);
+        const timeOffsetPollen = now * 0.0005;
+
         // Update each particle
         for (let i = 0; i < this.count; i++) {
             const idx = i * 3;
@@ -240,10 +245,10 @@ export class CPUParticleSystem {
                 // Update based on type
                 switch (this.type) {
                     case 'fireflies':
-                        this.updateFirefly(i, deltaTime, playerPosition, audioData);
+                        this.updateFirefly(i, deltaTime, playerPosition, audioData, timeOffsetFirefly);
                         break;
                     case 'pollen':
-                        this.updatePollen(i, deltaTime, playerPosition, audioData);
+                        this.updatePollen(i, deltaTime, playerPosition, audioData, timeOffsetPollen);
                         break;
                     case 'berries':
                         this.updateBerry(i, deltaTime);
@@ -264,13 +269,13 @@ export class CPUParticleSystem {
         posAttr.needsUpdate = true;
     }
     
-    private updateFirefly(i: number, deltaTime: number, playerPosition: THREE.Vector3, audioData: ParticleAudioData): void {
+    private updateFirefly(i: number, deltaTime: number, playerPosition: THREE.Vector3, audioData: ParticleAudioData, timeOffset: number): void {
         const idx = i * 3;
         
         // Curl noise approximation
-        const noiseX = Math.sin(this.positions[idx] * 0.1 + this.seeds[i]) * Math.cos(Date.now() * 0.001);
-        const noiseY = Math.sin(this.positions[idx + 1] * 0.1 + this.seeds[i] + 10) * Math.cos(Date.now() * 0.001);
-        const noiseZ = Math.sin(this.positions[idx + 2] * 0.1 + this.seeds[i] + 20) * Math.cos(Date.now() * 0.001);
+        const noiseX = Math.sin(this.positions[idx] * 0.1 + this.seeds[i]) * timeOffset;
+        const noiseY = Math.sin(this.positions[idx + 1] * 0.1 + this.seeds[i] + 10) * timeOffset;
+        const noiseZ = Math.sin(this.positions[idx + 2] * 0.1 + this.seeds[i] + 20) * timeOffset;
         
         // Spring force to center
         const springX = (this.center.x - this.positions[idx]) * 0.5;
@@ -317,7 +322,7 @@ export class CPUParticleSystem {
         }
     }
     
-    private updatePollen(i: number, deltaTime: number, playerPosition: THREE.Vector3, audioData: ParticleAudioData): void {
+    private updatePollen(i: number, deltaTime: number, playerPosition: THREE.Vector3, audioData: ParticleAudioData, timeOffset: number): void {
         const idx = i * 3;
         
         // Wind force
@@ -328,9 +333,9 @@ export class CPUParticleSystem {
         
         // Curl noise
         const noiseScale = 0.2;
-        const noiseX = Math.sin(this.positions[idx] * noiseScale + Date.now() * 0.0005);
-        const noiseY = Math.sin(this.positions[idx + 1] * noiseScale + Date.now() * 0.0005 + 10);
-        const noiseZ = Math.sin(this.positions[idx + 2] * noiseScale + Date.now() * 0.0005 + 20);
+        const noiseX = Math.sin(this.positions[idx] * noiseScale + timeOffset);
+        const noiseY = Math.sin(this.positions[idx + 1] * noiseScale + timeOffset + 10);
+        const noiseZ = Math.sin(this.positions[idx + 2] * noiseScale + timeOffset + 20);
         
         // Player repulsion
         const toPlayerX = this.positions[idx] - playerPosition.x;


### PR DESCRIPTION
Bottleneck: "Using THREE.BufferAttribute.setX(), .setXYZW(), and .getPose() inside hot loops, plus calling Date.now() per particle."
Fix: "Bypassed THREE methods by writing directly to typed arrays. Cached Date.now() outside loops. Exposed underlying arrays to bypass getters."
Impact: "Eliminated function call overhead inside loops traversing thousands of items, preventing GC spikes and lowering per-frame CPU usage."

---
*PR created automatically by Jules for task [16514408891188275870](https://jules.google.com/task/16514408891188275870) started by @ford442*