### PR TITLE
♿ Aria: [UX improvement] Add keyboard support for HUD abilities

### DIFF
--- a/src/core/input/input.ts
+++ b/src/core/input/input.ts
@@ -659,6 +659,35 @@ export function initInput(
     document.addEventListener('mousedown', onMouseDown);
     document.addEventListener('mouseup', onMouseUp);
 
+    // --- UX: Keyboard Interactions for HUD Abilities ---
+    function setupAbilityKeyboardInteractions(element: HTMLElement | null, keyCode: string) {
+        if (!element) return;
+
+        element.addEventListener('keydown', (e: KeyboardEvent) => {
+            if (e.key === 'Enter' || e.code === 'Space') {
+                e.preventDefault(); // Prevent scrolling for space
+                onKeyDown(new KeyboardEvent('keydown', { code: keyCode }));
+            }
+        });
+
+        element.addEventListener('keyup', (e: KeyboardEvent) => {
+            if (e.key === 'Enter' || e.code === 'Space') {
+                e.preventDefault();
+                onKeyUp(new KeyboardEvent('keyup', { code: keyCode }));
+            }
+        });
+
+        element.addEventListener('blur', () => {
+            // Ensure ability isn't stuck on if focus is lost while pressing
+            onKeyUp(new KeyboardEvent('keyup', { code: keyCode }));
+        });
+    }
+
+    setupAbilityKeyboardInteractions(hudDash, 'KeyE');
+    setupAbilityKeyboardInteractions(hudMine, 'KeyF');
+    setupAbilityKeyboardInteractions(hudPhase, 'KeyZ');
+    // ---------------------------------------------------
+
 
 // Cache timeouts to debounce rapid key presses
 const buttonPressTimeouts = new Map<string, NodeJS.Timeout | number>();


### PR DESCRIPTION
♿ Aria: [UX improvement] Add keyboard support for HUD abilities

💡 What: Added `keydown` and `keyup` event listeners to the HUD ability DOM elements (`#ability-dash`, `#ability-mine`, `#ability-phase`) that trigger the game's native input events when pressing Enter or Space. Also captures `blur` to reset the key state.

🎯 Why: The HUD ability slots had `role="button"` and `tabindex="0"`, making them reachable via keyboard navigation (Tab), but pressing action keys (Enter/Space) did nothing. This fixes the interactivity so keyboard users can actually activate and "hold" abilities through the HUD elements directly.

♿ Accessibility: Ensures interactive UI components with the `button` role respond natively to keyboard activation (Enter/Space), preventing keyboard traps and matching expected semantic behavior.

---
*PR created automatically by Jules for task [2081437171576413934](https://jules.google.com/task/2081437171576413934) started by @ford442*