### PR TITLE
🎨 Palette: Add Game Feel to Glass Mycelium

### DIFF
--- a/src/foliage/glass-mushroom-batcher.ts
+++ b/src/foliage/glass-mushroom-batcher.ts
@@ -188,6 +188,13 @@ export class GlassMushroomBatcher {
         return id;
     }
 
+    /** Update a specific instance matrix after registration */
+    updateInstance(index: number, matrix: THREE.Matrix4): void {
+        if (index < 0 || index >= this.count) return;
+        matrix.toArray(this.mesh.instanceMatrix.array, index * 16);
+        this.mesh.instanceMatrix.needsUpdate = true;
+    }
+
     /** Live instance count — used by world-health / telemetry callers. */
     getCount(): number {
         return this.count;

--- a/src/foliage/glass-mushroom.ts
+++ b/src/foliage/glass-mushroom.ts
@@ -2,6 +2,8 @@ import * as THREE from 'three';
 import { glassMushroomBatcher } from './glass-mushroom-batcher.ts';
 import { makeInteractive } from '../utils/interaction-utils.ts';
 import type { FoliageObject } from './types.ts';
+import { discoverySystem } from '../systems/discovery.ts';
+import { spawnImpact } from './impacts.ts';
 
 export interface GlassMushroomOptions {
     scale?: number;
@@ -24,9 +26,29 @@ export function createGlassMushroom(options: GlassMushroomOptions = {}): Foliage
     group.userData.radius = 0.6 * scale; // physics hitbox estimate
 
     group.userData.onPlacement = () => {
-        glassMushroomBatcher.register(group);
+        const id = glassMushroomBatcher.register(group);
+        group.userData.batchIndex = id;
         group.userData.isBatched = true;
         group.userData.onPlacement = null;
+    };
+
+    group.userData.onInteract = () => {
+        // Discovery & Particle Impact
+        discoverySystem.discover('glass_mushroom', 'Glass Mycelium', '🍄');
+        spawnImpact(group.position, 'spore', 0x4DE2FF);
+
+        // Tactile Game Feel Scale Bounce
+        if (group.userData.batchIndex !== undefined && group.userData.batchIndex !== -1) {
+            group.scale.setScalar(scale * 1.2);
+            group.updateMatrixWorld(true);
+            glassMushroomBatcher.updateInstance(group.userData.batchIndex, group.matrixWorld);
+
+            setTimeout(() => {
+                group.scale.setScalar(scale);
+                group.updateMatrixWorld(true);
+                glassMushroomBatcher.updateInstance(group.userData.batchIndex, group.matrixWorld);
+            }, 150);
+        }
     };
 
     return makeInteractive(group) as FoliageObject;


### PR DESCRIPTION
- **Visual Change**: Added particle impacts and a tactile scale bounce animation when players interact with Glass Mycelium mushrooms.
- **Juice Factor**: The interaction now feels responsive and "punchy", popping up before settling back down.
- **Technical**: Utilized the `batchIndex` property to safely perform manual `updateInstance` array mutations on the underlying `InstancedMesh` buffer inside `glass-mushroom-batcher.ts`, strictly avoiding re-registrations or material cloning on the GPU.

---
*PR created automatically by Jules for task [204359657718487449](https://jules.google.com/task/204359657718487449) started by @ford442*