### PR TITLE
✨ Architect: Implement TSL Volumetric God Rays and Selective DoF (#1173)

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -141,3 +141,7 @@ Next Step: Ask the user for the next task.
 Status: Implemented ✅
 * Implementation Details: Integrated Awakened Flora Persistence (v1) by adding `FloraPersistenceManager` in `src/systems/flora-persistence.ts` mapped directly to the Save System's `ProgressSaveData`. Auto-saves and updates state across sessions when players interact with flora.
 Next Step: Ask the user for the next task.
+
+Status: Implemented ✅
+* Implementation Details: Implemented TSL Volumetric God Rays + selective DoF (#1173). Replaced standard material opacity in `src/core/init.ts` with volumetric `uv()` fading to prevent hard intersections, and updated `_updateDepthOfField` in `src/core/game-loop.ts` to dynamically boost DoF mix based on active light shaft opacity, enhancing the cinematic feel.
+Next Step: Ask the user for the next task, potentially `#1134` (Stable release process) or `#1136` (Consolidate LoadingScreen).

--- a/src/core/game-loop.ts
+++ b/src/core/game-loop.ts
@@ -342,7 +342,12 @@ function _updateDepthOfField(delta: number): void {
     const prox = CONFIG.postfx.dofProximity;
     // Proximity ramp: full DoF within (prox-2), fading out by (prox+6).
     const proxMix = 1.0 - THREE.MathUtils.smoothstep(nearest, prox - 2.0, prox + 6.0);
-    const targetMix = _dofManual ? 1.0 : proxMix;
+
+    // TSL Volumetric God Rays: boost DoF when shafts are highly visible
+    const shaftBoost = uShaftOpacityRef ? (uShaftOpacityRef.value * 2.0) : 0.0;
+    const combinedMix = THREE.MathUtils.clamp(proxMix + shaftBoost, 0.0, 1.0);
+
+    const targetMix = _dofManual ? 1.0 : combinedMix;
 
     // Focus-follow: settle the focal plane on the flora we're approaching; otherwise rest.
     const targetFocus = CONFIG.postfx.dofFocusFollow

--- a/src/core/init.ts
+++ b/src/core/init.ts
@@ -1,7 +1,7 @@
 // src/core/init.ts
 
 import * as THREE from 'three';
-import { color, uniform } from 'three/tsl';
+import { color, uniform, uv, float, smoothstep } from 'three/tsl';
 import type UniformNode from 'three/src/nodes/core/UniformNode.js';
 import WebGPU from 'three/examples/jsm/capabilities/WebGPU.js';
 import { WebGPURenderer, MeshBasicNodeMaterial, StorageInstancedBufferAttribute, StorageBufferAttribute } from 'three/webgpu';
@@ -262,8 +262,21 @@ export function initScene(): SceneInitResult {
             side: THREE.DoubleSide,
             depthWrite: false
         });
-        // Link opacity to a global TSL uniform
-        (shaftMaterial as MeshBasicNodeMaterial).opacityNode = uShaftOpacity;
+
+        // TSL Volumetric God Rays:
+        // Fade out horizontally at edges to prevent hard intersections
+        const uvNode = uv();
+        // Use proper boundaries: edge0 < edge1, then invert the result for the right side
+        const leftFade = smoothstep(0.0, 0.4, uvNode.x);
+        const rightFade = float(1.0).sub(smoothstep(0.6, 1.0, uvNode.x));
+        const fadeX = leftFade.mul(rightFade);
+
+        // Fade vertically to give a sense of scattering/dissipation (invert correctly)
+        const fadeY = float(1.0).sub(smoothstep(0.0, 1.0, uvNode.y)).pow(float(1.5));
+
+        // Link combined soft edges to global TSL uniform
+        const softOpacity = fadeX.mul(fadeY).mul(uShaftOpacity);
+        (shaftMaterial as MeshBasicNodeMaterial).opacityNode = softOpacity;
     } else {
         // WebGL fallback: use standard material with static opacity
         // Note: Opacity is updated dynamically in game-loop.ts based on sunrise/sunset.


### PR DESCRIPTION
This commit implements TSL Volumetric God Rays and selective DoF (#1173) to revive golden-hour shafts and enhance cinematic atmosphere. This was achieved by transitioning standard material opacity to volumetric `uv()` fading to prevent hard intersections in the light shafts, and by updating the `_updateDepthOfField` logic to dynamically boost the DoF mix when shafts are highly visible. Also includes proper boundary handling for TSL `smoothstep` functions.

---
*PR created automatically by Jules for task [15426939643491453427](https://jules.google.com/task/15426939643491453427) started by @ford442*