### PR TITLE
♿ Aria: [UX improvement] Unify HUD Ability interactions for proper hold support

### DIFF
--- a/src/core/input/input.ts
+++ b/src/core/input/input.ts
@@ -682,10 +682,6 @@ export function initInput(
             onKeyUp(new KeyboardEvent('keyup', { code: keyCode }));
         });
     }
-
-    setupAbilityKeyboardInteractions(hudDash, 'KeyE');
-    setupAbilityKeyboardInteractions(hudMine, 'KeyF');
-    setupAbilityKeyboardInteractions(hudPhase, 'KeyZ');
     // ---------------------------------------------------
 
 
@@ -777,66 +773,10 @@ function triggerButtonPress(buttonId: string): void {
 
     // --- UX: Interactive Ability HUD ---
     // (Variables moved to top of initInput)
-
-    if (hudDash) {
-        hudDash.addEventListener('click', (e) => {
-            e.stopPropagation();
-            if (isExploreActive()) return;
-            if (hudDash.getAttribute('aria-disabled') !== 'true') {
-                triggerAbility('dash', hudDash);
-            }
-        });
-        // Add keyboard activation for accessibility (Enter/Space)
-        hudDash.addEventListener('keydown', (e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                e.stopPropagation();
-                if (hudDash.getAttribute('aria-disabled') !== 'true') {
-                    triggerAbility('dash', hudDash);
-                }
-            }
-        });
-    }
-
-    if (hudMine) {
-        hudMine.addEventListener('click', (e) => {
-            e.stopPropagation();
-            if (isExploreActive()) return;
-            if (hudMine.getAttribute('aria-disabled') !== 'true') {
-                triggerAbility('action', hudMine); // 'action' corresponds to Jitter Mine (KeyF)
-            }
-        });
-        // Add keyboard activation for accessibility (Enter/Space)
-        hudMine.addEventListener('keydown', (e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                e.stopPropagation();
-                if (hudMine.getAttribute('aria-disabled') !== 'true') {
-                    triggerAbility('action', hudMine);
-                }
-            }
-        });
-    }
-
-    if (hudPhase) {
-        hudPhase.addEventListener('click', (e) => {
-            e.stopPropagation();
-            if (isExploreActive()) return;
-            if (hudPhase.getAttribute('aria-disabled') !== 'true') {
-                triggerAbility('phase', hudPhase);
-            }
-        });
-        // Add keyboard activation for accessibility (Enter/Space)
-        hudPhase.addEventListener('keydown', (e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                e.stopPropagation();
-                if (hudPhase.getAttribute('aria-disabled') !== 'true') {
-                    triggerAbility('phase', hudPhase);
-                }
-            }
-        });
-    }
+    // Wire up the unified keyboard + click handling for ability buttons
+    setupAbilityKeyboardInteractions(hudDash, 'KeyE');
+    setupAbilityKeyboardInteractions(hudMine, 'KeyF');
+    setupAbilityKeyboardInteractions(hudPhase, 'KeyZ');
 
     const openA11yBtn = document.getElementById('openA11yBtn');
     if (openA11yBtn) {


### PR DESCRIPTION
💡 What: Removed duplicate `click` and `keydown` event listeners on the `hudDash`, `hudMine`, and `hudPhase` DOM elements, and consolidated all interaction logic under the generic `setupAbilityKeyboardInteractions` function. Updated this helper to support `pointerdown`, `pointerup`, and `pointercancel` alongside its keyboard events.

🎯 Why: The previous isolated `click` and `keydown` listeners triggered a generic 100ms ability press which did not properly support the "press-and-hold" mechanics of abilities. By unifying these DOM button interactions with synthetic game `KeyboardEvent`s, mouse/touch clicks now correctly support "holding" down an ability the exact same way holding the 'E' or 'F' key does. Additionally, this drastically cleans up duplicate DOM logic.

♿ Accessibility: The unified event helper correctly checks for and respects the `aria-disabled="true"` attribute on the UI elements for both pointer and keyboard events before dispatching the key actions to the game, ensuring users cannot accidentally trigger abilities while they are on cooldown or unavailable.

---
*PR created automatically by Jules for task [951255608222507273](https://jules.google.com/task/951255608222507273) started by @ford442*