### PR TITLE
⚡ Bolt: Optimize Depth of Field Distance Check

### DIFF
--- a/src/core/game-loop.ts
+++ b/src/core/game-loop.ts
@@ -332,13 +332,15 @@ function _updateDepthOfField(delta: number): void {
 
     const px = player.position.x;
     const pz = player.position.z;
-    let nearest = Infinity;
+    // ⚡ OPTIMIZATION: Deferred Math.sqrt() by tracking squared distances in the hot loop
+    let nearestSq = Infinity;
     for (let i = 0; i < _DOF_FLORA_ZONES.length; i++) {
         const dx = px - _DOF_FLORA_ZONES[i][0];
         const dz = pz - _DOF_FLORA_ZONES[i][1];
-        const d = Math.sqrt(dx * dx + dz * dz);
-        if (d < nearest) nearest = d;
+        const dSq = dx * dx + dz * dz;
+        if (dSq < nearestSq) nearestSq = dSq;
     }
+    const nearest = nearestSq === Infinity ? Infinity : Math.sqrt(nearestSq);
 
     const prox = CONFIG.postfx.dofProximity;
     // Proximity ramp: full DoF within (prox-2), fading out by (prox+6).


### PR DESCRIPTION
Bottleneck: Was evaluating `Math.sqrt()` inside a hot per-frame loop for every _DOF_FLORA_ZONES entry to find the nearest zone.
Fix: Converted the distance check loop to track `nearestSq` using squared distances. Performed a single `Math.sqrt()` only after the loop completed.
Impact: Eliminated O(N) CPU square-root math bottleneck in the `_updateDepthOfField` hot path, improving per-frame CPU timing.

---
*PR created automatically by Jules for task [10422553587719494492](https://jules.google.com/task/10422553587719494492) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized depth-of-field proximity calculations for improved rendering performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->