### PR TITLE
♿ Aria: [Arrow key navigation for radiogroup]

### DIFF
--- a/patch.cjs
+++ b/patch.cjs
@@ -1,7 +1,84 @@
 const fs = require('fs');
-const text = fs.readFileSync('src/utils/startup-profiler.ts', 'utf8');
-const newText = text.replace(
-  'return originalCreateShaderModule.call(device, desc);',
-  'return result;'
-);
-fs.writeFileSync('src/utils/startup-profiler.ts', newText);
+let code = fs.readFileSync('src/core/main.ts', 'utf8');
+
+const search = `
+    if (btnCoreOnly && btnFullGame && btnFastFull) {
+        const setupModeButton = (btn: HTMLButtonElement, mode: 'CORE' | 'FULL' | 'FAST_FULL') => {
+            btn.addEventListener('click', async () => {
+                btn.setAttribute('aria-busy', 'true');
+                btn.setAttribute('aria-disabled', 'true');
+                try {
+                    updateStartupMode(mode);
+                    await yieldFrame();
+                } finally {
+                    btn.setAttribute('aria-busy', 'false');
+                    btn.setAttribute('aria-disabled', 'false');
+                }
+            });
+        };
+
+        setupModeButton(btnCoreOnly, 'CORE');
+        setupModeButton(btnFullGame, 'FULL');
+        setupModeButton(btnFastFull, 'FAST_FULL');
+    }
+`;
+
+const replace = `
+    if (btnCoreOnly && btnFullGame && btnFastFull) {
+        const modeButtons = [
+            { btn: btnCoreOnly, mode: 'CORE' as const },
+            { btn: btnFullGame, mode: 'FULL' as const },
+            { btn: btnFastFull, mode: 'FAST_FULL' as const }
+        ];
+
+        const setupModeButton = (btn: HTMLButtonElement, mode: 'CORE' | 'FULL' | 'FAST_FULL', index: number) => {
+            btn.addEventListener('click', async () => {
+                btn.setAttribute('aria-busy', 'true');
+                btn.setAttribute('aria-disabled', 'true');
+                try {
+                    updateStartupMode(mode);
+                    await yieldFrame();
+                } finally {
+                    btn.setAttribute('aria-busy', 'false');
+                    btn.setAttribute('aria-disabled', 'false');
+                }
+            });
+
+            // ♿ Aria: Keyboard navigation for radiogroup
+            btn.addEventListener('keydown', (e) => {
+                let nextIndex = -1;
+                if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+                    nextIndex = (index + 1) % modeButtons.length;
+                } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+                    nextIndex = (index - 1 + modeButtons.length) % modeButtons.length;
+                }
+
+                if (nextIndex !== -1) {
+                    e.preventDefault();
+                    const nextBtn = modeButtons[nextIndex].btn;
+                    nextBtn.focus();
+                    nextBtn.click();
+                }
+            });
+
+            // ♿ Aria: Roving tabindex management
+            btn.addEventListener('focus', () => {
+                modeButtons.forEach(mb => mb.btn.setAttribute('tabindex', '-1'));
+                btn.setAttribute('tabindex', '0');
+            });
+        };
+
+        modeButtons.forEach((mb, index) => {
+            // Initialize roving tabindex: checked item is 0, others -1
+            mb.btn.setAttribute('tabindex', mb.btn.getAttribute('aria-checked') === 'true' ? '0' : '-1');
+            setupModeButton(mb.btn, mb.mode, index);
+        });
+    }
+`;
+
+if (code.includes(search)) {
+    fs.writeFileSync('src/core/main.ts', code.replace(search, replace));
+    console.log("Patched successfully");
+} else {
+    console.log("Could not find search block");
+}

--- a/src/core/main.ts
+++ b/src/core/main.ts
@@ -567,7 +567,13 @@ if (startButton) {
     }
 
     if (btnCoreOnly && btnFullGame && btnFastFull) {
-        const setupModeButton = (btn: HTMLButtonElement, mode: 'CORE' | 'FULL' | 'FAST_FULL') => {
+        const modeButtons = [
+            { btn: btnCoreOnly, mode: 'CORE' as const },
+            { btn: btnFullGame, mode: 'FULL' as const },
+            { btn: btnFastFull, mode: 'FAST_FULL' as const }
+        ];
+
+        const setupModeButton = (btn: HTMLButtonElement, mode: 'CORE' | 'FULL' | 'FAST_FULL', index: number) => {
             btn.addEventListener('click', async () => {
                 btn.setAttribute('aria-busy', 'true');
                 btn.setAttribute('aria-disabled', 'true');
@@ -579,11 +585,36 @@ if (startButton) {
                     btn.setAttribute('aria-disabled', 'false');
                 }
             });
+
+            // ♿ Aria: Keyboard navigation for radiogroup
+            btn.addEventListener('keydown', (e) => {
+                let nextIndex = -1;
+                if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+                    nextIndex = (index + 1) % modeButtons.length;
+                } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+                    nextIndex = (index - 1 + modeButtons.length) % modeButtons.length;
+                }
+
+                if (nextIndex !== -1) {
+                    e.preventDefault();
+                    const nextBtn = modeButtons[nextIndex].btn;
+                    nextBtn.focus();
+                    nextBtn.click();
+                }
+            });
+
+            // ♿ Aria: Roving tabindex management
+            btn.addEventListener('focus', () => {
+                modeButtons.forEach(mb => mb.btn.setAttribute('tabindex', '-1'));
+                btn.setAttribute('tabindex', '0');
+            });
         };
 
-        setupModeButton(btnCoreOnly, 'CORE');
-        setupModeButton(btnFullGame, 'FULL');
-        setupModeButton(btnFastFull, 'FAST_FULL');
+        modeButtons.forEach((mb, index) => {
+            // Initialize roving tabindex: checked item is 0, others -1
+            mb.btn.setAttribute('tabindex', mb.btn.getAttribute('aria-checked') === 'true' ? '0' : '-1');
+            setupModeButton(mb.btn, mb.mode, index);
+        });
     }
 
     // Wire the wait-for-full checkbox


### PR DESCRIPTION
This PR implements standard ARIA keyboard navigation for the startup mode selector. Since the mode selector operates as a `role="radiogroup"`, keyboard users expect to navigate between options using arrow keys, rather than tabbing through them.

**Changes:**
- Added a `keydown` event listener to `btn-core-only`, `btn-full-game`, and `btn-fast-full` in `src/core/main.ts` to support Left/Right/Up/Down arrow key navigation.
- Implemented a roving `tabindex` system where only the currently selected option is focusable (`tabindex="0"`) while others are skipped by `Tab` (`tabindex="-1"`), aligning with `radiogroup` specifications.
- Selecting an option with arrow keys immediately focuses and activates (clicks) the button.

---
*PR created automatically by Jules for task [14595411231608482731](https://jules.google.com/task/14595411231608482731) started by @ford442*