### PR TITLE
♿ Aria: Add ARIA live regions to save menu empty state

### DIFF
--- a/src/ui/save-menu/save-slots.ts
+++ b/src/ui/save-menu/save-slots.ts
@@ -87,7 +87,7 @@ export function renderLoadTab(
     
     if (manualSlots.length === 0 && autoSlots.length === 0) {
         return `
-            <div class="candy-empty-state">
+            <div class="candy-empty-state" role="status" aria-live="polite">
                 <div class="candy-empty-state__icon" aria-hidden="true">📝</div>
                 <div class="candy-empty-state__text">No memories found yet. Embark on a journey to save your progress!</div>
                 ${currentMode === 'full' ? `


### PR DESCRIPTION
Added `role="status"` and `aria-live="polite"` to the `candy-empty-state` in the save menu. This ensures that when the save slots list becomes empty, the screen reader automatically announces the empty state text, providing helpful guidance.

---
*PR created automatically by Jules for task [3970132995272939848](https://jules.google.com/task/3970132995272939848) started by @ford442*