### PR TITLE
⚡ Bolt: [Zero-Allocation] Pre-allocate uniform buffer array in ComputeParticleSystem

### DIFF
--- a/src/particles/compute-particles.ts
+++ b/src/particles/compute-particles.ts
@@ -87,6 +87,7 @@ export class ComputeParticleSystem {
     private particleBuffer: GPUBuffer | null = null;
     private nextSpawnIndex: number = 0;
     private static scratchFloat32Array = new Float32Array(4);
+    private uniformArray: Float32Array = new Float32Array(20);
 
     public initPromise: Promise<void> | null = null;
     
@@ -539,30 +540,28 @@ private getOpacityNode(): any {
             this.updateUniforms(deltaTime, playerPosition, audioData);
             
             // Write uniforms to GPU
-            const uniformArray = new Float32Array([
-                this.uniforms.deltaTime,
-                this.uniforms.time,
-                this.uniforms.count,
-                this.uniforms.boundsX,
-                this.uniforms.boundsY,
-                this.uniforms.boundsZ,
-                this.uniforms.centerX,
-                this.uniforms.centerY,
-                this.uniforms.centerZ,
-                this.uniforms.gravity,
-                this.uniforms.windX,
-                this.uniforms.windY,
-                this.uniforms.windZ,
-                this.uniforms.windSpeed,
-                this.uniforms.playerX,
-                this.uniforms.playerY,
-                this.uniforms.playerZ,
-                this.uniforms.audioLow,
-                this.uniforms.audioHigh,
-                this.uniforms.particleType
-            ]);
+            this.uniformArray[0] = this.uniforms.deltaTime;
+            this.uniformArray[1] = this.uniforms.time;
+            this.uniformArray[2] = this.uniforms.count;
+            this.uniformArray[3] = this.uniforms.boundsX;
+            this.uniformArray[4] = this.uniforms.boundsY;
+            this.uniformArray[5] = this.uniforms.boundsZ;
+            this.uniformArray[6] = this.uniforms.centerX;
+            this.uniformArray[7] = this.uniforms.centerY;
+            this.uniformArray[8] = this.uniforms.centerZ;
+            this.uniformArray[9] = this.uniforms.gravity;
+            this.uniformArray[10] = this.uniforms.windX;
+            this.uniformArray[11] = this.uniforms.windY;
+            this.uniformArray[12] = this.uniforms.windZ;
+            this.uniformArray[13] = this.uniforms.windSpeed;
+            this.uniformArray[14] = this.uniforms.playerX;
+            this.uniformArray[15] = this.uniforms.playerY;
+            this.uniformArray[16] = this.uniforms.playerZ;
+            this.uniformArray[17] = this.uniforms.audioLow;
+            this.uniformArray[18] = this.uniforms.audioHigh;
+            this.uniformArray[19] = this.uniforms.particleType;
             
-            this.device.queue.writeBuffer(this.uniformBuffer, 0, uniformArray);
+            this.device.queue.writeBuffer(this.uniformBuffer, 0, this.uniformArray);
             
             // Dispatch compute shader
             const commandEncoder = this.device.createCommandEncoder();


### PR DESCRIPTION
Bottleneck: "Was allocating a brand new `Float32Array(20)` every single frame in `ComputeParticleSystem.update()`, causing silent GC spikes in the WebGPU compute loop."
Fix: "Converted `uniformArray` to a pre-allocated class property and changed the `.update()` method to write float values directly by index instead of instantiating new arrays."
Impact: "Eliminated per-frame memory allocation for uniform writes, preventing garbage collection stutters in particle hot paths."

---
*PR created automatically by Jules for task [5739719412198624873](https://jules.google.com/task/5739719412198624873) started by @ford442*