### PR TITLE
♿ Aria: Add keyboard support and focus state for Wait Full checkbox

### DIFF
--- a/src/core/main.ts
+++ b/src/core/main.ts
@@ -627,6 +627,17 @@ if (startButton) {
             waitFullCheckbox.setAttribute('aria-checked', String(waitForFullPopulation));
             localStorage.setItem(WAIT_FULL_KEY, waitForFullPopulation ? '1' : '0');
         });
+
+        // ♿ Aria: Keyboard support for custom switch behavior on Enter
+        waitFullCheckbox.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                waitFullCheckbox.checked = !waitFullCheckbox.checked;
+                waitForFullPopulation = waitFullCheckbox.checked;
+                waitFullCheckbox.setAttribute('aria-checked', String(waitForFullPopulation));
+                localStorage.setItem(WAIT_FULL_KEY, waitForFullPopulation ? '1' : '0');
+            }
+        });
     }
 
     async function enterWorld() {

--- a/style.css
+++ b/style.css
@@ -623,6 +623,12 @@ button[aria-pressed="true"],
     box-shadow: 0 5px 18px rgba(125, 211, 252, 0.55);
 }
 
+/* ♿ Aria: Keyboard focus for wait full checkbox */
+#wait-full-checkbox:focus-visible {
+    outline: 2px solid #FF4081;
+    outline-offset: 2px;
+}
+
 /* 🎨 Palette: Tactile feedback on interactive elements */
 .toggle-button:not([aria-disabled="true"]):active,
 .toggle-button:not([aria-disabled="true"]).keyboard-active,


### PR DESCRIPTION
💡 **What:** Improved keyboard accessibility for the new "Wait for complete scenery before entering" checkbox on the startup screen.
🎯 **Why:** Custom checkboxes acting as switches need explicit Enter key support (they natively only support Space) and clear visual focus outlines for keyboard/screen-reader users.
♿ **Accessibility:** Added `keydown` listener for the 'Enter' key to toggle the `checked` and `aria-checked` states. Added `:focus-visible` styling to match the game's existing UI focus indicators.

---
*PR created automatically by Jules for task [5292200177086836478](https://jules.google.com/task/5292200177086836478) started by @ford442*