### PR TITLE
♿ Aria: [UX improvement] Add pointer holding support for HUD ability buttons

### DIFF
--- a/src/core/input/input.ts
+++ b/src/core/input/input.ts
@@ -660,6 +660,7 @@ export function initInput(
     document.addEventListener('mouseup', onMouseUp);
 
     // --- UX: Keyboard Interactions for HUD Abilities ---
+    // ♿ Aria: Support pointer hold for ability buttons
     function setupAbilityKeyboardInteractions(element: HTMLElement | null, keyCode: string) {
         if (!element) return;
 
@@ -675,6 +676,29 @@ export function initInput(
                 e.preventDefault();
                 onKeyUp(new KeyboardEvent('keyup', { code: keyCode }));
             }
+        });
+
+        element.addEventListener('pointerdown', (e: PointerEvent) => {
+            e.preventDefault();
+            e.stopPropagation();
+            element.setPointerCapture(e.pointerId);
+            onKeyDown(new KeyboardEvent('keydown', { code: keyCode }));
+        });
+
+        element.addEventListener('pointerup', (e: PointerEvent) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onKeyUp(new KeyboardEvent('keyup', { code: keyCode }));
+        });
+
+        element.addEventListener('pointercancel', (e: PointerEvent) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onKeyUp(new KeyboardEvent('keyup', { code: keyCode }));
+        });
+
+        element.addEventListener('contextmenu', (e: MouseEvent) => {
+            e.preventDefault();
         });
 
         element.addEventListener('blur', () => {


### PR DESCRIPTION
💡 What: Mapped pointerdown, pointerup, and pointercancel events to the game's keyboard input loop for HUD ability slots. Also added a contextmenu prevent default.
🎯 Why: Touchscreen and mouse users couldn't "hold" abilities (like charging or continuous effects) using the on-screen ability HUD, as standard click events don't distinguish between press and release duration reliably in this custom loop.
♿ Accessibility: Ensures that players using touch or a mouse have the same continuous interaction capability as keyboard users for time-sensitive abilities. The context menu block prevents mobile browsers from interrupting long presses with UI popups.

---
*PR created automatically by Jules for task [4717813067642013569](https://jules.google.com/task/4717813067642013569) started by @ford442*