### PR TITLE
♿ Aria: [UX improvement] Add keyboard tactile feedback to Accessibility Menu

### DIFF
--- a/src/ui/accessibility-menu-handlers.ts
+++ b/src/ui/accessibility-menu-handlers.ts
@@ -24,6 +24,22 @@ export class AccessibilityMenuHandlers extends AccessibilityMenuRendering {
       return;
     }
 
+    // ♿ Aria: Keyboard tactile feedback for interactive elements
+    if (event.key === 'Enter' || event.key === ' ') {
+      const activeElement = document.activeElement as HTMLElement;
+      if (activeElement && (
+        activeElement.classList.contains('a11y-tab') ||
+        activeElement.classList.contains('a11y-button') ||
+        activeElement.classList.contains('a11y-preset-card') ||
+        activeElement.classList.contains('a11y-close-btn')
+      )) {
+        activeElement.classList.add('keyboard-active');
+        setTimeout(() => {
+          if (activeElement) activeElement.classList.remove('keyboard-active');
+        }, 150);
+      }
+    }
+
     // ♿ Aria: Keyboard navigation for Tabs (Up/Down/Left/Right Arrows)
     if (event.key === 'ArrowUp' || event.key === 'ArrowDown' || event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
       const activeElement = document.activeElement as HTMLElement;


### PR DESCRIPTION
💡 What: Added tactile visual feedback (.keyboard-active pulse) to interactive elements within the Accessibility Menu when activated via `Enter` or `Space`.

🎯 Why: Users navigating via keyboard lacked the same immediate visual confirmation (active states) that mouse/touch users get. This bridges the UX gap.

♿ Accessibility: Enhances visual cues for keyboard focus and activation without disrupting the established DOM structure or ARIA states.

---
*PR created automatically by Jules for task [1159736016078952608](https://jules.google.com/task/1159736016078952608) started by @ford442*