### PR TITLE
⚡ Bolt: [Optimization Name] - Removed array allocations from applyMapMusicContext

### DIFF
--- a/src/systems/music-reactivity-core.ts
+++ b/src/systems/music-reactivity-core.ts
@@ -28,7 +28,7 @@ import {
 import { getMapMusicContext } from '../world/map-music-context.ts';
 import type { MapMusicOverrides } from '../world/map-loader.ts';
 
-
+const _WEATHER_KEYS: Array<'rainIntensity' | 'thunderPulse' | 'fogDensity'> = ['rainIntensity', 'thunderPulse', 'fogDensity'];
 
 
 
@@ -97,7 +97,7 @@ export const MRState = {
     } as any,
     skyWavePropagationMs: defaultSkyWavePropagationMs,
     skyWaveDecayMs: defaultSkyWaveDecayMs,
-    skyWaveTargets: defaultSkyWaveTargets as readonly string[],
+    skyWaveTargets: [...defaultSkyWaveTargets] as string[],
     activeWave: null as any,
     waveDecayStartTime: 0,
     channelValidationDone: false,
@@ -212,7 +212,10 @@ export function applyMapMusicContext(overrides: MapMusicOverrides | undefined): 
     };
     MRState.skyWavePropagationMs = defaultSkyWavePropagationMs;
     MRState.skyWaveDecayMs = defaultSkyWaveDecayMs;
-    MRState.skyWaveTargets = defaultSkyWaveTargets;
+    MRState.skyWaveTargets.length = 0;
+    for (let i = 0; i < defaultSkyWaveTargets.length; i++) {
+        MRState.skyWaveTargets.push(defaultSkyWaveTargets[i]);
+    }
 
     const biomeOverrides = overrides?.biomes;
     if (biomeOverrides && typeof biomeOverrides === 'object') {
@@ -278,12 +281,24 @@ export function applyMapMusicContext(overrides: MapMusicOverrides | undefined): 
         MRState.skyWaveDecayMs = Math.max(100, overrides.skyWave.decayMs);
     }
     if (Array.isArray(overrides?.skyWave?.targetBiomes) && overrides.skyWave.targetBiomes.length > 0) {
-        const filteredTargets = overrides.skyWave.targetBiomes.filter((name: string) => typeof name === 'string');
-        if (filteredTargets.length > 0) MRState.skyWaveTargets = filteredTargets;
+        // ⚡ OPTIMIZATION: Replaced .filter() with manual loop + in-place mutation to eliminate array allocation in context syncs.
+        MRState.skyWaveTargets.length = 0;
+        for (let i = 0; i < overrides.skyWave.targetBiomes.length; i++) {
+            const name = overrides.skyWave.targetBiomes[i];
+            if (typeof name === 'string') {
+                MRState.skyWaveTargets.push(name);
+            }
+        }
+        // Fallback to default if empty
+        if (MRState.skyWaveTargets.length === 0) {
+            for (let i = 0; i < defaultSkyWaveTargets.length; i++) {
+                MRState.skyWaveTargets.push(defaultSkyWaveTargets[i]);
+            }
+        }
     }
     if (overrides?.weatherReactivity && typeof overrides.weatherReactivity === 'object') {
-        const keys: Array<'rainIntensity' | 'thunderPulse' | 'fogDensity'> = ['rainIntensity', 'thunderPulse', 'fogDensity'];
-        for (const key of keys) {
+        for (let i = 0; i < _WEATHER_KEYS.length; i++) {
+            const key = _WEATHER_KEYS[i];
             const current = MRState.weatherBindings[key];
             const override = overrides.weatherReactivity[key];
             if (!override || typeof override !== 'object') continue;

--- a/src/systems/music-reactivity.ts
+++ b/src/systems/music-reactivity.ts
@@ -26,6 +26,8 @@ import {
     applyAtmosphereMapOverrides,
 } from './atmosphere-reactivity.ts';
 
+const _WEATHER_KEYS: Array<'rainIntensity' | 'thunderPulse' | 'fogDensity'> = ['rainIntensity', 'thunderPulse', 'fogDensity'];
+
 // ⚡ OPTIMIZATION: Pre-parsed channel index arrays from music-bindings.json.
 // Resolved once at module init — immutable after that, zero per-frame allocations.
 const _defaultArpeggioShimmerCh: readonly number[] = musicBindings.biomes.arpeggio_grove.shimmer;
@@ -138,7 +140,7 @@ const _defaultSkyWaveDecayMs = _skyWaveConfig?.decay_ms ?? 2000;
 const _defaultSkyWaveTargets: readonly string[] = _skyWaveConfig?.target_biomes ?? ['arpeggio_grove', 'crystalline_nebula', 'luminous_plants', 'sky_moon', 'global', 'musical_flora', 'lake_features'];
 let _skyWavePropagationMs = _defaultSkyWavePropagationMs;
 let _skyWaveDecayMs = _defaultSkyWaveDecayMs;
-let _skyWaveTargets: readonly string[] = _defaultSkyWaveTargets;
+let _skyWaveTargets: string[] = [..._defaultSkyWaveTargets];
 
 // Map from sky_wave.target_biomes keys (in music-bindings.json) → the Color uniform to receive the propagating hue.
 // This makes the wave fully data-driven. Adding a new target = add key here + entry in JSON list.
@@ -221,7 +223,10 @@ function applyMapMusicContext(overrides: MapMusicOverrides | undefined): void {
     };
     _skyWavePropagationMs = _defaultSkyWavePropagationMs;
     _skyWaveDecayMs = _defaultSkyWaveDecayMs;
-    _skyWaveTargets = _defaultSkyWaveTargets;
+    _skyWaveTargets.length = 0;
+    for (let i = 0; i < _defaultSkyWaveTargets.length; i++) {
+        _skyWaveTargets.push(_defaultSkyWaveTargets[i]);
+    }
 
     const biomeOverrides = overrides?.biomes;
     if (biomeOverrides && typeof biomeOverrides === 'object') {
@@ -278,12 +283,24 @@ function applyMapMusicContext(overrides: MapMusicOverrides | undefined): void {
         _skyWaveDecayMs = Math.max(100, overrides.skyWave.decayMs);
     }
     if (Array.isArray(overrides?.skyWave?.targetBiomes) && overrides.skyWave.targetBiomes.length > 0) {
-        const filteredTargets = overrides.skyWave.targetBiomes.filter((name: string) => typeof name === 'string');
-        if (filteredTargets.length > 0) _skyWaveTargets = filteredTargets;
+        // ⚡ OPTIMIZATION: Replaced .filter() with manual loop + in-place mutation to eliminate array allocation in context syncs.
+        _skyWaveTargets.length = 0;
+        for (let i = 0; i < overrides.skyWave.targetBiomes.length; i++) {
+            const name = overrides.skyWave.targetBiomes[i];
+            if (typeof name === 'string') {
+                _skyWaveTargets.push(name);
+            }
+        }
+        // Fallback to default if empty
+        if (_skyWaveTargets.length === 0) {
+            for (let i = 0; i < _defaultSkyWaveTargets.length; i++) {
+                _skyWaveTargets.push(_defaultSkyWaveTargets[i]);
+            }
+        }
     }
     if (overrides?.weatherReactivity && typeof overrides.weatherReactivity === 'object') {
-        const keys: Array<'rainIntensity' | 'thunderPulse' | 'fogDensity'> = ['rainIntensity', 'thunderPulse', 'fogDensity'];
-        for (const key of keys) {
+        for (let i = 0; i < _WEATHER_KEYS.length; i++) {
+            const key = _WEATHER_KEYS[i];
             const current = _weatherBindings[key];
             const override = overrides.weatherReactivity[key];
             if (!override || typeof override !== 'object') continue;
@@ -1146,3 +1163,4 @@ export class MusicReactivitySystem {
 
 export const musicReactivitySystem = new MusicReactivitySystem();
 
+// ⚡ Bolt: Removed array allocations from applyMapMusicContext


### PR DESCRIPTION
## Bottleneck
In `applyMapMusicContext` (which syncs weather state for the music reactivity system), there were two per-call allocations:
1. `const keys = ['rainIntensity', 'thunderPulse', 'fogDensity']` created a new array every time.
2. `overrides.skyWave.targetBiomes.filter(...)` ran a higher-order array method that instantiated a new filtered array.

Since `applyMapMusicContext` is synced during the reactivity update loop (`syncMapMusicContext` in `update()`), these allocations accumulate and trigger GC spikes, impacting frame consistency.

## Fix
- Hoisted `_WEATHER_KEYS` out of the function into the module scope.
- Replaced `.filter()` with an in-place manual loop, modifying `skyWaveTargets` array directly (`.length = 0` + `.push()`).

## Impact
Eliminated per-sync allocations in `applyMapMusicContext`, keeping the audio reactivity update path free of unnecessary GC pressure.

---
*PR created automatically by Jules for task [10754495559182602051](https://jules.google.com/task/10754495559182602051) started by @ford442*