### PR TITLE
♿ Aria: [UX improvement] Screen reader announcements for Jukebox uploads

### DIFF
--- a/src/core/input/playlist-manager.ts
+++ b/src/core/input/playlist-manager.ts
@@ -7,6 +7,7 @@ import { AudioSystem } from '../../audio/audio-system';
 import { PointerLockControls } from 'three/examples/jsm/controls/PointerLockControls.js';
 import { trapFocusInside } from '../../utils/interaction-utils.ts';
 import { formatSongTitle, filterValidMusicFiles } from './input-types.ts';
+import { announce } from '../../ui/announcer.ts';
 
 // State
 let isPlaylistOpen = false;
@@ -180,14 +181,23 @@ export function initPlaylistManager(
 
                     import('../../utils/toast.ts').then(({ showToast }) => {
                         if (invalidFiles.length > 0) {
-                            showToast(`Added ${validFiles.length} song${validFiles.length > 1 ? 's' : ''}. (${invalidFiles.length} ignored)`, '⚠️');
+                            const msg = `Added ${validFiles.length} song${validFiles.length > 1 ? 's' : ''}. (${invalidFiles.length} ignored)`;
+                            showToast(msg, '⚠️');
+                            announce(msg, 'polite');
                         } else {
-                            showToast(`Added ${validFiles.length} Song${validFiles.length > 1 ? 's' : ''}! 🎶`, '📂');
+                            const msg = `Added ${validFiles.length} Song${validFiles.length > 1 ? 's' : ''}! 🎶`;
+                            showToast(msg, '📂');
+                            if (validFiles.length === 1) {
+                                announce(`Song '${validFiles[0].name}' has been added and is ready to play.`, 'polite');
+                            } else {
+                                announce(`Added ${validFiles.length} songs to the playlist.`, 'polite');
+                            }
                         }
                     });
                 } else {
                     import('../../utils/toast.ts').then(({ showToast }) => {
                         showToast("❌ Only .mod, .xm, .it, .s3m allowed!", '🚫');
+                        announce("Failed to add songs, invalid format.", 'polite');
                     });
                 }
             }
@@ -236,14 +246,23 @@ function handlePlaylistUpload(e: Event): void {
                 audioSystemRef!.addToQueue(validFiles);
                 import('../../utils/toast.ts').then(({ showToast }) => {
                     if (invalidFiles.length > 0) {
-                        showToast(`Added ${validFiles.length} song${validFiles.length > 1 ? 's' : ''}. (${invalidFiles.length} ignored)`, '⚠️');
+                        const msg = `Added ${validFiles.length} song${validFiles.length > 1 ? 's' : ''}. (${invalidFiles.length} ignored)`;
+                        showToast(msg, '⚠️');
+                        announce(msg, 'polite');
                     } else {
-                        showToast(`Added ${validFiles.length} Song${validFiles.length > 1 ? 's' : ''}! 🎶`, '📂');
+                        const msg = `Added ${validFiles.length} Song${validFiles.length > 1 ? 's' : ''}! 🎶`;
+                        showToast(msg, '📂');
+                        if (validFiles.length === 1) {
+                            announce(`Song '${validFiles[0].name}' has been added and is ready to play.`, 'polite');
+                        } else {
+                            announce(`Added ${validFiles.length} songs to the playlist.`, 'polite');
+                        }
                     }
                 });
             } else {
                 import('../../utils/toast.ts').then(({ showToast }) => {
                     showToast("❌ Only .mod, .xm, .it, .s3m allowed!", '🚫');
+                    announce("Failed to add songs, invalid format.", 'polite');
                 });
             }
 


### PR DESCRIPTION
Added screen reader announcements for the Jukebox Drag & Drop and manual file upload buttons. Also fixed a missing import for `announce` in the playlist-manager.ts file.

---
*PR created automatically by Jules for task [3191778925102159000](https://jules.google.com/task/3191778925102159000) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added polite accessibility announcements when songs are added through drag-and-drop or file upload.
  * Success and warning messages now include spoken feedback, including singular/plural handling and “ready to play” for single tracks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->