### PR TITLE
🎨 Palette: Add TSL Wind Sway and Player Interaction to Glass Mushrooms

### DIFF
--- a/src/foliage/glass-mushroom-batcher.ts
+++ b/src/foliage/glass-mushroom-batcher.ts
@@ -94,7 +94,14 @@ function createGlassMushroomMaterial(): MeshStandardNodeMaterial {
     const rippleWave = sin(radial.mul(9.0).sub(uTime.mul(4.0)).add(aPhase));
     const ripple = rippleWave.mul(uAudioLow).mul(0.12).mul(capMask);
     const idleSway = sin(uTime.mul(1.1).add(aPhase)).mul(0.015).mul(capMask);
-    const displaced = positionLocal.add(normalLocal.mul(ripple.add(idleSway)));
+
+    // 🎨 PALETTE: added calculateWindSway + applyPlayerInteraction to glass mushrooms
+    // so they feel alive and consistent with the rest of the foliage.
+    // Wind and player interaction MUST run *before* any other vertex offsets!
+    const interactiveBase = calculateWindSway(applyPlayerInteraction(positionLocal));
+
+    // Then add the local cap ripple and standard deformation
+    const displaced = interactiveBase.add(normalLocal.mul(ripple.add(idleSway)));
     mat.positionNode = applyStandardDeformation(displaced);
 
     // --- Emissive vein network (fake SSS along the stem) ---------------------


### PR DESCRIPTION
Visual Change: Glass mushrooms now gently sway in the breeze and react/bounce away when the player approaches or touches them.

"Juice" Factor: Replaces static placement with continuous organic motion, making them feel alive and consistent with the rest of the magical candy ecosystem. The subtle movement catches glossy clearcoat highlights beautifully.

Technical: Added `calculateWindSway` and `applyPlayerInteraction` to the material's `positionNode` processing stack, ensuring they compose cleanly before the local cap-ripple displacement is applied.

---
*PR created automatically by Jules for task [13524996579885135687](https://jules.google.com/task/13524996579885135687) started by @ford442*