### PR TITLE
Fix ReferenceError: foliageCaves is not defined in physics-states

### DIFF
--- a/src/systems/physics/physics-states.ts
+++ b/src/systems/physics/physics-states.ts
@@ -18,7 +18,8 @@ import {
     bpmWind,
     grooveGravity,
     AudioState,
-    KeyStates
+    KeyStates,
+    foliageCaves
 } from './physics-types.js';
 import { 
     activeVineSwing, 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The production app crashes on every animation frame with:

```
Uncaught ReferenceError: foliageCaves is not defined
    at updateStateTransitions (physics-states.ts)
```

`updateStateTransitions()` calls `calculateWaterLevel(playerPos, foliageCaves)` for water/cave flooding checks, but `foliageCaves` was never imported in `physics-states.ts`. Other physics modules (`physics-core.ts`, `physics-updates.ts`) already import it from `physics-types.ts`.

## Fix

Add `foliageCaves` to the existing import from `./physics-types.js` in `physics-states.ts`.

## Testing

- `pnpm run build:ci` — passes
- `pnpm run test:wasm` — passes
- `RENDERER=webgl pnpm run test` — smoke test passes (scene boots, no console errors)

## Notes on other console messages

The following reported warnings/errors are expected and unrelated to this crash:

- `powerPreference` ignored on Windows — Chromium bug, harmless
- `candy_native_st.js` 404 — Emscripten native module not built (JS fallbacks used)
- `/api/save-startup-profile` 404 and `startup-profile.json` 405 — dev-only profiler endpoints, not present in production
- Preload warnings for splash/map assets — performance hints, not functional errors
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d608de6-2daf-45e6-b564-92ad3f08517e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d608de6-2daf-45e6-b564-92ad3f08517e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

